### PR TITLE
feat(ui/runtime): antinvestor_auth_runtime v0.1.0 — Flutter auth runtime

### DIFF
--- a/docs/auth-runtime-integration.md
+++ b/docs/auth-runtime-integration.md
@@ -1,0 +1,226 @@
+# Integrating `antinvestor_auth_runtime` into a consuming app
+
+This guide walks through wiring `antinvestor_auth_runtime` into an
+existing Flutter app — specifically `service-chat` and `service-fintech`,
+but the procedure applies to any Antinvestor Flutter client.
+
+Each step lists the files to create or edit and the exact snippet to
+drop in. Substitute the client-specific placeholders where called out.
+
+---
+
+## Step 1 — Add the dependency
+
+In the consuming app's `pubspec.yaml`:
+
+```yaml
+dependencies:
+  antinvestor_auth_runtime: ^0.1.0
+```
+
+Then run `flutter pub get` (or `dart pub get`).
+
+If you are developing against the runtime inside this monorepo, use a
+path dependency instead:
+
+```yaml
+dependencies:
+  antinvestor_auth_runtime:
+    path: ../../service-authentication/ui/runtime
+```
+
+## Step 2 — Decide the OAuth client ID
+
+Each consuming app is its own OAuth client registered with the
+Antinvestor IdP (Hydra). Use a descriptive, stable client ID per app.
+
+| App | Suggested client ID placeholder | Replace with |
+|-----|---------------------------------|--------------|
+| service-chat | `antinvestor-chat-mobile` | Real Hydra client ID once provisioned |
+| service-fintech | `antinvestor-fintech-mobile` | Real Hydra client ID once provisioned |
+
+These IDs must be registered in the IdP tenancy config with the
+`authorization_code` grant, `refresh_token` grant, and the app's redirect
+URI in the allow-list.
+
+## Step 3 — Register the redirect scheme per platform
+
+See the runtime's README "Platform setup" section for iOS + Android
+manifest edits. For `service-chat` use `com.antinvestor.chat` as the
+scheme; for `service-fintech` use `com.antinvestor.fintech`.
+
+## Step 4 — Create `lib/auth/auth_config.dart`
+
+A single file pinning the per-app configuration. Example for
+`service-chat`:
+
+```dart
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+
+const AuthConfig chatAuthConfig = AuthConfig(
+  clientId: 'antinvestor-chat-mobile',
+  idpBaseUrl: 'https://auth.antinvestor.com',
+  apiBaseUrl: 'https://chat-api.antinvestor.com',
+  redirectScheme: 'com.antinvestor.chat',
+  scopes: <String>[
+    'openid',
+    'profile',
+    'email',
+    'offline_access',
+    'chat:read',
+    'chat:write',
+  ],
+);
+```
+
+Mirror this for `service-fintech` with the fintech-specific values.
+
+## Step 5 — Wire `createAuthRuntime` at app start
+
+In the consuming app's `main.dart` (or wherever `runApp` lives):
+
+```dart
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'auth/auth_config.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final runtime = createAuthRuntime(chatAuthConfig);
+
+  runApp(ProviderScope(
+    overrides: [
+      authRuntimeProvider.overrideWithValue(runtime),
+    ],
+    child: const ChatApp(),
+  ));
+}
+```
+
+If the app is not already a Riverpod app, use `AuthRuntimeScope` instead
+(see the README).
+
+Optional but recommended: kick off discovery during splash so the first
+sign-in isn't the one paying the round-trip:
+
+```dart
+unawaited(runtime.prefetchDiscovery());
+```
+
+## Step 6 — Wrap the navigator with `AuthGate`
+
+```dart
+class ChatApp extends StatelessWidget {
+  const ChatApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Antinvestor Chat',
+      home: AuthGate(
+        child: const HomeScreen(),
+        // Optional: customise the unauthenticated placeholder.
+        unauthenticatedBuilder: (context) => const SignInLandingPage(),
+      ),
+    );
+  }
+}
+```
+
+`AuthGate` listens on `authStateProvider` and re-builds whenever the
+runtime transitions. Once authenticated, the subtree mounts.
+
+## Step 7 — Replace ad-hoc HTTP calls with `runtime.fetch`
+
+Before:
+
+```dart
+final dio = Dio();
+final res = await dio.get('/v1/conversations',
+    options: Options(headers: {'Authorization': 'Bearer $token'}));
+```
+
+After:
+
+```dart
+final runtime = ref.read(authRuntimeProvider);
+final res = await runtime.fetch('/v1/conversations');
+final data = jsonDecode(utf8.decode(res.body));
+```
+
+The `apiBaseUrl` from `AuthConfig` is prepended automatically, the
+`Authorization` header (Bearer or DPoP) is added, DPoP proofs are minted
+per-request, and 401 responses trigger a transparent refresh + retry.
+
+For uploads:
+
+```dart
+final res = await runtime.upload(
+  '/v1/attachments',
+  fieldName: 'file',
+  filename: 'pic.jpg',
+  contentType: 'image/jpeg',
+  bytes: file.openRead(),
+  length: await file.length(),
+);
+```
+
+## Step 8 — Migrate any existing token storage
+
+During a rollout from a legacy auth stack:
+
+1. On first launch against the new runtime, read the legacy token store.
+2. If a legacy refresh token exists and is still valid, *do not* attempt
+   to import it — request a fresh sign-in instead. Cross-stack token
+   reuse is a correctness footgun; the refresh token format, the IdP
+   session, and the DPoP binding all differ.
+3. Call `legacyStore.clear()` once the new runtime reports
+   `AuthState.authenticated` so old artefacts don't linger.
+4. Always call `runtime.dispose()` on app shutdown — this flushes the
+   stream controllers and lets `flutter_secure_storage` release its
+   keychain handles cleanly.
+
+## Step 9 — Validation test
+
+Add a test in the consuming app that asserts the runtime ends up
+authenticated when fed a fake OAuth flow. The runtime ships an
+integration harness pattern you can borrow — the minimal shape:
+
+```dart
+// test/auth/auth_smoke_test.dart
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('runtime authenticates against a stubbed IdP', () async {
+    // Construct a real runtime with a FakeOAuthFlow pointing at a
+    // MockIdp (see the runtime's test/integration/_helpers.dart for
+    // the fixture). On CI the package's own integration tests cover
+    // this path; a smoke test here just confirms wiring.
+    //
+    // The key assertion is that after `ensureAuthenticated` returns,
+    // `runtime.state == AuthState.authenticated` and
+    // `runtime.getClaims()` contains the expected subject.
+  });
+}
+```
+
+For rich end-to-end coverage refer to the runtime's own
+`test/integration/` suite, which drives a shelf-backed MockIdp end-to-end.
+
+---
+
+## Reference: matrix of placeholders
+
+| Placeholder | service-chat | service-fintech |
+|-------------|--------------|-----------------|
+| `clientId` | `antinvestor-chat-mobile` | `antinvestor-fintech-mobile` |
+| `idpBaseUrl` | `https://auth.antinvestor.com` | `https://auth.antinvestor.com` |
+| `apiBaseUrl` | `https://chat-api.antinvestor.com` | `https://fintech-api.antinvestor.com` |
+| `redirectScheme` | `com.antinvestor.chat` | `com.antinvestor.fintech` |
+
+Replace the placeholder client IDs with values obtained from the
+Antinvestor IdP admin console before shipping a release build.

--- a/docs/platform-services-metrics-audit.md
+++ b/docs/platform-services-metrics-audit.md
@@ -1,0 +1,558 @@
+# Antinvestor Platform — Service Metrics Audit
+
+> Generated: 2026-04-14
+> Frame Version (all services): v1.93.9
+> Frame PR for tenant-aware telemetry: pitabwire/frame#644
+
+---
+
+## Executive Summary
+
+All 10 Antinvestor services (30+ sub-applications) were analysed for their purpose, exposed APIs, current telemetry state, and essential product metrics. The findings:
+
+| Service | Sub-Apps | Endpoints | Current Metrics | Coverage |
+|---------|----------|-----------|----------------|----------|
+| authentication | 3 | 35+ HTTP/RPC | None | 0% |
+| profile | 4 | 60+ RPC | Partial (devices cache, geolocation) | ~25% |
+| notification | 5 | 30+ RPC/HTTP | None | 0% |
+| files | 4 | 50+ RPC/HTTP | Dead code (Prometheus struct, never wired) | 0% |
+| chat | 2 | 20+ RPC | Good (internal/telemetry/) | ~70% |
+| commerce | 1 | 19 RPC | None | 0% |
+| payment | 10 | 40+ RPC + webhooks | None (billing has otelconnect only) | ~5% |
+| fintech | 7 | 120+ RPC/HTTP | None (audit logging only) | 0% |
+| thesa | 1 | 22 HTTP | Minimal (trace ID in errors) | ~5% |
+| trustage | 3 | 50+ RPC/HTTP | Good but many instruments unrecorded | ~50% |
+
+**Key insight**: Only 2 of 10 services (chat, trustage) have meaningful custom metrics. The remaining 8 rely entirely on Frame's automatic HTTP/OTel instrumentation (request count, latency) with zero product-specific metrics. The new Frame tenant-aware telemetry (PR #644) will automatically add `tenant_id`/`partition_id` to all traced spans and latency histograms across all services with zero code changes.
+
+---
+
+## 1. service-authentication
+
+### Purpose
+Multi-tenant OAuth2/OIDC authentication platform — the Login & Consent Provider for Ory Hydra. Handles user login (contact verification, social login, remember-me), OAuth2 consent, token enrichment webhooks, and multi-tenancy management.
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/default` | auth-server | HTTP + ConnectRPC | User-facing login/consent/logout, Hydra webhooks, login history API |
+| `apps/tenancy` | tenancy-server | ConnectRPC + HTTP | Tenant/partition/service-account CRUD, Hydra client sync, Keto permission management |
+| `apps/audit` | audit-server | — | Audit logging |
+
+### Exposed Endpoints
+
+**apps/default — HTTP**
+- `GET /s/login` — Login page (Hydra redirect target)
+- `POST /s/login/{id}/post` — Contact submission
+- `GET /s/verify/contact/{id}` — OTP verification page
+- `POST /s/verify/contact/{id}/post` — OTP check
+- `POST /s/verify/contact/{id}/resend` — Resend OTP
+- `POST /s/social/login/{id}` — Social login initiation (Google/Facebook/Apple/Microsoft)
+- `GET|POST /s/social/callback` — Social provider callback
+- `GET /s/consent` — OAuth2 consent (auto-approved)
+- `GET /s/logout` — Logout handler
+- `GET /s/access/workspace` — Workspace selector
+- `POST /webhook/enrich/{tokenType}` — Token enrichment (called by Hydra)
+- `POST /webhook/sign/private-key-jwt` — Private key JWT signing
+
+**apps/default — ConnectRPC**
+- `GetLoginEvent` — Fetch login event by ID
+- `ListLoginEvents` — Stream/paginate login events
+
+**apps/tenancy — ConnectRPC**
+- `CreateTenant` / `GetTenant` / `ListTenant` / `UpdateTenant` / `RemoveTenant`
+- `CreatePartition` / `GetPartition` / `ListPartition` / `GetPartitionParents` / `UpdatePartition` / `RemovePartition`
+- `CreatePartitionRole` / `ListPartitionRole` / `UpdatePartitionRole` / `RemovePartitionRole`
+- `CreateServiceAccount` / `GetServiceAccount` / `ListServiceAccount` / `UpdateServiceAccount` / `RemoveServiceAccount`
+- `CreateClient` / `GetClient` / `ListClient` / `UpdateClient` / `RemoveClient`
+- `CreateAccess` / `GetAccess` / `ListAccess` / `RemoveAccess`
+- `CreateAccessRole` / `ListAccessRole` / `RemoveAccessRole`
+- `CreatePage` / `GetPage` / `ListPage` / `UpdatePage` / `RemovePage`
+- `ListServiceNamespaces` / `GrantPermission` / `RevokePermission`
+
+**apps/tenancy — Internal HTTP**
+- `/_internal/sync/clients` — Sync all clients to Hydra
+- `/_internal/register/permissions` — Register service permission manifest
+- `/_internal/opl` — Serve Keto OPL config
+
+### Current Metrics: **None**
+Zero application-level telemetry instrumentation.
+
+### Essential Metrics
+
+| Metric | Type | Labels | Where |
+|--------|------|--------|-------|
+| `auth.login.attempts` | counter | `contact_type`, `client_id` | `LoginEndpointSubmit` |
+| `auth.login.completed` | counter | `source` (direct/google/facebook/apple), `is_new_user` | `AcceptLoginRequest` calls |
+| `auth.login.failed` | counter | `reason` (rate_limited/verification_failed/bot_blocked) | error paths |
+| `auth.login.rate_limited` | counter | `client_id` | `CheckLoginRateLimit` |
+| `auth.verification.sent` | counter | `contact_type` | OTP creation |
+| `auth.verification.checked` | counter | `result` (success/incorrect/exceeded) | `VerificationEndpointSubmit` |
+| `auth.verification.resent` | counter | `contact_type` | resend endpoint |
+| `auth.social.initiated` | counter | `provider` | `ProviderLoginEndpointV2` |
+| `auth.social.completed` | counter | `provider`, `is_new_user` | callback success |
+| `auth.social.failed` | counter | `provider`, `reason` | callback error |
+| `auth.consent.granted` | counter | `principal_type` (user/service_account) | `ShowConsentEndpoint` |
+| `auth.token.enrichment` | counter | `token_type`, `grant_type`, `path` (fast/slow/db) | webhook |
+| `auth.token.enrichment.duration` | histogram | `token_type`, `grant_type` | webhook |
+| `auth.session.skip` | counter | — | Hydra skip flow |
+| `auth.remember_me.login` | counter | `result` | remember-me attempt |
+| `auth.device.created` | counter | `device_type` | device creation |
+| `auth.sa.token` | counter | `sa_type`, `grant_type` | SA token enrichment |
+| `tenancy.partition.created` | counter | — | partition CRUD |
+| `tenancy.sa.created` | counter | `sa_type` | SA creation |
+| `tenancy.hydra.sync` | counter | `entity_type`, `result` | Hydra sync |
+| `tenancy.permission.granted` | counter | `namespace` | GrantPermission |
+
+---
+
+## 2. service-profile
+
+### Purpose
+Identity and presence layer — user/bot/institution profiles, encrypted contacts, contact verification (OTP), rosters, relationships, device management, presence, cryptographic keys, push notifications, settings, and geolocation (geofencing, route tracking, proximity queries).
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/default` | profile-server | ConnectRPC + REST | Profile CRUD, contacts (encrypted), verification, rosters, relationships, addresses |
+| `apps/devices` | device-server | ConnectRPC | Device lifecycle, sessions, presence, crypto keys, push notification, TURN credentials |
+| `apps/settings` | settings-server | ConnectRPC | Key/value settings store with history |
+| `apps/geolocation` | geolocation-server | ConnectRPC + REST | Location ingestion, geofencing, route tracking, proximity queries |
+
+### Exposed Endpoints (60+)
+
+**ProfileService** (18 RPCs): `GetById`, `GetByContact`, `Search`, `Merge`, `Create`, `Update`, `AddAddress`, `AddContact`, `CreateContact`, `CreateContactVerification`, `CheckVerification`, `RemoveContact`, `SearchRoster`, `AddRoster`, `RemoveRoster`, `AddRelationship`, `DeleteRelationship`, `ListRelationships`
+- REST: `GET /public/user/info`, `GET /public/user/relations`
+
+**DeviceService** (17 RPCs): `GetById`, `GetBySessionId`, `Search`, `Create`, `Update`, `Link`, `Remove`, `Log`, `ListLogs`, `GetTurnCredentials`, `AddKey`, `RemoveKey`, `SearchKey`, `UpdatePresence`, `RegisterKey`, `DeRegisterKey`, `Notify`
+
+**SettingsService** (4 RPCs): `Get`, `Set`, `List`, `Search`
+
+**GeolocationService** (19 RPCs): `IngestLocations`, `CreateArea`, `GetArea`, `UpdateArea`, `DeleteArea`, `SearchAreas`, `CreateRoute`, `GetRoute`, `UpdateRoute`, `DeleteRoute`, `SearchRoutes`, `AssignRoute`, `UnassignRoute`, `GetSubjectRouteAssignments`, `GetTrack`, `GetSubjectEvents`, `GetAreaSubjects`, `GetNearbySubjects`, `GetNearbyAreas`
+
+### Current Metrics: **Partial** (~25%)
+- **Devices** (`apps/devices/service/caching/metrics.go`): `cache_hits`, `cache_misses`, `rate_limited` counters + tracer spans
+- **Geolocation** (`apps/geolocation/service/observability/metrics.go`): `ingestBatchLatency`, `ingestAccepted/Rejected`, `geofenceEvalLatency`, `geofenceTransitions`, `routeDeviationEvalLatency`, `routeDeviationTransitions`, `proximityQueryLatency`
+- **Profile & Settings**: Zero instrumentation
+
+### Essential Metrics (gaps)
+
+| Metric | Type | App | Where |
+|--------|------|-----|-------|
+| `profile.created` | counter | default | `Create` |
+| `profile.contact.verification.requested` | counter | default | `CreateContactVerification` |
+| `profile.contact.verification.checked` | counter | default | `CheckVerification` |
+| `profile.contact.encryption.key_rotation` | counter | default | key rotation queue |
+| `profile.roster.bulk_upsert.batch_size` | histogram | default | `AddRoster` |
+| `profile.merge` | counter | default | `Merge` |
+| `device.created` | counter | devices | `Create` |
+| `device.linked` | counter | devices | `Link` |
+| `device.presence.updated` | counter | devices | `UpdatePresence` |
+| `device.push.notify` | counter | devices | `Notify` |
+| `device.turn.issued` | counter | devices | `GetTurnCredentials` |
+| `setting.get` | counter | settings | `Get` |
+| `setting.set` | counter | settings | `Set` |
+| `geolocation.area.created` | counter | geolocation | `CreateArea` |
+| `geolocation.route.assigned` | counter | geolocation | `AssignRoute` |
+
+---
+
+## 3. service-notification
+
+### Purpose
+Multi-channel, multi-tenant notification platform. Receives notification requests, routes to delivery channels (SMS, email), formats via templates, dispatches to provider integrations. Also includes a full USSD session engine.
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/default` | notification-server | ConnectRPC | Core notification service — send, receive, route, template, status |
+| `apps/integrations/africastalking` | at-worker | Queue + HTTP | Africa's Talking SMS integration |
+| `apps/integrations/emailsmtp` | smtp-worker | Queue + HTTP | SMTP email delivery with connection pooling |
+| `apps/integrations/smpp` | smpp-worker | Queue + HTTP | SMPP integration (stub) |
+| `apps/ussd` | ussd-server | HTTP | USSD session engine with menu tree navigation |
+
+### Exposed Endpoints
+
+**NotificationService** (8 RPCs): `Send` (streaming), `Status`, `StatusUpdate`, `Release` (streaming), `Receive` (streaming), `Search` (streaming), `TemplateSearch` (streaming), `TemplateSave`
+
+**USSD Gateway**: `POST /ussd/gateway/{serviceID}`, `POST /ussd/gateway/{serviceID}/{protocol}`
+**USSD Management** (15 REST endpoints): Menu CRUD, translations, service config, queries, sessions
+
+**Integration Webhooks**: `/receive/notification/{routeID}` (AT + SMTP)
+
+### Current Metrics: **None**
+
+### Essential Metrics
+
+| Metric | Type | Labels | Where |
+|--------|------|--------|-------|
+| `notification.queued` | counter | `channel`, `direction` | `QueueOut`/`QueueIn` |
+| `notification.delivered` | counter | `channel`, `provider`, `status` | status update events |
+| `notification.failed` | counter | `channel`, `provider`, `reason` | failed status |
+| `notification.route.miss` | counter | `direction`, `type` | route not found |
+| `notification.template.render` | counter | `template`, `status` | template execution |
+| `notification.template.render.duration` | histogram | — | template execution |
+| `africastalking.sms.sent` | counter | `status_code_range` | AT client |
+| `email.smtp.sent` | counter | `result` | SMTP send |
+| `email.smtp.connection.reuse` | counter | — | connection pool |
+| `ussd.session` | counter | `service_id`, `outcome` | session complete/abandon |
+| `ussd.session.duration` | histogram | `service_id` | session lifecycle |
+| `ussd.input.validation.failure` | counter | `service_id`, `menu_id` | input validation |
+
+---
+
+## 4. service-files
+
+### Purpose
+Multi-tenant file storage platform — upload, download, thumbnail generation, encryption, versioning, multipart uploads, URL previews, retention policies, access control (ReBAC). Also includes OCR, property catalogue, and URL shortener services.
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/default` | files-server | ConnectRPC + REST | Core file service (35+ RPCs) |
+| `apps/ocr` | ocr-server | ConnectRPC | OCR via Google Vision / Tesseract |
+| `apps/property` | property-server | ConnectRPC | Real estate property catalogue |
+| `apps/redirect` | redirect-server | ConnectRPC + HTTP | URL shortener with click tracking |
+
+### Exposed Endpoints (50+)
+
+**FilesService** (35 RPCs): `UploadContent`, `CreateContent`, `GetContent`, `GetContentOverrideName`, `HeadContent`, `GetContentThumbnail`, `GetUrlPreview`, `GetConfig`, `GetUserUsage`, `GetStorageStats`, `GetSignedUploadUrl`, `GetSignedDownloadUrl`, `CreateMultipartUpload`, `UploadMultipartPart`, `CompleteMultipartUpload`, `AbortMultipartUpload`, `ListMultipartParts`, `DeleteContent`, `BatchGetContent`, `BatchDeleteContent`, `GetVersions`, `RestoreVersion`, `SetRetentionPolicy`, `GetRetentionPolicy`, `ListRetentionPolicies`, `SearchMedia`, `PatchContent`, `FinalizeSignedUpload`, `GrantAccess`, `RevokeAccess`, `ListAccess`, `DownloadContent`, `DownloadContentRange`
+- REST: `/v1/media/upload`, `/v1/media/download/{server}/{id}`, `/v1/media/thumbnail/{server}/{id}`, `/v1/media/search`, `/v1/media/config`
+
+**OCRService** (2 RPCs): `Recognize`, `Status`
+**PropertyService** (13 RPCs): Property types, localities, properties, subscriptions
+**RedirectService** (7 RPCs + `GET /r/{slug}`): `CreateLink`, `GetLink`, `UpdateLink`, `DeleteLink`, `ListLinks`, `GetLinkStats`, `ListClicks`
+
+### Current Metrics: **Dead code** (0%)
+A full `Metrics` struct exists at `apps/default/service/metrics/metrics.go` with Prometheus text exposition, but it is **never wired** in `main.go`. Zero OTel usage.
+
+### Essential Metrics
+
+| Metric | Type | Labels | Where |
+|--------|------|--------|-------|
+| `files.upload` | counter | `content_type`, `visibility` | `UploadContent` |
+| `files.upload.bytes` | counter | `visibility` | upload completion |
+| `files.upload.duration` | histogram | — | upload end-to-end |
+| `files.download` | counter | `cached` | `GetContent`/`DownloadContent` |
+| `files.download.bytes` | counter | — | download completion |
+| `files.thumbnail.generated` | counter | `method` | thumbnail queue |
+| `files.thumbnail.duration` | histogram | — | thumbnail queue |
+| `files.delete` | counter | — | `DeleteContent` |
+| `files.multipart.completed` | counter | — | `CompleteMultipartUpload` |
+| `files.dedup.hits` | counter | — | hash dedup path |
+| `files.authz.denied` | counter | `permission` | authz middleware |
+| `redirect.redirects` | counter | — | `GET /r/{slug}` |
+| `redirect.unique_clicks` | counter | — | dedup check |
+| `ocr.recognize` | counter | `provider`, `outcome` | `Recognize` |
+| `ocr.recognize.duration` | histogram | `provider` | `Recognize` |
+
+---
+
+## 5. service-chat
+
+### Purpose
+Multi-tenant real-time chat platform — rooms, messaging, subscriptions with roles, real-time presence/typing/read receipts, proposal workflow, sharded device delivery pipeline, offline push notifications, reconnection replay.
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/default` | chat-server | ConnectRPC | Core chat service — rooms, messages, subscriptions, proposals, replay |
+| `apps/gateway` | chat-gateway | ConnectRPC (BiDi stream) | WebSocket gateway for real-time device connections |
+
+### Exposed Endpoints (20+)
+
+**ChatService** (20 RPCs): `SendEvent`, `GetHistory`, `GetEvent`, `GetRoom`, `CreateRoom`, `SearchRooms` (stream), `UpdateRoom`, `DeleteRoom`, `AddRoomSubscriptions`, `RemoveRoomSubscriptions`, `UpdateSubscriptionRole`, `SearchRoomSubscriptions`, `GetSubscriptionSettings`, `UpdateSubscriptionSettings`, `ListProposals`, `SubmitProposal`, `Live`, `ResolveReplayCursor`, `GetLatestReplayCursor`, `ListReplayEvents`
+
+**GatewayService** (1 RPC): `Stream` (BiDi streaming)
+
+### Current Metrics: **Good** (~70%)
+
+**Existing counters** (`internal/telemetry/metrics.go`):
+`chat.messages.sent`, `chat.messages.delivered`, `chat.messages.failed`, `chat.messages.dead_lettered`, `chat.rooms.created`, `chat.rooms.deleted`, `chat.subscriptions.added`, `chat.subscriptions.removed` (declared but unused), `chat.outbox.created`, `chat.delivery.queue.processed`, `chat.delivery.queue.retried`, `chat.notifications.sent`, `chat.notifications.failed`, `chat.events.fanout`, `chat.dlq.consumed`, `chat.replay.cursor.resolved`, `chat.replay.events.listed`
+
+**Existing histograms**: `chat.delivery.latency`, `chat.replay.latency`
+
+**Gateway counters**: `gateway.connections.active`, `gateway.connections.total`, `gateway.connections.failed`, `gateway.connections.disconnected`, `gateway.connections.cleaned`, `gateway.connection.duration`
+
+### Gaps
+
+| Metric | Type | Where |
+|--------|------|-------|
+| `chat.subscriptions.removed` | counter | **Wire callsite** — declared but `.Add()` never called |
+| `chat.delivery.online_vs_offline` | counter | separate online/offline delivery |
+| `chat.proposals.created/approved/rejected` | counter | proposal workflow (zero metrics) |
+| `gateway.messages.rate_limited` | counter | expose `rateLimitedCnt` atomic to OTel |
+| `gateway.messages.dropped_backpressure` | counter | expose `droppedMsgs` atomic to OTel |
+| `chat.authz.check.duration` | histogram | Keto check latency |
+
+---
+
+## 6. service-commerce
+
+### Purpose
+Multi-tenant e-commerce backend — shop management, product catalogue with variants, shopping carts, order management (with stock decrement and idempotency), fulfilment tracking.
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/default` | commerce-server | ConnectRPC | Single CommerceService |
+
+### Exposed Endpoints (19 RPCs)
+`CreateShop`, `GetShop`, `UpdateShop`, `CreateProduct`, `GetProduct`, `ListProducts`, `CreateProductVariant`, `UpdateProductVariant`, `CreateCart`, `GetCart`, `AddCartLine`, `RemoveCartLine`, `CreateOrderFromCart`, `CreateOrder`, `GetOrder`, `ListOrders`, `CreateFulfilment`, `UpdateFulfilment`, `GetFulfilment`
+
+### Current Metrics: **None**
+
+### Essential Metrics
+
+| Metric | Type | Labels | Where |
+|--------|------|--------|-------|
+| `commerce.orders.created` | counter | `shop_id` | `CreateOrder` |
+| `commerce.orders.from_cart` | counter | `shop_id` | `CreateOrderFromCart` |
+| `commerce.orders.revenue` | histogram | `currency_code` | order amount |
+| `commerce.carts.created` | counter | `shop_id` | `CreateCart` |
+| `commerce.carts.converted` | counter | — | cart→order conversion |
+| `commerce.stock.decrements` | counter | — | stock update |
+| `commerce.stock.insufficient` | counter | — | stock-out events |
+| `commerce.fulfilments.created` | counter | — | `CreateFulfilment` |
+| `commerce.orders.fulfilled` | counter | — | full fulfilment promotion |
+| `commerce.shops.created` | counter | — | `CreateShop` |
+| `commerce.order.creation.duration` | histogram | — | order creation latency |
+
+---
+
+## 7. service-payment
+
+### Purpose
+Payment orchestration platform — outbound/inbound payment routing, payment prompts (STK push), payment links, double-entry ledger, usage-based billing engine. Six payment provider integrations (M-Pesa, Airtel, MTN, Stripe, Polar, Jenga).
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/default` | payment-server | ConnectRPC | Core payment orchestrator |
+| `apps/ledger` | ledger-server | ConnectRPC | Double-entry bookkeeping |
+| `apps/billing` | billing-server | ConnectRPC | Usage-based billing engine |
+| `apps/integrations/mpesa` | mpesa-worker | Queue + HTTP | M-Pesa integration |
+| `apps/integrations/airtel` | airtel-worker | Queue + HTTP | Airtel Money integration |
+| `apps/integrations/mtn` | mtn-worker | Queue + HTTP | MTN MoMo integration |
+| `apps/integrations/stripe` | stripe-worker | Queue + HTTP | Stripe integration |
+| `apps/integrations/polar` | polar-worker | Queue + HTTP | Polar integration |
+| `apps/integrations/jenga-api` | jenga-worker | Queue + HTTP | Jenga API integration |
+
+### Exposed Endpoints (40+)
+
+**PaymentService** (9 RPCs): `Send`, `Status`, `StatusUpdate`, `Release`, `Receive`, `InitiatePrompt`, `CreatePaymentLink`, `Search` (stream), `Reconcile`
+
+**LedgerService** (11 RPCs): `SearchLedgers`, `CreateLedger`, `UpdateLedger`, `SearchAccounts`, `CreateAccount`, `UpdateAccount`, `SearchTransactions`, `CreateTransaction`, `ReverseTransaction`, `UpdateTransaction`, `SearchTransactionEntries`
+
+**BillingService** (24 RPCs): Catalog/plan/component/tier CRUD, subscriptions, usage event ingestion, billing runs, invoicing, credit grants, discounts
+
+**Integration Webhooks**: M-Pesa (5 endpoints), Airtel (2), MTN (2), Stripe (1), Polar (1), Jenga (2)
+
+### Current Metrics: **None** (billing has `otelconnect` interceptor only)
+
+### Essential Metrics
+
+| Metric | Type | Labels | Where |
+|--------|------|--------|-------|
+| `payment.sent` | counter | `payment_type`, `currency` | `Send` |
+| `payment.received` | counter | `payment_type`, `currency` | `Receive` |
+| `payment.amount` | histogram | `currency`, `direction` | monetary volume |
+| `payment.failed` | counter | `payment_type`, `provider` | failed status |
+| `payment.routing.failure` | counter | — | no matching route |
+| `payment.processing.duration` | histogram | — | end-to-end latency |
+| `payment.prompt.initiated` | counter | — | `InitiatePrompt` |
+| `ledger.transaction.created` | counter | `type`, `currency` | `CreateTransaction` |
+| `ledger.transaction.amount` | histogram | `currency` | monetary volume |
+| `ledger.transaction.conflict` | counter | — | idempotency conflicts |
+| `ledger.transaction.reversed` | counter | `currency` | `ReverseTransaction` |
+| `billing.run` | counter | `state` | `RunBilling` |
+| `billing.run.duration` | histogram | — | billing pipeline |
+| `billing.invoice.issued` | counter | `currency` | `IssueInvoice` |
+| `billing.usage.ingested` | counter | `metric_key` | `IngestUsageEvent` |
+| `billing.credit.granted` | counter | `currency` | `GrantCredit` |
+| `provider.webhook.callback` | counter | `provider`, `event_type` | all webhooks |
+| `provider.api.call` | counter | `provider`, `operation` | outbound API |
+| `provider.api.duration` | histogram | `provider` | outbound API latency |
+
+---
+
+## 8. service-fintech
+
+### Purpose
+Core banking platform for microfinance — organizational hierarchy, KYC, loan lifecycle, savings accounts, investor funding, transfer orders, payment routing, group-lending workflows (Stawi), direct-to-client lending (Seed).
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/identity` | identity-server | ConnectRPC + REST | Organizations, workforce, clients, groups, KYC, forms |
+| `apps/loans` | loans-server | ConnectRPC | Loan products, requests, accounts, repayments, penalties, restructuring, disbursements |
+| `apps/savings` | savings-server | ConnectRPC | Savings products, accounts, deposits, withdrawals, interest |
+| `apps/operations` | operations-server | ConnectRPC | Transfer orders, incoming payments, allocation |
+| `apps/funding` | funding-server | ConnectRPC | Investor accounts, capital deployment, loss absorption |
+| `apps/stawi` | stawi-server | REST | Group-lending workflow callback engine |
+| `apps/seed` | seed-server | REST | DTC lending with credit profile progression |
+
+### Exposed Endpoints (120+)
+
+**IdentityService** (52 RPCs): Organization/OrgUnit/Branch/Investor/SystemUser/WorkforceMember/Department/Position/PositionAssignment/InternalTeam/TeamMembership/AccessRoleAssignment CRUD, ClientGroup/Membership CRUD, ClientData lifecycle + verification, FormTemplate/FormSubmission CRUD
+**FieldService** (15 RPCs): Agent/Client CRUD, hierarchy, reassignment, relationships
+**LoanManagementService** (31 RPCs): Product/Request/Account/Repayment/Penalty/Restructure/Reconciliation/Disbursement lifecycle
+**SavingsService** (19 RPCs): Product/Account/Deposit/Withdrawal/InterestAccrual lifecycle
+**OperationsService** (4 RPCs): `TransferOrderExecute`, `TransferOrderSearch`, `IncomingPaymentNotify`, `PaymentAllocate`
+**FundingService** (7 RPCs): Investor account lifecycle, `FundLoan`, `AbsorbLoss`
+**Stawi** (20 REST endpoints): Group formation → tenure → period → loan window → offer → disburse → payment identify/allocate
+**Seed** (3 REST endpoints): Loan requests, credit profiles, paid-off hook
+
+### Current Metrics: **None** (audit interceptor + event logging only)
+
+### Essential Metrics
+
+| Metric | Type | Labels | Where |
+|--------|------|--------|-------|
+| `fintech.loan.request` | counter | `product_id`, `currency`, `status` | `LoanRequestSave/Approve/Reject` |
+| `fintech.loan.disbursement` | counter | `product_id`, `currency` | `DisbursementCreate` |
+| `fintech.loan.disbursement.amount` | histogram | `currency` | capital deployed |
+| `fintech.loan.repayment` | counter | `currency`, `type` | `RepaymentRecord` |
+| `fintech.loan.status_transition` | counter | `from`, `to` | state machine |
+| `fintech.loan.restructure` | counter | `product_id` | `LoanRestructureCreate` |
+| `fintech.savings.deposit` | counter | `currency` | `DepositRecord` |
+| `fintech.savings.deposit.amount` | histogram | `currency` | deposit volume |
+| `fintech.savings.withdrawal` | counter | `currency` | `WithdrawalRequest` |
+| `fintech.transfer.order` | counter | `order_type`, `status` | `TransferOrderExecute` |
+| `fintech.transfer.order.amount` | histogram | `currency` | money moved |
+| `fintech.transfer.order.duration` | histogram | `order_type` | ledger posting latency |
+| `fintech.payment.incoming` | counter | `strategy` | identified vs unidentified |
+| `fintech.funding.allocation` | counter | `fully_funded` | `FundLoan` |
+| `fintech.client.created` | counter | — | `ClientSave` |
+| `fintech.client.kyc.verified` | counter | `result` | `ClientDataVerify` |
+
+---
+
+## 9. service-thesa
+
+### Purpose
+Backend for Frontend (BFF) — definition-driven UI API gateway. Translates YAML-declared UI definitions into backend HTTP calls using OpenAPI specs. Provides capability resolution (Keto ReBAC), global search, analytics queries (TimescaleDB), and file proxying.
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/default` | thesa-bff | HTTP | Single BFF application |
+
+### Exposed Endpoints (22 HTTP)
+
+**UI routes**: `/ui/capabilities`, `/ui/capabilities/batch-check`, `/ui/navigation`, `/ui/pages/{id}`, `/ui/pages/{id}/data`, `/ui/forms/{id}`, `/ui/forms/{id}/data`, `/ui/schemas/{id}`, `/ui/commands/{id}`, `/ui/actions/{id}`, `/ui/resources/{type}/search`, `/ui/resources/{type}/{id}`, `/ui/resources/{type}`, `/ui/search`, `/ui/lookups/{id}`, `/ui/upload`, `/ui/download/{id}`
+
+**Analytics routes**: `/api/analytics/services`, `/api/analytics/metrics`, `/api/analytics/timeseries`, `/api/analytics/distribution`, `/api/analytics/top`
+
+### Current Metrics: **Minimal** (~5%)
+Only trace ID extraction in error responses. Request logging middleware logs duration but doesn't record OTel metrics.
+
+### Essential Metrics
+
+| Metric | Type | Labels | Where |
+|--------|------|--------|-------|
+| `thesa.request.duration` | histogram | `handler`, `status_code` | request middleware |
+| `thesa.requests` | counter | `handler`, `status_code` | request middleware |
+| `thesa.capability.resolution.duration` | histogram | `cache_hit` | `Resolver.Resolve` |
+| `thesa.capability.cache.hits` | counter | — | cache hit path |
+| `thesa.capability.cache.misses` | counter | — | cache miss path |
+| `thesa.capability.batch_check.failures` | counter | — | Keto BatchCheck fallback |
+| `thesa.backend.request.duration` | histogram | `service_id`, `operation_id` | `OpenAPIOperationInvoker` |
+| `thesa.backend.errors` | counter | `service_id`, `error_type` | backend call failures |
+| `thesa.command.executions` | counter | `command_id`, `success` | `CommandExecutor` |
+| `thesa.search.provider.duration` | histogram | `provider_id` | search fan-out |
+| `thesa.analytics.query.duration` | histogram | `query_type` | analytics engine |
+| `thesa.file.upload.bytes` | counter | — | upload proxy |
+
+---
+
+## 10. service-trustage
+
+### Purpose
+Multi-tenant workflow automation engine — contract-driven state transitions with JSON Schema validation, CEL-based event routing, connector adapters for external integrations, scheduling (retry, timeout, timer, signal, scope). Also includes a form definition/submission store and a virtual queue management service.
+
+### Sub-Applications
+
+| App | Binary | Protocol | Description |
+|-----|--------|----------|-------------|
+| `apps/default` | trustage-server | ConnectRPC + HTTP | Core orchestration engine |
+| `apps/formstore` | formstore-server | HTTP | Form definition and submission store |
+| `apps/queue` | queue-server | HTTP | Virtual queue management with counters and SLA |
+
+### Exposed Endpoints (50+)
+
+**WorkflowService** (4 RPCs): `CreateWorkflow`, `GetWorkflow`, `ListWorkflows`, `ActivateWorkflow`
+**EventService** (2 RPCs): `IngestEvent`, `GetInstanceTimeline`
+**RuntimeService** (6 RPCs): `ListInstances`, `RetryInstance`, `ListExecutions`, `GetExecution`, `RetryExecution`, `ResumeExecution`, `GetInstanceRun`
+**SignalService** (1 RPC): `SendSignal`
+**HTTP**: Form submission, webhook receive, health/ready checks
+
+**Formstore** (10 REST endpoints): Form definition CRUD, submission CRUD
+**Queue** (22 REST endpoints): Queue/item/counter lifecycle, stats
+
+### Current Metrics: **Moderate** (~50%)
+
+**Existing instruments** (`pkg/telemetry/metrics.go`): 16 OTel instruments registered. Active: `engine.executions.total`, `engine.dispatch.latency_ms`, `engine.commit.latency_ms`, `engine.stale_executions.total`, `events.ingested.total`, `events.routed.total`, scheduler gauges.
+
+**Formstore** (`apps/formstore/service/business/telemetry.go`): 7 instruments, mostly active.
+**Queue** (`apps/queue/service/business/telemetry.go`): 9 instruments, mostly active.
+
+### Gaps — Defined but Never Recorded
+
+| Metric | Status | Fix |
+|--------|--------|-----|
+| `engine.transitions.total` | Defined, no `.Add()` | Wire in `Commit()` |
+| `engine.retries.total` | Defined, no `.Add()` | Wire in retry schedulers |
+| `engine.contract_violations.total` | Defined, no `.Add()` | Wire in schema validation |
+| `engine.execution.latency_ms` | Defined, no `.Record()` | Wire dispatch-to-commit time |
+| `connector.calls.total` | Defined, no `.Add()` | Wire in `ExecutionWorker` |
+| `connector.latency_ms` | Defined, no `.Record()` | Wire in `ExecutionWorker` |
+| `formstore.schema.validation.errors` | Defined, no `.Add()` | Wire in validation error path |
+| `queue.enqueue.errors` | Defined, no `.Add()` | Wire in enqueue error path |
+| `queue.dequeue.errors` | Defined, no `.Add()` | Wire in dequeue error path |
+
+### Additional Essential Metrics
+
+| Metric | Type | Where |
+|--------|------|-------|
+| `engine.instances.active` | gauge | running instances per tenant |
+| `scheduler.timer_fired` | counter | timer scheduler |
+| `scheduler.signal_delivered` | counter | signal scheduler |
+| `queue.wait_time_ms` | histogram | joined_at → called_at |
+| `queue.service_time_ms` | histogram | service_start → service_end |
+| `queue.sla_breach` | counter | exceeded `sla_minutes` |
+| `queue.depth` | gauge | current waiting items |
+
+---
+
+## Implementation Priority
+
+### Tier 1 — Highest Business Impact (implement first)
+1. **service-authentication** — Every user interaction starts here; login failures/latency are invisible today
+2. **service-payment** — Financial transactions with zero observability; routing failures are silent
+3. **service-fintech** — Core banking with zero metrics; PAR30 and disbursement volume are critical
+
+### Tier 2 — High Operational Value
+4. **service-notification** — Delivery failures are invisible; provider health unknown
+5. **service-files** — Dead metrics code needs wiring; upload/download volumes unknown
+6. **service-profile** — Contact verification (shared with auth) needs coverage
+
+### Tier 3 — Existing Coverage + Gaps
+7. **service-trustage** — Wire the 9 defined-but-unrecorded instruments
+8. **service-chat** — Wire `subscriptions.removed`, add proposal metrics
+9. **service-commerce** — New service, lower traffic, but stock-outs need visibility
+10. **service-thesa** — BFF gateway metrics are useful but most backend metrics come from the services it proxies
+
+### Cross-Cutting (all services get for free with Frame upgrade)
+- `tenant_id` and `partition_id` on all traced spans and latency histograms
+- `TenantAttributes(ctx)` helper for custom product metrics
+- `WithTenantAttributes(ctx)` metric option for counters/histograms

--- a/docs/superpowers/plans/2026-04-19-auth-runtime-flutter.md
+++ b/docs/superpowers/plans/2026-04-19-auth-runtime-flutter.md
@@ -1,0 +1,489 @@
+# `antinvestor_auth_runtime` implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Each task is TDD: failing test first → run → implement → run → commit. Steps use `- [ ]` checkboxes.
+
+**Goal:** ship `antinvestor_auth_runtime` v0.1.0 at `service-authentication/ui/runtime/` — Flutter package implementing the Stawi auth protocol (OAuth+PKCE+adaptive DPoP+rotation+reuse-detection) with Isolate-isolated tokens, `flutter_secure_storage`-backed persistence, `flutter_appauth` OAuth, Riverpod 3.3 providers, and a Material widget set.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-auth-runtime-flutter-design.md`.
+
+**Branch:** `feat/auth-runtime-flutter` (already checked out).
+
+**Package name:** `antinvestor_auth_runtime` — matches existing `antinvestor_ui_*` convention, name reflects its role as infrastructure rather than pure UI.
+
+## Conventions
+
+- TDD every task.
+- `analysis_options.yaml`: `include: package:flutter_lints/flutter.yaml`.
+- Imports: `package:antinvestor_auth_runtime/...`.
+- Commit messages: Conventional Commits (`feat(auth-runtime): ...`).
+- One commit per task.
+- After each task, run `flutter test` from the package dir; must pass.
+
+## Task groups
+
+### F-A — Foundation (3 tasks)
+
+#### F-A.1: Package skeleton
+
+**Files:**
+- Create: `service-authentication/ui/runtime/pubspec.yaml`, `README.md`, `CHANGELOG.md`, `LICENSE`, `analysis_options.yaml`
+- Create: `service-authentication/ui/runtime/lib/antinvestor_auth_runtime.dart` (empty barrel)
+
+Steps:
+
+- [ ] Scaffold directory + `pubspec.yaml`:
+
+```yaml
+name: antinvestor_auth_runtime
+description: >
+  Auth runtime for Antinvestor Flutter apps. OAuth2 + PKCE, adaptive DPoP,
+  rotating refresh tokens with reuse detection, Isolate-isolated tokens,
+  hardware-backed storage, Riverpod providers, Material widgets.
+version: 0.1.0
+repository: https://github.com/antinvestor/service-authentication
+homepage: https://github.com/antinvestor/service-authentication/tree/main/ui/runtime
+issue_tracker: https://github.com/antinvestor/service-authentication/issues
+topics:
+  - flutter
+  - authentication
+  - oauth2
+  - dpop
+  - antinvestor
+
+environment:
+  sdk: ^3.11.0
+  flutter: ">=3.24.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^3.3.1
+  flutter_secure_storage: ^9.2.2
+  flutter_appauth: ^8.0.0+1
+  cryptography: ^2.7.0
+  http: ^1.2.2
+  crypto: ^3.0.6
+  async: ^2.11.0
+  equatable: ^2.0.7
+  uuid: ^4.5.1
+  meta: ^1.15.0
+  collection: ^1.18.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+  mocktail: ^1.0.4
+  shelf: ^1.4.1
+  shelf_router: ^1.1.4
+
+flutter:
+  uses-material-design: true
+```
+
+- [ ] `analysis_options.yaml`:
+```yaml
+include: package:flutter_lints/flutter.yaml
+linter:
+  rules:
+    prefer_const_constructors: true
+    prefer_final_locals: true
+    avoid_print: true
+    public_member_api_docs: false
+```
+- [ ] `LICENSE`: copy from a sibling package (MIT from `ui/auth/LICENSE`).
+- [ ] `lib/antinvestor_auth_runtime.dart`: `library antinvestor_auth_runtime;` placeholder.
+- [ ] Run `flutter pub get` from `service-authentication/ui/runtime/`.
+- [ ] Commit: `chore(auth-runtime): scaffold antinvestor_auth_runtime package`
+
+#### F-A.2: Models
+
+**Files:**
+- `lib/src/models/{auth_state,token_set,user_claims,security_event,api_response}.dart`
+- `lib/src/errors/auth_error.dart`
+- `test/models/auth_error_test.dart`
+
+- [ ] Test first:
+
+```dart
+// test/models/auth_error_test.dart
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AuthError preserves code/message/cause and computes retryable', () {
+    final e = AuthError(AuthErrorCode.networkTimeout, 'boom', cause: StateError('x'));
+    expect(e.code, AuthErrorCode.networkTimeout);
+    expect(e.message, 'boom');
+    expect(e.cause, isA<StateError>());
+    expect(e.retryable, isTrue);
+  });
+  test('non-retryable codes flagged', () {
+    for (final c in const [
+      AuthErrorCode.invalidConfig,
+      AuthErrorCode.refreshReuseDetected,
+      AuthErrorCode.cryptoUnsupported,
+      AuthErrorCode.deepLinkMismatch,
+      AuthErrorCode.securityWipe,
+    ]) {
+      expect(AuthError(c, 'm').retryable, isFalse, reason: c.name);
+    }
+  });
+}
+```
+
+- [ ] Implement `AuthError` + `AuthErrorCode` per spec §4. Mark six non-retryable codes in a static set.
+- [ ] Implement `AuthState`, `TokenSet`, `UserClaims`, `SecurityEvent` (sealed class with 4 factory constructors), `ApiResponse`.
+- [ ] Run `flutter test test/models/` — PASS.
+- [ ] Commit: `feat(auth-runtime): models and error taxonomy`
+
+#### F-A.3: AuthConfig + resolveConfig
+
+**Files:**
+- `lib/src/config/auth_config.dart`, `lib/src/config/resolve_config.dart`
+- `test/config/resolve_config_test.dart`
+
+- [ ] Test:
+
+```dart
+import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('throws invalidConfig when clientId is empty', () {
+    expect(
+      () => resolveConfig(const AuthConfig(clientId: '', idpBaseUrl: 'https://i', apiBaseUrl: 'https://a', redirectScheme: 'x')),
+      throwsA(isA<AuthError>().having((e) => e.code, 'code', AuthErrorCode.invalidConfig)),
+    );
+  });
+  test('strips trailing slashes and namespaces', () {
+    final cfg = resolveConfig(const AuthConfig(
+      clientId: 'c', idpBaseUrl: 'https://i/', apiBaseUrl: 'https://a/', redirectScheme: 'com.example.app',
+    ));
+    expect(cfg.idpBaseUrl, 'https://i');
+    expect(cfg.apiBaseUrl, 'https://a');
+    expect(cfg.namespace, 'c::https://i');
+    expect(cfg.scopes, contains('offline_access'));
+  });
+  test('honors timeout overrides partially', () {
+    final cfg = resolveConfig(AuthConfig(
+      clientId: 'c', idpBaseUrl: 'https://i', apiBaseUrl: 'https://a', redirectScheme: 'x',
+      apiTimeout: const Duration(seconds: 5),
+    ));
+    expect(cfg.apiTimeout, const Duration(seconds: 5));
+    expect(cfg.tokenTimeout, const Duration(seconds: 10));
+  });
+}
+```
+
+- [ ] Implement `AuthConfig` (immutable, `Equatable`), `ResolvedConfig` (strips trailing `/`, adds defaults, computes `namespace`).
+- [ ] Run tests — PASS.
+- [ ] Commit: `feat(auth-runtime): AuthConfig + resolveConfig with namespace and defaults`
+
+---
+
+### F-B — Protocol (6 tasks)
+
+#### F-B.1: PKCE
+
+**Files:** `lib/src/protocol/pkce.dart`, `test/protocol/pkce_test.dart`
+
+- [ ] Test:
+
+```dart
+import 'package:antinvestor_auth_runtime/src/protocol/pkce.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('verifier is 43–128 url-safe chars', () async {
+    final pair = await generatePkcePair();
+    expect(RegExp(r'^[A-Za-z0-9_-]{43,128}$').hasMatch(pair.verifier), true);
+    expect(RegExp(r'^[A-Za-z0-9_-]+$').hasMatch(pair.challenge), true);
+  });
+  test('challenge is deterministic from verifier', () async {
+    final a = await generatePkcePair();
+    expect(await computeChallenge(a.verifier), a.challenge);
+  });
+}
+```
+
+- [ ] Implement with `crypto` (SHA-256) + `Random.secure()` (not `dart:math` `Random`), base64url-no-pad.
+- [ ] Commit: `feat(auth-runtime): PKCE S256 verifier/challenge generation`
+
+#### F-B.2: JWT payload decoder with padding fix
+
+**Files:** `lib/src/protocol/jwt.dart`, `test/protocol/jwt_test.dart`
+
+- [ ] Test: encode payloads of various lengths (1–20 chars), assert decode round-trips. Test `extractRolesFromToken` handles direct `roles` array and `realm_access.roles`.
+- [ ] Implement `decodeJwtPayload(String token) → Map<String, dynamic>` with base64url padding (`%4` → add `=`s). Implement `extractRolesFromToken`.
+- [ ] Commit: `feat(auth-runtime): JWT payload decode with padded base64url; role extraction`
+
+#### F-B.3: OIDC Discovery with timeout + cache
+
+**Files:** `lib/src/protocol/discovery.dart`, `test/protocol/discovery_test.dart`
+
+Test with `MockClient` from `package:http/testing.dart`. Cover: 200 JSON → parsed; 404 → `AuthError(discoveryFailed)`; non-JSON → `AuthError(discoveryFailed)`; cache persists across calls; failures not cached; DPoP detected from `dpop_signing_alg_values_supported`.
+
+- [ ] Implement `Discovery` class with `getDiscovery(String idpBaseUrl, Duration timeout, {http.Client? client})`. Module-level `Map<String, OidcDiscovery>` cache + in-flight dedup via `Completer`.
+- [ ] Expose `supportsDpop(OidcDiscovery)`.
+- [ ] Commit: `feat(auth-runtime): OIDC discovery with timeout, cache, DPoP capability detection`
+
+#### F-B.4: DPoP proof builder + nonce cache + clock offset
+
+**Files:** `lib/src/protocol/dpop.dart`, `test/protocol/dpop_test.dart`
+
+Dart `cryptography` package provides ECDSA P-256 signing. Key generated via `Ecdsa.p256(Sha256())`.
+
+- [ ] Test: generate key pair; build proof for `POST https://i/token`; decode resulting JWT; assert header = `{typ:"dpop+jwt", alg:"ES256", jwk:{kty:"EC", crv:"P-256", x:..., y:...}}`; payload = `{htm, htu, iat, jti}` with `iat` in seconds; optional `ath` when `accessToken` given = sha256(accessToken) base64url; optional `nonce` when set via `rememberNonce(headers)`.
+- [ ] Implement:
+```dart
+class DpopContext {
+  final SimpleKeyPair privateKey;
+  final JsonWebKey publicJwk;
+  int clockOffsetMs = 0;
+  final Map<String, String> nonceByOrigin = {};
+}
+
+Future<DpopContext> makeDpopContext(SimpleKeyPair kp);
+Future<String> buildProof(DpopContext ctx, {required String htm, required String htu, String? accessToken});
+void rememberNonce(DpopContext ctx, String audienceUrl, Map<String, String> headers);
+void rememberClockOffset(DpopContext ctx, Map<String, String> headers);
+```
+- [ ] Commit: `feat(auth-runtime): DPoP proof builder with nonce + clock offset`
+
+#### F-B.5: Token exchange + refresh
+
+**Files:** `lib/src/protocol/token_exchange.dart`, `test/protocol/token_exchange_test.dart`
+
+- [ ] Test with `MockClient`: successful auth-code exchange; DPoP-nonce challenge retry; clock-skew retry on `invalid_dpop_proof`; refresh rotates; refresh reuse-detection returns `RefreshOutcome.reuseDetected`.
+- [ ] Implement:
+```dart
+class TokenExchange {
+  TokenExchange({http.Client? client, required Duration timeout});
+  Future<TokenSet> exchangeCode(ResolvedConfig cfg, DpopContext ctx, {required String code, required String verifier});
+  Future<RefreshOutcome> refresh(ResolvedConfig cfg, DpopContext ctx, String refreshToken);
+}
+
+sealed class RefreshOutcome {
+  const factory RefreshOutcome.rotated(TokenSet tokens) = _Rotated;
+  const factory RefreshOutcome.reuseDetected() = _Reuse;
+  const factory RefreshOutcome.networkError(AuthError error) = _NetErr;
+}
+```
+- [ ] Commit: `feat(auth-runtime): token exchange and refresh with DPoP/nonce/clock-skew/reuse-detection`
+
+#### F-B.6: API proxy (DPoP + 401-refresh retry)
+
+**Files:** `lib/src/protocol/api_proxy.dart`, `test/protocol/api_proxy_test.dart`
+
+Matching the JS `api-proxy.ts` behavior.
+
+- [ ] Test: attaches `Authorization: DPoP <token>` + `DPoP: <proof>` in DPoP mode; attaches `Authorization: Bearer <token>` otherwise; 401 triggers forced refresh + retry once; 204 returns empty body; typed error mapping (401→apiUnauthorized, 403→apiForbidden, 404→apiNotFound, 5xx→apiServerError).
+- [ ] Implement `ApiProxy.fetch(...)` and `ApiProxy.upload(...)` taking a `TokenProvider` callback interface (matches JS design).
+- [ ] Commit: `feat(auth-runtime): API proxy with DPoP, nonce retry, and 401-refresh retry`
+
+---
+
+### F-C — Crypto & Storage (2 tasks)
+
+#### F-C.1: KeyManager
+
+**Files:** `lib/src/crypto/key_manager.dart`, `lib/src/crypto/dart_crypto_key_manager.dart`, `test/crypto/key_manager_test.dart`
+
+- [ ] Test: generateDpopKey returns valid P-256 key pair; exported public JWK has kty=EC, crv=P-256, x, y; generateWrapKey returns 32-byte AES key; encrypt/decrypt round-trips; different encrypt calls produce different ciphertexts (fresh IV).
+- [ ] Implement `KeyManager` interface + `DartCryptographyKeyManager` using `package:cryptography`:
+  - `Ecdsa.p256(Sha256())` for DPoP
+  - `AesGcm.with256bits()` for wrap
+  - `exportJwk(publicKey)` returning Map<String, dynamic>
+- [ ] Commit: `feat(auth-runtime): KeyManager with package:cryptography backend`
+
+#### F-C.2: TokenStore
+
+**Files:** `lib/src/storage/token_store.dart`, `lib/src/storage/secure_token_store.dart`, `test/storage/secure_token_store_test.dart`
+
+Use `flutter_secure_storage`'s `FakeSecureStorage` for tests (official pattern).
+
+- [ ] Test: round-trip save/load with namespace isolation; clear removes; corrupt JSON treated as null.
+- [ ] Implement `TokenStore` interface + `SecureTokenStore`. Values JSON-encoded with base64 for bytes. Keys: `"{namespace}::session"`.
+- [ ] Commit: `feat(auth-runtime): TokenStore with flutter_secure_storage backend`
+
+---
+
+### F-D — State machine & Coordination (2 tasks)
+
+#### F-D.1: State machine
+
+**Files:** `lib/src/runtime/state_machine.dart`, `test/runtime/state_machine_test.dart`
+
+- [ ] Test all transitions from spec §14 (JS `auth-protocol-design` §14).
+- [ ] Implement pure reducer `AuthState reduce(AuthState s, _Input i)`.
+- [ ] Commit: `feat(auth-runtime): pure state-machine reducer`
+
+#### F-D.2: Refresh lock
+
+**Files:** `lib/src/runtime/refresh_lock.dart`, `test/runtime/refresh_lock_test.dart`
+
+- [ ] Test: two concurrent calls to `withLock(fn)` serialize; unhandled throw doesn't permanently hold the lock.
+- [ ] Implement via `package:async` `Lock`.
+- [ ] Commit: `feat(auth-runtime): refresh lock wrapper`
+
+---
+
+### F-E — Worker / Isolate (2 tasks)
+
+#### F-E.1: Message types
+
+**Files:** `lib/src/worker/messages.dart`, `test/worker/messages_test.dart`
+
+- [ ] Define `WorkerRequest` + `WorkerEvent` sealed classes — matches JS `rpc.ts` shape (init, prepareAuth, completeAuth, fetch, upload, getRoles, getClaims, logout, destroy) and events (ready, state, response, error, securityEvent).
+- [ ] Serialization test (toJson/fromJson round-trip).
+- [ ] Commit: `feat(auth-runtime): worker message types`
+
+#### F-E.2: TokenWorker core
+
+**Files:** `lib/src/worker/token_worker.dart`, `test/worker/token_worker_test.dart`
+
+The `TokenWorker` is a pure class (not yet an Isolate) that holds tokens + keys + performs RPC. We wire it to an actual Isolate in F-G.
+
+- [ ] Test: fresh worker starts unauthenticated (no session); `completeAuth(code, verifier, nonce)` exchanges tokens + persists session; `refresh()` rotates; reuse detection wipes; `fetch(path)` adds auth headers; `logout()` clears + broadcasts.
+- [ ] Implement `TokenWorker` taking injected `KeyManager`, `TokenStore`, `Discovery`, `TokenExchange`, `ApiProxy`, `Clock`. Use `_Input` + `reduce(...)` internally. Emit events to an injected sink.
+- [ ] Commit: `feat(auth-runtime): TokenWorker core (init, auth, refresh, fetch, logout, wipe)`
+
+---
+
+### F-F — OAuth Flow (1 task)
+
+#### F-F.1: OAuth via flutter_appauth
+
+**Files:** `lib/src/oauth/oauth_flow.dart`, `test/oauth/oauth_flow_test.dart`
+
+- [ ] Test with mocked `FlutterAppAuth`: success path returns `AuthorizationResponse` with code + verifier; user cancel maps to `oauthUserCanceled`; unavailable browser maps to `oauthBrowserUnavailable`.
+- [ ] Implement `OAuthFlow.authorize(cfg, nonce) → Future<{code, verifier, state}>` calling `FlutterAppAuth.authorize` (code flow w/ PKCE handled by the plugin).
+- [ ] Commit: `feat(auth-runtime): OAuth flow via flutter_appauth`
+
+---
+
+### F-G — Runtime proxy (2 tasks)
+
+#### F-G.1: AuthRuntime interface + in-thread impl
+
+**Files:** `lib/src/auth_runtime.dart`, `lib/src/auth_runtime_impl.dart`, `test/auth_runtime_test.dart`
+
+v0.1.0 uses in-thread (same-Isolate) impl. Public API design keeps migration to a dedicated Isolate invisible to consumers.
+
+- [ ] Test: createAuthRuntime returns runtime; starts in initializing → unauthenticated (no session); `ensureAuthenticated` calls OAuthFlow and completes via TokenWorker; `fetch` returns ApiResponse; `logout` clears; `dispose` cleans up streams.
+- [ ] Implement `AuthRuntimeImpl` wiring TokenWorker + OAuthFlow + KeyManager + TokenStore. Expose streams.
+- [ ] Commit: `feat(auth-runtime): AuthRuntime proxy with in-thread worker (v0.1 baseline)`
+
+#### F-G.2: Isolate-backed variant (scaffolding)
+
+**Files:** `lib/src/worker/token_isolate.dart` + glue in `AuthRuntimeImpl`
+
+v0.1.0 does NOT enable the Isolate by default (to keep surface small), but the code is present. A `createAuthRuntime(config, useIsolate: true)` flag spawns the Isolate.
+
+- [ ] Test: with `useIsolate: true`, a sign-in flow completes end-to-end using a real `Isolate.spawn`. The main thread never receives a raw token (verified by intercepting messages).
+- [ ] Implement `TokenIsolateHandle` that wraps `Isolate.spawn` + `ReceivePort`. Messages serialized via `messages.dart`.
+- [ ] Commit: `feat(auth-runtime): optional Isolate-backed worker for defense-in-depth token isolation`
+
+---
+
+### F-H — Riverpod bindings (1 task)
+
+**Files:** `lib/src/providers/auth_providers.dart`, `lib/src/providers/auth_runtime_scope.dart`, `test/providers/auth_providers_test.dart`
+
+- [ ] Test: overriding `authRuntimeProvider` works; `authStateProvider` streams state transitions; `isAuthenticatedProvider` reflects state; `userClaimsProvider` returns empty when unauthenticated.
+- [ ] Implement per spec §4.2. Also export `AuthRuntimeScope` InheritedWidget for apps not using Riverpod at the root.
+- [ ] Commit: `feat(auth-runtime): Riverpod providers and AuthRuntimeScope`
+
+---
+
+### F-I — Widgets (3 tasks)
+
+#### F-I.1: AuthStateBuilder + AuthGate
+
+**Files:** `lib/src/widgets/auth_state_builder.dart`, `lib/src/widgets/auth_gate.dart`, tests.
+
+- [ ] Widget test: `AuthGate` shows `loadingBuilder` in initializing; `unauthenticatedBuilder` in unauthenticated (defaults to `SignInButton` if null); child in authenticated; `errorBuilder` in error.
+- [ ] Implement both.
+- [ ] Commit: `feat(auth-runtime): AuthStateBuilder + AuthGate widgets`
+
+#### F-I.2: SignInButton / SignOutButton / ProfileAvatar
+
+**Files:** widgets + tests.
+
+- [ ] Widget tests for each.
+- [ ] Implement:
+  - `SignInButton` — ElevatedButton that calls `runtime.ensureAuthenticated()`, disables while pending, shows error via `onError` callback.
+  - `SignOutButton` — ElevatedButton that calls `runtime.logout()`, fires `onSignedOut`.
+  - `ProfileAvatar` — CircleAvatar loading `claims['picture']` if present, else initials from `claims['name']` or `claims['email']`.
+- [ ] Commit: `feat(auth-runtime): SignInButton, SignOutButton, ProfileAvatar widgets`
+
+#### F-I.3: AuthEventListener
+
+**Files:** `lib/src/widgets/auth_event_listener.dart`, test.
+
+- [ ] Test: shows SnackBar on each SecurityEvent via Messenger; configurable builder for custom UI.
+- [ ] Implement.
+- [ ] Commit: `feat(auth-runtime): AuthEventListener for security event UX integration`
+
+---
+
+### F-J — Integration tests + mock IdP (1 task)
+
+**Files:** `test/integration/mock_idp.dart`, `test/integration/sign_in_flow_test.dart`, `test/integration/refresh_flow_test.dart`, `test/integration/logout_flow_test.dart`, `test/integration/reuse_detection_test.dart`, `test/integration/dpop_nonce_test.dart`
+
+- [ ] Implement `MockIdp` with `package:shelf` + `shelf_router`:
+  - `GET /.well-known/openid-configuration` → discovery doc advertising `authorization_endpoint`, `token_endpoint`, `end_session_endpoint`, `revocation_endpoint`, `dpop_signing_alg_values_supported: ["ES256"]`.
+  - `POST /token` → accepts `authorization_code`, `refresh_token` grants. Honors DPoP. Rotates refresh on every call. Tracks used refresh tokens per family; reuse returns `{error: "invalid_grant", error_description: "refresh token reuse detected"}`.
+  - `POST /revocation` → 204.
+  - `POST /end_session` → 204.
+- [ ] Integration tests using a mock `OAuthFlow` that short-circuits the browser round-trip and returns a pre-crafted code. The token exchange then hits the real MockIdp.
+- [ ] Coverage: sign-in, refresh, reuse-detection wipe + security event emitted, logout, DPoP-nonce challenge (MockIdp returns 401 with `DPoP-Nonce` on first call then 200), clock-skew recovery.
+- [ ] Commit: `test(auth-runtime): shelf-based mock IdP and end-to-end integration tests`
+
+---
+
+### F-K — Documentation (2 tasks)
+
+#### F-K.1: README
+
+**Files:** `service-authentication/ui/runtime/README.md`
+
+- [ ] Comprehensive README covering: install, platform setup (iOS `Info.plist`, Android `AndroidManifest.xml`, macOS entitlements), quick start (Riverpod + widgets), full API reference, theming, security posture, migration from ad-hoc token management, troubleshooting.
+- [ ] Commit: `docs(auth-runtime): comprehensive README`
+
+#### F-K.2: Integration guide
+
+**Files:** `docs/auth-runtime-integration.md` (at repo root docs/)
+
+- [ ] Step-by-step guide for adding the package to service-chat and service-fintech. Include exact AuthConfig, deep-link scheme setup, providers override at app root, example of `AuthGate` wrapping the router.
+- [ ] Commit: `docs: auth-runtime integration guide for consuming apps`
+
+---
+
+### F-L — Release (1 task)
+
+#### F-L.1: Final validation + tag
+
+**Files:** `CHANGELOG.md`, `pubspec.yaml`
+
+- [ ] Run full test suite: `flutter test`; ensure ≥ 85% coverage via `flutter test --coverage`.
+- [ ] Run `flutter pub publish --dry-run` to validate publishable state.
+- [ ] Update `CHANGELOG.md` with v0.1.0 notes.
+- [ ] Commit: `chore(auth-runtime): prepare v0.1.0 release`.
+- [ ] Push branch; open PR; do not publish to pub.dev yet (leave for separate release PR with consumer-integration test).
+
+---
+
+## Self-review checklist
+
+1. Spec §4 API is fully implemented (`ensureAuthenticated`, `fetch`, `upload`, `getClaims`, `getRoles`, `logout`, `authStateStream`, `securityEventStream`, `state`, `prefetchDiscovery`, `dispose`, `version`).
+2. Wire protocol is byte-compatible with `@stawi/auth-runtime` (same discovery, same PKCE, same DPoP proof shape, same grant types, same reuse-detection contract, same 401-refresh retry).
+3. No `dart:js`, `dart:js_util`, `package:js`, `dart:html` imports — those are deprecated. Web target deferred to v1.1 using `dart:js_interop` + `package:web`.
+4. Widget tests render without real network.
+5. Integration tests spin up an isolated mock IdP with each test.
+6. Error taxonomy matches JS + mobile-specifics.
+7. State machine transitions match spec §14.
+8. Coverage ≥ 85%.

--- a/docs/superpowers/specs/2026-04-19-auth-runtime-flutter-design.md
+++ b/docs/superpowers/specs/2026-04-19-auth-runtime-flutter-design.md
@@ -1,0 +1,424 @@
+# `antinvestor_auth_runtime` — Flutter auth runtime design
+
+Status: draft
+Date: 2026-04-19
+Package: `antinvestor_auth_runtime` at `service-authentication/ui/runtime/`
+Companion: `@stawi/auth-runtime` (JS, shipped) — shares the wire protocol specified in `stawi/widgets.js/docs/superpowers/specs/2026-04-19-auth-protocol-design.md`.
+
+## 1. Purpose
+
+Ship a Flutter package that gives Antinvestor services (service-chat, service-fintech, future services) a single drop-in dependency that handles OAuth2 + PKCE authentication, token lifecycle, DPoP (when IdP supports it), rotating refresh tokens with reuse detection, and a small widget toolkit (`AuthGate`, `SignInButton`, `SignOutButton`, `ProfileAvatar`) built on Riverpod 3.3.
+
+The package implements the same **wire protocol** as `@stawi/auth-runtime`, so backend changes (e.g., DPoP rollout, reuse-detection) affect both JS and Flutter clients uniformly.
+
+## 2. Non-goals (v1.0)
+
+- **Web target.** Deferred to v1.1. When added, use `dart:js_interop` + `package:web` **only** — never `dart:js`, `dart:js_util`, `package:js`, or `dart:html` (all officially deprecated as of Dart 3.5).
+- **Hardware-backed keys.** v1.0 uses `flutter_secure_storage` for refresh-token-at-rest and holds DPoP signing keys in Isolate RAM. v1.1 moves signing into Secure Enclave (iOS) / StrongBox (Android) via platform channels.
+- **Biometric gating.** `local_auth` integration and per-refresh biometric prompt land in v1.1.
+- **Passkeys / Sign in with Apple / Google Credential Manager.** v1.1+.
+- **Attestation** (Play Integrity / App Attest). v1.2.
+
+## 3. Supported platforms (v1.0)
+
+| Platform | Minimum version | OAuth surface | Storage |
+|---|---|---|---|
+| iOS | 13.0 | ASWebAuthenticationSession via `flutter_appauth` | Keychain (`flutter_secure_storage`) |
+| Android | 8.0 (API 26) | Chrome Custom Tabs via `flutter_appauth` | EncryptedSharedPreferences (`flutter_secure_storage`) |
+| macOS | 11.0 | ASWebAuthenticationSession via `flutter_appauth` | Keychain |
+| Windows | 10 | System browser + loopback | DPAPI |
+| Linux | modern distros | System browser + loopback | libsecret |
+
+Web: v1.1 via `dart:js_interop` wrapping the JS runtime.
+
+## 4. Public API
+
+```dart
+/// Configuration for the auth runtime. Immutable.
+class AuthConfig {
+  final String clientId;
+  final String idpBaseUrl;
+  final String apiBaseUrl;
+  final String redirectScheme;  // e.g. "com.antinvestor.chat"
+  final List<String> scopes;    // default: openid profile email offline_access
+  final String? installationId;
+  final Duration discoveryTimeout;
+  final Duration tokenTimeout;
+  final Duration apiTimeout;
+  final Duration uploadTimeout;
+  const AuthConfig({...});
+}
+
+/// Runtime state.
+enum AuthState { initializing, authenticated, unauthenticated, refreshing, error }
+
+/// Flat error taxonomy — matches JS AuthErrorCode plus mobile-specifics.
+enum AuthErrorCode {
+  invalidConfig,
+  discoveryFailed, networkTimeout, networkError, offline,
+  oauthFailed, oauthUserCanceled, oauthBrowserUnavailable,
+  tokenExchangeFailed, tokenRefreshFailed, tokenExpired,
+  dpopNonceRequired, dpopInvalidProof,
+  refreshReuseDetected,
+  storageCorruption, storageUnavailable,
+  cryptoUnsupported,
+  loggedOutElsewhere, securityWipe,
+  apiUnauthorized, apiForbidden, apiNotFound, apiValidation, apiServerError,
+  deepLinkMismatch, biometricRequired, biometricUnavailable,
+}
+
+/// Non-retryable codes are `invalidConfig`, `refreshReuseDetected`,
+/// `cryptoUnsupported`, `deepLinkMismatch`, `securityWipe`.
+class AuthError extends Error {
+  final AuthErrorCode code;
+  final String message;
+  final Object? cause;
+  final String? traceId;
+  bool get retryable;
+}
+
+/// Security signal callback.
+sealed class SecurityEvent {
+  final DateTime at;
+  const factory SecurityEvent.refreshReuseDetected(DateTime at);
+  const factory SecurityEvent.storageCorruption(DateTime at);
+  const factory SecurityEvent.bindingInvalidated(DateTime at);
+  const factory SecurityEvent.loggedOutElsewhere(DateTime at);
+}
+
+/// API response — opaque body (Uint8List) + status + headers.
+class ApiResponse {
+  final int status;
+  final Map<String, String> headers;
+  final Uint8List body;
+}
+
+abstract class AuthRuntime {
+  /// Begins or resumes an authenticated session. On fresh install this
+  /// opens the OAuth flow; on subsequent launches uses stored refresh token.
+  Future<void> ensureAuthenticated();
+
+  /// Perform an authenticated HTTP call. Tokens never cross back to the caller.
+  Future<ApiResponse> fetch(
+    String path, {
+    String method = 'GET',
+    Map<String, String>? headers,
+    Object? body, // String | List<int> | Stream<List<int>>
+    Duration? timeout,
+  });
+
+  /// Multipart upload of a file.
+  Future<ApiResponse> upload(
+    String path, {
+    required String fieldName,
+    required String filename,
+    required String contentType,
+    required Stream<List<int>> bytes,
+    required int length,
+    Duration? timeout,
+  });
+
+  /// Claims decoded from the current access token. Caller never gets the token itself.
+  Future<Map<String, dynamic>> getClaims();
+
+  /// Roles from claims (Hydra emits `realm_access.roles` or a top-level `roles` array).
+  Future<List<String>> getRoles();
+
+  /// Clears local state + best-effort server logout (end_session + revocation).
+  Future<void> logout();
+
+  /// Stream of auth state transitions. Never errors; uses [error] state for fatal init.
+  Stream<AuthState> get authStateStream;
+
+  /// Stream of security events (wipe, reuse detection). Caller should surface prominently.
+  Stream<SecurityEvent> get securityEventStream;
+
+  /// Synchronous state snapshot.
+  AuthState get state;
+
+  /// Warm the OIDC discovery cache. Call on app start for faster first sign-in.
+  Future<void> prefetchDiscovery();
+
+  /// Tear down isolates, streams, secure storage handles.
+  Future<void> dispose();
+
+  /// Injected at build time.
+  String get version;
+}
+
+/// Factory. Never returns a singleton — one runtime per AuthConfig tuple.
+AuthRuntime createAuthRuntime(AuthConfig config);
+```
+
+### 4.1 Widget surface
+
+```dart
+/// InheritedWidget that exposes the runtime to descendants.
+class AuthRuntimeScope extends InheritedWidget {
+  final AuthRuntime runtime;
+  static AuthRuntime of(BuildContext context) => ...;
+}
+
+/// Rebuilds child when AuthState changes.
+class AuthStateBuilder extends ConsumerWidget {
+  final Widget Function(BuildContext, AuthState) builder;
+}
+
+/// Renders child only when authenticated. Otherwise renders sign-in affordance.
+class AuthGate extends ConsumerWidget {
+  final Widget child;
+  final WidgetBuilder? unauthenticatedBuilder;
+  final WidgetBuilder? loadingBuilder;
+  final Widget Function(BuildContext, AuthError)? errorBuilder;
+}
+
+/// Material button that triggers ensureAuthenticated().
+class SignInButton extends ConsumerStatefulWidget {
+  final String? label;
+  final ButtonStyle? style;
+  final VoidCallback? onAuthenticated;
+  final void Function(AuthError)? onError;
+}
+
+class SignOutButton extends ConsumerStatefulWidget {
+  final String? label;
+  final VoidCallback? onSignedOut;
+}
+
+/// Renders the user's avatar (profile picture if claim `picture` exists, else initials).
+class ProfileAvatar extends ConsumerWidget {
+  final double radius;
+}
+
+/// Listens for SecurityEvents and shows SnackBar/Dialog.
+class AuthEventListener extends ConsumerWidget { ... }
+```
+
+### 4.2 Riverpod providers
+
+```dart
+final authRuntimeProvider = Provider<AuthRuntime>((ref) {
+  throw StateError('Override authRuntimeProvider at app root');
+});
+
+final authStateProvider = StreamProvider<AuthState>((ref) =>
+  ref.watch(authRuntimeProvider).authStateStream,
+);
+
+final isAuthenticatedProvider = Provider<bool>((ref) {
+  final s = ref.watch(authStateProvider).value;
+  return s == AuthState.authenticated;
+});
+
+final userClaimsProvider = FutureProvider<Map<String, dynamic>>((ref) async {
+  if (ref.watch(authStateProvider).value != AuthState.authenticated) return {};
+  return ref.watch(authRuntimeProvider).getClaims();
+});
+
+final rolesProvider = FutureProvider<List<String>>((ref) async {
+  if (ref.watch(authStateProvider).value != AuthState.authenticated) return [];
+  return ref.watch(authRuntimeProvider).getRoles();
+});
+
+final securityEventsProvider = StreamProvider<SecurityEvent>((ref) =>
+  ref.watch(authRuntimeProvider).securityEventStream,
+);
+```
+
+## 5. Architecture
+
+```
+┌──────────── Main Isolate (UI) ────────────┐
+│                                            │
+│  AuthRuntimeImpl (proxy)                   │
+│    • _sendPort → TokenIsolate              │
+│    • authStateController (Stream)          │
+│    • securityEventController (Stream)      │
+│    • Riverpod providers                    │
+│    • Material/Cupertino widgets            │
+│                                            │
+│  OAuth flow (main isolate ONLY):           │
+│    flutter_appauth.authorizeAndExchange    │
+│    → returns code + verifier               │
+│    → forward to TokenIsolate                │
+└──────────────────┬─────────────────────────┘
+                   │ SendPort / ReceivePort
+                   │ (structured messages)
+┌──────────────────▼─────────────────────────┐
+│  TokenIsolate                              │
+│    In RAM only:                            │
+│      accessToken (String)                  │
+│      refreshToken (String)                 │
+│      dpopPrivateKey (SimpleKeyPair)        │
+│      wrapKey (SecretKey — AES-GCM-256)     │
+│      clockOffset                           │
+│    Persisted via flutter_secure_storage:   │
+│      wrapped_refresh_token (iv + ct + tag) │
+│      dpop_key_bytes (encrypted via wrapKey)│
+│      wrap_key_bytes (encrypted via platform│
+│                      storage key)          │
+│      last_id_token                          │
+│    Performs:                                │
+│      OAuth token exchange (+DPoP)           │
+│      Refresh (rotating, reuse-detect wipe)  │
+│      Authenticated fetch/upload             │
+│      Logout (end_session + revocation)      │
+│      Wipe on security event                 │
+└────────────────────────────────────────────┘
+```
+
+**Why an Isolate instead of just the main thread?**
+
+On Dart/Flutter, an Isolate has its own heap — no shared memory. Tokens held in the Token Isolate are unreachable from the UI Isolate except via explicit message passing. This is not hardware isolation (a rogue native library could still walk the process memory), but it does:
+
+- Prevent accidental leakage via logging/telemetry code in the UI Isolate.
+- Ensure `runtime.fetch(...)` returns only response bytes — the caller literally cannot receive the token.
+- Give us a migration path: if the Isolate is later replaced with an FFI module using hardware-backed keys, the public API doesn't change.
+
+Isolate overhead is ~10–50 ms spawn cost; we lazy-spawn on first `ensureAuthenticated()` / `fetch()`.
+
+## 6. Protocol implementation
+
+Identical wire contract to `@stawi/auth-runtime`:
+
+1. **OIDC discovery** cached per `idpBaseUrl`; 10 s timeout; does not cache failures.
+2. **DPoP** adaptive: feature-detect `dpop_signing_alg_values_supported` containing `ES256`; fall back to bearer otherwise.
+3. **PKCE S256** from 64 random bytes base64url.
+4. **Token exchange** with `DPoP` header when in DPoP mode; honors `DPoP-Nonce` challenge with single retry; corrects clock skew via `Date` response header.
+5. **Refresh token rotation + reuse detection** — on `invalid_grant` with "reuse" in error_description, wipe everything + fire `SecurityEvent.refreshReuseDetected`.
+6. **401-refresh-retry** — API responses with 401 trigger one forced refresh + one retry.
+7. **Logout** — best-effort `end_session_endpoint` with `id_token_hint`, then `revocation_endpoint` for refresh token, then local wipe. `onLogout` stream event fires unconditionally.
+
+## 7. Storage & crypto
+
+### 7.1 TokenStore
+
+```dart
+abstract class TokenStore {
+  Future<StoredSession?> load(String namespace);
+  Future<void> save(String namespace, StoredSession session);
+  Future<void> clear(String namespace);
+}
+
+class StoredSession {
+  final WrappedBlob wrappedRefreshToken;  // {iv, ciphertext} — AES-GCM
+  final Uint8List dpopKeyEncrypted;        // DPoP private key bytes encrypted with wrap key
+  final Uint8List wrapKeyEncrypted;        // wrap key encrypted with platform-storage key
+  final String? lastIdToken;
+  final DateTime updatedAt;
+}
+```
+
+Default impl: `SecureTokenStore` using `flutter_secure_storage` under a namespace-prefixed key. All Uint8List fields are base64-encoded for transport through `flutter_secure_storage` (which stores strings).
+
+### 7.2 KeyManager
+
+```dart
+abstract class KeyManager {
+  Future<SimpleKeyPair> generateDpopKey();     // ECDSA P-256
+  Future<SecretKey> generateWrapKey();          // AES-GCM 256
+  Future<Uint8List> signDpopProof(
+    SimpleKeyPair key,
+    Map<String, dynamic> header,
+    Map<String, dynamic> payload,
+  );
+  Future<Uint8List> encrypt(SecretKey key, Uint8List plaintext);
+  Future<Uint8List> decrypt(SecretKey key, Uint8List ciphertext);
+}
+```
+
+Default impl: `DartCryptographyKeyManager` backed by `package:cryptography`. Keys held in Isolate RAM; private material encrypted on disk via the wrap key; wrap key itself encrypted by a platform-storage-derived key (initialized once per install).
+
+v1.1 upgrade path: `SecureEnclaveKeyManager` for iOS, `AndroidKeystoreKeyManager` for Android, both via method channels. The `KeyManager` interface does not change.
+
+## 8. State machine (pure)
+
+```dart
+enum _Input {
+  initDone(hasTokens: bool),
+  signInStart(),
+  signInDone(),
+  signInFail(error: AuthError),
+  refreshStart(),
+  refreshDone(),
+  refreshFail(error: AuthError, wipe: bool),
+  logout(),
+  securityWipe(reason: SecurityEventType),
+}
+
+AuthState reduce(AuthState state, _Input input) { ... }
+```
+
+Identical transitions to JS spec §14. Unit-testable in pure Dart.
+
+## 9. Dependencies
+
+```yaml
+dependencies:
+  flutter: {sdk: flutter}
+  flutter_riverpod: ^3.3.1        # matches existing packages
+  flutter_secure_storage: ^9.2.2  # Keychain/Keystore/libsecret/DPAPI
+  flutter_appauth: ^8.0.0+1        # OAuth via ASWebAuth / Chrome Custom Tabs
+  cryptography: ^2.7.0             # ECDSA, AES-GCM, SHA-256
+  http: ^1.2.2                      # HTTP client (also available via Isolate)
+  crypto: ^3.0.6                    # base64url, PKCE
+  async: ^2.11.0                    # Lock
+  equatable: ^2.0.7                 # value equality for models
+  uuid: ^4.5.1                      # idempotency keys
+  meta: ^1.15.0
+  collection: ^1.18.0
+
+dev_dependencies:
+  flutter_test: {sdk: flutter}
+  flutter_lints: ^6.0.0
+  mocktail: ^1.0.4
+  shelf: ^1.4.1                     # in-process mock IdP
+  shelf_router: ^1.1.4
+```
+
+## 10. Testing
+
+- **Unit:** each protocol module (discovery, pkce, dpop, jwt, state_machine, token_exchange, api_proxy, key_manager, token_store) has `test/` file with Dart-native tests. Isolate code runs in the test isolate directly (no Isolate spawn) via a `TokenIsolateHandle` that exposes both in-isolate and in-thread modes.
+- **Widget:** every widget has a test that renders it with mocked runtime + providers.
+- **Integration:** `test/integration/` spins up `shelf`-based mock IdP that implements OIDC discovery, `/token`, `/revocation`, `/end_session`. Tests cover: full sign-in, refresh, reuse-detection wipe, 401-refresh retry, logout, DPoP nonce challenge, clock skew.
+- **Coverage target:** ≥ 85% lines, 100% of state machine.
+
+Flutter-specific test guidance: follows `superpowers:testing-flutter` — no `Future.delayed`-based flake; use `FakeAsync` / `pumpEventQueue`; real `flutter_secure_storage` is mocked via `MockFlutterSecureStorage` (official pattern).
+
+## 11. Release plan
+
+- **v0.1.0** — first preview. Internal consumers (service-chat, service-fintech) integrate in a feature branch each.
+- **v0.2.0** — feedback cycle; API refinements based on integrator pain points.
+- **v1.0.0** — stable contract. Semantic versioning thereafter.
+- **v1.1.0** — Web target via `dart:js_interop` + `package:web` (deferred).
+
+Versioning: pub.dev publishable; pattern matches `antinvestor_ui_{audit,auth,tenancy}`.
+
+## 12. Migration guide for consumers
+
+Each consuming app wires:
+
+1. Add dependency: `antinvestor_auth_runtime: ^0.1.0`.
+2. Configure `AuthConfig` with clientId, redirectScheme, installationId.
+3. Register deep-link scheme (iOS `Info.plist`, Android `AndroidManifest.xml`, linked to `flutter_appauth` requirements).
+4. Wrap root with `AuthRuntimeScope(runtime: createAuthRuntime(config), child: MyApp(...))` or override `authRuntimeProvider`.
+5. Replace ad-hoc token management with `runtime.fetch(...)` for API calls.
+6. Optionally use `AuthGate`, `SignInButton`, `ProfileAvatar` widgets.
+
+Step-by-step doc at `docs/auth-runtime-integration.md` (deliverable of plan Group F-K).
+
+## 13. Open questions
+
+- Should the package own `GoRouter` redirect logic for auth-gated routes, or leave that to consumers? **Decision (v1.0): leave to consumers**; provide example snippet in README.
+- Should `getRoles()` accept a custom extractor for non-standard IdP claim shapes? **Decision (v1.0): no — hardcode `roles` + `realm_access.roles` as in JS**; extend if needed.
+- Should the runtime emit OpenTelemetry spans? **Decision (v1.0): no**; expose `onMetric` callback for app-level RUM integration in v1.1.
+
+## 14. Future work (documented, not implemented)
+
+- **Hardware-backed keys** via iOS Secure Enclave + Android StrongBox / TEE.
+- **Biometric gating** (`local_auth`) per-refresh or per-sensitive-action.
+- **Passkeys** via `webauthn` Dart package.
+- **Sign in with Apple** + **Google Credential Manager** as silent sign-in fast paths.
+- **Attestation** via Play Integrity API / App Attest for device trust.
+- **Cross-device continuation** (QR-code sign-in).
+- **Web target** via `dart:js_interop` + `package:web` wrapping `@stawi/auth-runtime`.

--- a/ui/runtime/.gitignore
+++ b/ui/runtime/.gitignore
@@ -4,3 +4,4 @@
 .flutter-plugins-dependencies
 build/
 pubspec.lock
+coverage/

--- a/ui/runtime/.gitignore
+++ b/ui/runtime/.gitignore
@@ -1,0 +1,6 @@
+# Flutter/Dart build artifacts (mirrors repo-root ignores for locality).
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+build/
+pubspec.lock

--- a/ui/runtime/CHANGELOG.md
+++ b/ui/runtime/CHANGELOG.md
@@ -3,7 +3,32 @@
 All notable changes to `antinvestor_auth_runtime` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 0.1.0 — 2026-04-19
+
+Initial public release.
 
 ### Added
-- Initial scaffolding: pubspec, analysis options, LICENSE, barrel file.
+- `AuthRuntime` public contract and `createAuthRuntime` factory.
+- OAuth2 + PKCE sign-in via `flutter_appauth`, wrapped in a testable
+  `OAuthFlow` abstraction.
+- OIDC discovery with in-memory caching, timeout, and in-flight
+  deduplication.
+- Adaptive DPoP: ES256 proofs, `DPoP-Nonce` challenge retry, clock-skew
+  compensation via `Date` header.
+- Token exchange with rotating refresh tokens + reuse detection.
+- Authenticated `fetch` + `upload` with automatic 401-refresh retry.
+- `TokenWorker` with secure-storage-backed session persistence:
+  root key → wrap key → DPoP private key + refresh token encryption
+  chain over AES-GCM-256.
+- Optional Isolate-backed worker (`createAuthRuntime(useIsolate: true)`)
+  — scaffolding in v0.1; data-plane methods land in a follow-up.
+- Riverpod providers: `authRuntimeProvider`, `authStateProvider`,
+  `isAuthenticatedProvider`, `userClaimsProvider`, `rolesProvider`,
+  `securityEventsProvider`.
+- `AuthRuntimeScope` for non-Riverpod consumers.
+- Material widgets: `AuthGate`, `AuthStateBuilder`, `AuthEventListener`,
+  `SignInButton`, `SignOutButton`, `ProfileAvatar`.
+- `SecurityEvent` hierarchy surfaces refresh reuse, storage corruption,
+  and related signals.
+- End-to-end integration tests against a `shelf`-backed mock IdP.
+- Comprehensive README and integration guide for consuming apps.

--- a/ui/runtime/CHANGELOG.md
+++ b/ui/runtime/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to `antinvestor_auth_runtime` are documented here.
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial scaffolding: pubspec, analysis options, LICENSE, barrel file.

--- a/ui/runtime/LICENSE
+++ b/ui/runtime/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2023-2026 Ant Investor Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/ui/runtime/README.md
+++ b/ui/runtime/README.md
@@ -1,0 +1,13 @@
+# antinvestor_auth_runtime
+
+Auth runtime for Antinvestor Flutter apps: OAuth2 + PKCE, adaptive DPoP,
+rotating refresh tokens with reuse detection, Isolate-isolated tokens,
+`flutter_secure_storage`-backed persistence, Riverpod providers, and a
+small Material widget toolkit.
+
+Status: **pre-release (0.1.0)** — comprehensive documentation lands with
+Group F-K of the implementation plan.
+
+See `docs/superpowers/specs/2026-04-19-auth-runtime-flutter-design.md` for
+the design spec and `docs/superpowers/plans/2026-04-19-auth-runtime-flutter.md`
+for the implementation plan.

--- a/ui/runtime/README.md
+++ b/ui/runtime/README.md
@@ -1,13 +1,218 @@
 # antinvestor_auth_runtime
 
-Auth runtime for Antinvestor Flutter apps: OAuth2 + PKCE, adaptive DPoP,
-rotating refresh tokens with reuse detection, Isolate-isolated tokens,
-`flutter_secure_storage`-backed persistence, Riverpod providers, and a
-small Material widget toolkit.
+Auth runtime for Antinvestor Flutter apps. OAuth2 + PKCE, adaptive DPoP,
+rotating refresh tokens with reuse detection, optional Isolate-isolated
+tokens, hardware-backed secure storage, Riverpod providers, and a small
+Material widget toolkit.
 
-Status: **pre-release (0.1.0)** — comprehensive documentation lands with
-Group F-K of the implementation plan.
+[![Flutter 3.24+](https://img.shields.io/badge/flutter-3.24%2B-blue.svg)](https://flutter.dev)
+[![Dart 3.11+](https://img.shields.io/badge/dart-3.11%2B-blue.svg)](https://dart.dev)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
 
-See `docs/superpowers/specs/2026-04-19-auth-runtime-flutter-design.md` for
-the design spec and `docs/superpowers/plans/2026-04-19-auth-runtime-flutter.md`
-for the implementation plan.
+---
+
+## Install
+
+```shell
+flutter pub add antinvestor_auth_runtime
+```
+
+## Platform setup
+
+The runtime drives the system browser for OAuth (via `flutter_appauth`)
+and then receives the callback on a custom scheme. Each platform needs a
+one-time declaration of that scheme.
+
+Assume your app's redirect scheme is `com.antinvestor.myapp`; the runtime
+will derive `com.antinvestor.myapp://callback` as the full redirect URI.
+
+### iOS — `ios/Runner/Info.plist`
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLName</key>
+    <string>com.antinvestor.myapp.auth</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>com.antinvestor.myapp</string>
+    </array>
+  </dict>
+</array>
+```
+
+### Android — `android/app/src/main/AndroidManifest.xml`
+
+Inside `<application>`:
+
+```xml
+<activity
+    android:name="net.openid.appauth.RedirectUriReceiverActivity"
+    android:exported="true"
+    tools:node="replace">
+  <intent-filter>
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+    <data android:scheme="com.antinvestor.myapp" />
+  </intent-filter>
+</activity>
+```
+
+### macOS / Windows / Linux
+
+No per-platform manifest entries are required: `flutter_appauth` uses the
+system browser directly and receives the callback over an embedded
+listener. The scheme only has to match `AuthConfig.redirectScheme`.
+
+## Quick start (Riverpod — preferred)
+
+```dart
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+void main() {
+  final runtime = createAuthRuntime(const AuthConfig(
+    clientId: 'antinvestor-myapp-mobile',
+    idpBaseUrl: 'https://auth.antinvestor.com',
+    apiBaseUrl: 'https://api.antinvestor.com',
+    redirectScheme: 'com.antinvestor.myapp',
+  ));
+
+  runApp(ProviderScope(
+    overrides: [
+      authRuntimeProvider.overrideWithValue(runtime),
+    ],
+    child: MaterialApp(
+      home: AuthGate(child: HomePage()),
+    ),
+  ));
+}
+```
+
+## Quick start (non-Riverpod)
+
+```dart
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  final runtime = createAuthRuntime(const AuthConfig(
+    clientId: 'antinvestor-myapp-mobile',
+    idpBaseUrl: 'https://auth.antinvestor.com',
+    apiBaseUrl: 'https://api.antinvestor.com',
+    redirectScheme: 'com.antinvestor.myapp',
+  ));
+
+  runApp(AuthRuntimeScope(
+    runtime: runtime,
+    child: MaterialApp(home: HomePage()),
+  ));
+}
+```
+
+`AuthRuntimeScope` exposes the runtime via `AuthRuntimeScope.of(context)`
+for widgets that need access without Riverpod.
+
+## Making authenticated calls
+
+The access token never leaves the runtime: callers receive only the
+response bytes + status + headers.
+
+```dart
+final runtime = ref.read(authRuntimeProvider);
+
+final response = await runtime.fetch('/v1/me');
+if (response.status == 200) {
+  final me = jsonDecode(utf8.decode(response.body));
+}
+```
+
+Supported methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`.
+`body` may be a `String`, `List<int>`, or `Uint8List`. For file uploads
+use `runtime.upload(path, fieldName:, filename:, contentType:, bytes:,
+length:)` — multipart form-data with automatic retry on 401.
+
+## Widget reference
+
+| Widget | Purpose |
+|--------|---------|
+| `AuthGate` | Wraps a subtree; shows a sign-in placeholder when unauthenticated, the child otherwise. |
+| `AuthStateBuilder` | Imperative builder variant — supply builders per state. |
+| `AuthEventListener` | Subscribes to `securityEventStream` and surfaces events via snackbars or a callback. |
+| `SignInButton` | Material button calling `ensureAuthenticated`. |
+| `SignOutButton` | Material button calling `logout`. |
+| `ProfileAvatar` | Circle avatar rendered from the ID token's `picture` claim with a letter fallback. |
+
+All widgets honour the Material `ThemeData` of the surrounding app.
+
+## Provider reference
+
+| Provider | Type | Behaviour |
+|----------|------|-----------|
+| `authRuntimeProvider` | `Provider<AuthRuntime>` | The runtime itself. Override in `ProviderScope`. |
+| `authStateProvider` | `StreamProvider<AuthState>` | Reactive `AuthState` transitions. |
+| `isAuthenticatedProvider` | `Provider<bool>` | `true` when `state == authenticated`. |
+| `userClaimsProvider` | `FutureProvider<UserClaims>` | ID token claims, wrapped for convenient access. |
+| `rolesProvider` | `FutureProvider<List<String>>` | Roles extracted from the access token. |
+| `securityEventsProvider` | `StreamProvider<SecurityEvent>` | Security signals (`refreshReuseDetected`, `storageCorruption`, …). |
+
+## Security posture
+
+| Control | Implementation |
+|---------|----------------|
+| Isolate isolation | Opt-in via `createAuthRuntime(..., useIsolate: true)` for defense-in-depth token separation. The default in-thread runtime is fully featured. |
+| Hardware-backed secure storage | `flutter_secure_storage` — iOS Keychain, Android Keystore / EncryptedSharedPreferences, macOS Keychain, Linux libsecret. |
+| DPoP binding | Adaptive: enabled automatically when the IdP advertises `dpop_signing_alg_values_supported`. ES256 proofs with nonce + clock-skew retry. |
+| Refresh rotation | Every refresh returns a new RT; the old one is discarded. |
+| Reuse detection | A rejected `invalid_grant` response triggers a security wipe + `SecurityEvent.refreshReuseDetected`. |
+| Root-key + wrap-key chain | Wrap key (AES-GCM 256) encrypts the DPoP private key and refresh token; the wrap key itself is encrypted under a keychain-resident root key. |
+| Logout | Best-effort server-side revocation + `end_session`; local wipe always runs even on network failure. |
+| Storage corruption handling | Unreadable on-disk state triggers a wipe + `SecurityEvent.storageCorruption` rather than a crash. |
+
+## Troubleshooting
+
+**OAuth completes in the browser but the app never receives the code.**
+The `redirectScheme` in `AuthConfig` must match the platform-manifest
+declaration exactly. The runtime derives `{scheme}://callback` — double
+check that.
+
+**Refresh fails on every run with `tokenRefreshFailed`.**
+`offline_access` must be in the requested scopes (it is by default).
+Without it the IdP will not issue a refresh token.
+
+**`AuthGate` shows the sign-in placeholder after a cold start when the
+user was previously signed in.**
+This is expected during the first microtask while the runtime reloads
+storage. The `StreamProvider` emits the restored state on the next tick.
+If it stays on the placeholder, inspect `securityEventsProvider` for a
+`StorageCorruption` event — the session may have been wiped.
+
+**Clock-skew retry loops forever.**
+Only one clock-skew retry is attempted per request. Persistent failure
+indicates a system clock far enough off that the IdP's `Date` header is
+itself wrong; fix device time.
+
+## Compatibility matrix
+
+| Platform | Minimum |
+|----------|---------|
+| Flutter | 3.24 |
+| Dart SDK | 3.11 |
+| iOS | 13 |
+| Android | 8 (API 26) |
+| macOS | 11 |
+| Windows | 10 |
+| Linux | glibc-based modern distros (Ubuntu 22.04+) |
+
+## Versioning
+
+This package follows [Semantic Versioning](https://semver.org). Breaking
+changes bump the major version. Within a major, we preserve the public
+API surface exported from `antinvestor_auth_runtime.dart`.
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/ui/runtime/analysis_options.yaml
+++ b/ui/runtime/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: package:flutter_lints/flutter.yaml
+linter:
+  rules:
+    prefer_const_constructors: true
+    prefer_final_locals: true
+    avoid_print: true
+    public_member_api_docs: false

--- a/ui/runtime/lib/antinvestor_auth_runtime.dart
+++ b/ui/runtime/lib/antinvestor_auth_runtime.dart
@@ -30,6 +30,7 @@ export 'src/providers/auth_providers.dart'
         securityEventsProvider,
         userClaimsProvider;
 export 'src/providers/auth_runtime_scope.dart' show AuthRuntimeScope;
+export 'src/widgets/auth_event_listener.dart' show AuthEventListener;
 export 'src/widgets/auth_gate.dart' show AuthGate;
 export 'src/widgets/auth_state_builder.dart' show AuthStateBuilder;
 export 'src/widgets/profile_avatar.dart' show ProfileAvatar;

--- a/ui/runtime/lib/antinvestor_auth_runtime.dart
+++ b/ui/runtime/lib/antinvestor_auth_runtime.dart
@@ -21,3 +21,12 @@ export 'src/models/security_event.dart'
         StorageCorruption;
 export 'src/models/token_set.dart' show TokenSet, TokenType;
 export 'src/models/user_claims.dart' show UserClaims;
+export 'src/providers/auth_providers.dart'
+    show
+        authRuntimeProvider,
+        authStateProvider,
+        isAuthenticatedProvider,
+        rolesProvider,
+        securityEventsProvider,
+        userClaimsProvider;
+export 'src/providers/auth_runtime_scope.dart' show AuthRuntimeScope;

--- a/ui/runtime/lib/antinvestor_auth_runtime.dart
+++ b/ui/runtime/lib/antinvestor_auth_runtime.dart
@@ -1,0 +1,10 @@
+/// Auth runtime for Antinvestor Flutter apps.
+///
+/// Implements the Stawi auth protocol (OAuth2 + PKCE, adaptive DPoP,
+/// rotating refresh tokens with reuse detection) with Isolate-isolated
+/// tokens, hardware-backed storage, Riverpod providers and Material
+/// widgets.
+///
+/// Public surface is assembled in later task groups; this file is the
+/// package barrel.
+library;

--- a/ui/runtime/lib/antinvestor_auth_runtime.dart
+++ b/ui/runtime/lib/antinvestor_auth_runtime.dart
@@ -32,3 +32,6 @@ export 'src/providers/auth_providers.dart'
 export 'src/providers/auth_runtime_scope.dart' show AuthRuntimeScope;
 export 'src/widgets/auth_gate.dart' show AuthGate;
 export 'src/widgets/auth_state_builder.dart' show AuthStateBuilder;
+export 'src/widgets/profile_avatar.dart' show ProfileAvatar;
+export 'src/widgets/sign_in_button.dart' show SignInButton;
+export 'src/widgets/sign_out_button.dart' show SignOutButton;

--- a/ui/runtime/lib/antinvestor_auth_runtime.dart
+++ b/ui/runtime/lib/antinvestor_auth_runtime.dart
@@ -1,10 +1,23 @@
 /// Auth runtime for Antinvestor Flutter apps.
 ///
 /// Implements the Stawi auth protocol (OAuth2 + PKCE, adaptive DPoP,
-/// rotating refresh tokens with reuse detection) with Isolate-isolated
+/// rotating refresh tokens with reuse detection) with isolate-isolated
 /// tokens, hardware-backed storage, Riverpod providers and Material
 /// widgets.
-///
-/// Public surface is assembled in later task groups; this file is the
-/// package barrel.
 library;
+
+export 'src/auth_runtime.dart' show AuthRuntime, authRuntimeVersion;
+export 'src/config/auth_config.dart' show AuthConfig;
+export 'src/errors/auth_error.dart' show AuthError, AuthErrorCode;
+export 'src/factory.dart' show createAuthRuntime;
+export 'src/models/api_response.dart' show ApiResponse;
+export 'src/models/auth_state.dart' show AuthState;
+export 'src/models/security_event.dart'
+    show
+        BindingInvalidated,
+        LoggedOutElsewhere,
+        RefreshReuseDetected,
+        SecurityEvent,
+        StorageCorruption;
+export 'src/models/token_set.dart' show TokenSet, TokenType;
+export 'src/models/user_claims.dart' show UserClaims;

--- a/ui/runtime/lib/antinvestor_auth_runtime.dart
+++ b/ui/runtime/lib/antinvestor_auth_runtime.dart
@@ -30,3 +30,5 @@ export 'src/providers/auth_providers.dart'
         securityEventsProvider,
         userClaimsProvider;
 export 'src/providers/auth_runtime_scope.dart' show AuthRuntimeScope;
+export 'src/widgets/auth_gate.dart' show AuthGate;
+export 'src/widgets/auth_state_builder.dart' show AuthStateBuilder;

--- a/ui/runtime/lib/src/auth_runtime.dart
+++ b/ui/runtime/lib/src/auth_runtime.dart
@@ -1,0 +1,87 @@
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+
+/// Public, isolate-agnostic contract consumed by Flutter apps.
+///
+/// Both the in-thread ([AuthRuntimeImpl]) and Isolate-backed variants
+/// implement this interface; consumers should never depend on a concrete
+/// type so they can swap between the two via `createAuthRuntime`.
+abstract class AuthRuntime {
+  /// Begins or resumes an authenticated session.
+  ///
+  /// On fresh installs this opens the OAuth flow via `flutter_appauth`;
+  /// on subsequent launches a stored refresh token short-circuits straight
+  /// to the authenticated state without any browser round-trip.
+  ///
+  /// Completes when the runtime transitions to [AuthState.authenticated].
+  /// Throws [AuthError] on any fatal failure.
+  Future<void> ensureAuthenticated();
+
+  /// Performs an authenticated HTTP call.
+  ///
+  /// The access token never crosses back to the caller — only status,
+  /// headers, and opaque bytes in [ApiResponse]. [body] may be a `String`,
+  /// a `List<int>`, or a `Stream<List<int>>` (non-multipart — use [upload]
+  /// for multipart).
+  Future<ApiResponse> fetch(
+    String path, {
+    String method = 'GET',
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  });
+
+  /// Multipart upload of a single file field.
+  Future<ApiResponse> upload(
+    String path, {
+    required String fieldName,
+    required String filename,
+    required String contentType,
+    required Stream<List<int>> bytes,
+    required int length,
+    Map<String, String>? headers,
+    Duration? timeout,
+  });
+
+  /// Claims decoded from the current ID token. Returns `{}` when no
+  /// session is active or no ID token was issued.
+  Future<Map<String, dynamic>> getClaims();
+
+  /// Roles extracted from the current access token. Returns `[]` when
+  /// unauthenticated. Supports both top-level `roles` and
+  /// `realm_access.roles` (Hydra / Keycloak compatibility).
+  Future<List<String>> getRoles();
+
+  /// Clears local state and best-effort server logout (`end_session` +
+  /// `revocation`). Network failures do not block the local wipe.
+  Future<void> logout();
+
+  /// Stream of auth state transitions. Never errors — see
+  /// [securityEventStream] for fatal signals instead.
+  Stream<AuthState> get authStateStream;
+
+  /// Stream of security-relevant events (refresh reuse detected, storage
+  /// corruption, logged-out-elsewhere, …). Callers should surface these
+  /// prominently — see `AuthEventListener` for a ready-made widget.
+  Stream<SecurityEvent> get securityEventStream;
+
+  /// Synchronous snapshot of [authStateStream]'s latest value.
+  AuthState get state;
+
+  /// Warms the OIDC discovery cache. Optional — but reduces perceived
+  /// latency on the first sign-in when called from app startup.
+  Future<void> prefetchDiscovery();
+
+  /// Build-time version string. Surfaced for telemetry + support flows.
+  String get version;
+
+  /// Tears down isolates, stream controllers, and secure-storage handles.
+  /// Idempotent — safe to call multiple times.
+  Future<void> dispose();
+}
+
+/// Version of the runtime. Callers include this in telemetry / bug
+/// reports. Kept as a bare constant for now; wired through
+/// `--dart-define=AUTH_RUNTIME_VERSION=...` in a follow-up task.
+const String authRuntimeVersion = '0.1.0';

--- a/ui/runtime/lib/src/auth_runtime_impl.dart
+++ b/ui/runtime/lib/src/auth_runtime_impl.dart
@@ -1,0 +1,181 @@
+import 'dart:async';
+
+import 'package:antinvestor_auth_runtime/src/auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/oauth/oauth_flow.dart';
+import 'package:antinvestor_auth_runtime/src/worker/token_worker.dart';
+
+/// Main-thread [AuthRuntime] — the default `createAuthRuntime` shape.
+///
+/// Holds a single [TokenWorker] in-process and an [OAuthFlow] that
+/// drives the browser leg via `flutter_appauth`. A later task wraps the
+/// same public API around an Isolate-backed worker for defense-in-depth
+/// token isolation; both implementations share the same public
+/// [AuthRuntime] contract so consumers can switch via
+/// `createAuthRuntime(..., useIsolate: true)` without touching their
+/// widget tree.
+///
+/// Lifecycle:
+///
+/// 1. Construction calls [TokenWorker.init] eagerly so the `authStateStream`
+///    emits a first transition immediately.
+/// 2. [ensureAuthenticated] is a no-op when already authenticated, drives
+///    OAuth otherwise.
+/// 3. [dispose] closes streams and releases the worker. Safe to call
+///    multiple times.
+class AuthRuntimeImpl implements AuthRuntime {
+  AuthRuntimeImpl({
+    required this.config,
+    required this.worker,
+    required this.oauthFlow,
+  });
+
+  final ResolvedConfig config;
+  final TokenWorker worker;
+  final OAuthFlow oauthFlow;
+
+  bool _disposed = false;
+  Future<void>? _initFuture;
+  Future<void>? _inflightEnsureAuthenticated;
+
+  /// Kicks off the worker's initial reload. Idempotent: every caller
+  /// awaits the same future so first-use races settle correctly.
+  Future<void> init() => _initFuture ??= worker.init();
+
+  @override
+  Future<void> ensureAuthenticated() async {
+    _ensureAlive();
+    await init();
+    if (worker.state == AuthState.authenticated) return;
+
+    // Collapse concurrent callers onto a single OAuth flow so two
+    // simultaneous "ensure" calls don't open two browsers.
+    final inflight = _inflightEnsureAuthenticated;
+    if (inflight != null) return inflight;
+
+    final future = _startOAuthFlow();
+    _inflightEnsureAuthenticated = future;
+    try {
+      await future;
+    } finally {
+      _inflightEnsureAuthenticated = null;
+    }
+  }
+
+  Future<void> _startOAuthFlow() async {
+    final prepared = await worker.prepareAuth();
+    final result = await oauthFlow.authorize(config);
+    await worker.completeAuth(
+      code: result.code,
+      verifier: result.verifier,
+      state: result.state ?? prepared.state,
+      nonce: result.nonce ?? prepared.nonce,
+      expectedState: result.state ?? prepared.state,
+    );
+  }
+
+  @override
+  Future<ApiResponse> fetch(
+    String path, {
+    String method = 'GET',
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) {
+    _ensureAlive();
+    return worker.fetch(
+      path: path,
+      method: method,
+      headers: headers,
+      body: body,
+      timeout: timeout,
+    );
+  }
+
+  @override
+  Future<ApiResponse> upload(
+    String path, {
+    required String fieldName,
+    required String filename,
+    required String contentType,
+    required Stream<List<int>> bytes,
+    required int length,
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) {
+    _ensureAlive();
+    return worker.upload(
+      path: path,
+      fieldName: fieldName,
+      filename: filename,
+      contentType: contentType,
+      bytes: bytes,
+      length: length,
+      headers: headers,
+      timeout: timeout,
+    );
+  }
+
+  @override
+  Future<Map<String, dynamic>> getClaims() async {
+    _ensureAlive();
+    if (worker.state != AuthState.authenticated) {
+      return const <String, dynamic>{};
+    }
+    return worker.getClaims();
+  }
+
+  @override
+  Future<List<String>> getRoles() async {
+    _ensureAlive();
+    if (worker.state != AuthState.authenticated) return const <String>[];
+    return worker.getRoles();
+  }
+
+  @override
+  Future<void> logout() async {
+    _ensureAlive();
+    await worker.logout();
+  }
+
+  @override
+  Stream<AuthState> get authStateStream => worker.authStateStream;
+
+  @override
+  Stream<SecurityEvent> get securityEventStream =>
+      worker.securityEventStream;
+
+  @override
+  AuthState get state => worker.state;
+
+  @override
+  Future<void> prefetchDiscovery() async {
+    _ensureAlive();
+    // Piggyback on the worker's discovery client — result is cached at
+    // the module level so subsequent calls reuse it for free.
+    await worker.discoveryClient.getDiscovery(
+      config.idpBaseUrl,
+      config.discoveryTimeout,
+    );
+  }
+
+  @override
+  String get version => authRuntimeVersion;
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await worker.destroy();
+  }
+
+  void _ensureAlive() {
+    if (_disposed) {
+      throw StateError('AuthRuntime has been disposed');
+    }
+  }
+}
+

--- a/ui/runtime/lib/src/config/auth_config.dart
+++ b/ui/runtime/lib/src/config/auth_config.dart
@@ -1,0 +1,46 @@
+import 'package:equatable/equatable.dart';
+
+/// Configuration for the auth runtime. Immutable value.
+///
+/// Fields are deliberately permissive so callers can pass raw values
+/// (trailing slashes, omitted timeouts) — [resolveConfig] normalizes
+/// them into a [ResolvedConfig].
+class AuthConfig extends Equatable {
+  const AuthConfig({
+    required this.clientId,
+    required this.idpBaseUrl,
+    required this.apiBaseUrl,
+    required this.redirectScheme,
+    this.scopes,
+    this.installationId,
+    this.discoveryTimeout,
+    this.tokenTimeout,
+    this.apiTimeout,
+    this.uploadTimeout,
+  });
+
+  final String clientId;
+  final String idpBaseUrl;
+  final String apiBaseUrl;
+  final String redirectScheme;
+  final List<String>? scopes;
+  final String? installationId;
+  final Duration? discoveryTimeout;
+  final Duration? tokenTimeout;
+  final Duration? apiTimeout;
+  final Duration? uploadTimeout;
+
+  @override
+  List<Object?> get props => [
+        clientId,
+        idpBaseUrl,
+        apiBaseUrl,
+        redirectScheme,
+        scopes,
+        installationId,
+        discoveryTimeout,
+        tokenTimeout,
+        apiTimeout,
+        uploadTimeout,
+      ];
+}

--- a/ui/runtime/lib/src/config/resolve_config.dart
+++ b/ui/runtime/lib/src/config/resolve_config.dart
@@ -1,0 +1,94 @@
+import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+
+/// Default OAuth scopes requested when caller supplies none.
+///
+/// Mirrors the JS runtime — `offline_access` is required for refresh
+/// token issuance under our Hydra setup.
+const List<String> defaultScopes = [
+  'openid',
+  'profile',
+  'email',
+  'offline_access',
+];
+
+const Duration _defaultDiscoveryTimeout = Duration(seconds: 10);
+const Duration _defaultTokenTimeout = Duration(seconds: 10);
+const Duration _defaultApiTimeout = Duration(seconds: 30);
+const Duration _defaultUploadTimeout = Duration(seconds: 60);
+
+/// Fully-resolved, normalized configuration.
+///
+/// Unlike [AuthConfig], every field has a concrete value. URLs are
+/// trimmed of trailing slashes so that paths we concatenate don't
+/// double-slash.
+class ResolvedConfig {
+  const ResolvedConfig({
+    required this.clientId,
+    required this.idpBaseUrl,
+    required this.apiBaseUrl,
+    required this.redirectScheme,
+    required this.scopes,
+    required this.installationId,
+    required this.discoveryTimeout,
+    required this.tokenTimeout,
+    required this.apiTimeout,
+    required this.uploadTimeout,
+  });
+
+  final String clientId;
+  final String idpBaseUrl;
+  final String apiBaseUrl;
+  final String redirectScheme;
+  final List<String> scopes;
+  final String? installationId;
+  final Duration discoveryTimeout;
+  final Duration tokenTimeout;
+  final Duration apiTimeout;
+  final Duration uploadTimeout;
+
+  /// `"{clientId}::{idpBaseUrl}"` — cache and storage key suffix.
+  String get namespace => '$clientId::$idpBaseUrl';
+
+  /// Convention-driven redirect URI: `{scheme}://callback`.
+  String get redirectUri => '$redirectScheme://callback';
+}
+
+/// Normalizes an [AuthConfig] into a fully-populated [ResolvedConfig].
+///
+/// Throws `AuthError(invalidConfig)` if any required string is blank.
+ResolvedConfig resolveConfig(AuthConfig cfg) {
+  if (cfg.clientId.isEmpty) {
+    throw AuthError(AuthErrorCode.invalidConfig, 'clientId is required');
+  }
+  if (cfg.idpBaseUrl.isEmpty) {
+    throw AuthError(AuthErrorCode.invalidConfig, 'idpBaseUrl is required');
+  }
+  if (cfg.apiBaseUrl.isEmpty) {
+    throw AuthError(AuthErrorCode.invalidConfig, 'apiBaseUrl is required');
+  }
+  if (cfg.redirectScheme.isEmpty) {
+    throw AuthError(AuthErrorCode.invalidConfig, 'redirectScheme is required');
+  }
+
+  return ResolvedConfig(
+    clientId: cfg.clientId,
+    idpBaseUrl: _stripTrailingSlash(cfg.idpBaseUrl),
+    apiBaseUrl: _stripTrailingSlash(cfg.apiBaseUrl),
+    redirectScheme: cfg.redirectScheme,
+    scopes: List<String>.unmodifiable(cfg.scopes ?? defaultScopes),
+    installationId: cfg.installationId,
+    discoveryTimeout: cfg.discoveryTimeout ?? _defaultDiscoveryTimeout,
+    tokenTimeout: cfg.tokenTimeout ?? _defaultTokenTimeout,
+    apiTimeout: cfg.apiTimeout ?? _defaultApiTimeout,
+    uploadTimeout: cfg.uploadTimeout ?? _defaultUploadTimeout,
+  );
+}
+
+String _stripTrailingSlash(String s) {
+  var end = s.length;
+  while (end > 0 && s.codeUnitAt(end - 1) == 0x2F /* '/' */) {
+    end--;
+  }
+  return s.substring(0, end);
+}

--- a/ui/runtime/lib/src/crypto/default_key_manager.dart
+++ b/ui/runtime/lib/src/crypto/default_key_manager.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart' as dpop;
+import 'package:cryptography/cryptography.dart'
+    show AesGcm, Mac, SecretBox;
+import 'package:pointycastle/export.dart' as pc;
+
+/// Default [KeyManager] implementation.
+///
+/// - **DPoP (ECDSA P-256)**: backed by PointyCastle. The plan originally
+///   mandated pure `package:cryptography`, but that package's pure-Dart
+///   ECDSA raises [UnimplementedError] (it only wires up the browser
+///   `SubtleCrypto` path). PointyCastle signs + verifies end-to-end on
+///   every Dart platform, matching F-B.4 behaviour.
+/// - **AES-GCM wrap**: backed by `package:cryptography`'s `AesGcm` —
+///   fully implemented in pure Dart and what the plan asked for.
+class DefaultKeyManager implements KeyManager {
+  DefaultKeyManager({AesGcm? aesGcm}) : _aesGcm = aesGcm ?? AesGcm.with256bits();
+
+  final AesGcm _aesGcm;
+
+  @override
+  Future<dpop.DpopKeyPair> generateDpopKey() async =>
+      dpop.generateDpopKeyPair();
+
+  @override
+  Future<Uint8List> signDpopJws(
+    dpop.DpopKeyPair key,
+    String signingInput,
+  ) async {
+    final signer = pc.ECDSASigner(
+      pc.SHA256Digest(),
+      pc.HMac.withDigest(pc.SHA256Digest()),
+    )..init(
+        true,
+        pc.PrivateKeyParameter<pc.ECPrivateKey>(key.privateKey),
+      );
+    final sig =
+        signer.generateSignature(Uint8List.fromList(utf8.encode(signingInput)))
+            as pc.ECSignature;
+    return Uint8List.fromList([
+      ..._bigIntToFixedBytes(sig.r, 32),
+      ..._bigIntToFixedBytes(sig.s, 32),
+    ]);
+  }
+
+  @override
+  Future<Map<String, dynamic>> exportDpopPublicJwk(dpop.DpopKeyPair key) async {
+    final q = key.publicKey.Q;
+    if (q == null) {
+      throw AuthError(
+        AuthErrorCode.cryptoUnsupported,
+        'DPoP public key has no affine point',
+      );
+    }
+    final x = q.x?.toBigInteger();
+    final y = q.y?.toBigInteger();
+    if (x == null || y == null) {
+      throw AuthError(
+        AuthErrorCode.cryptoUnsupported,
+        'DPoP public key missing x/y coordinates',
+      );
+    }
+    return <String, dynamic>{
+      'kty': 'EC',
+      'crv': 'P-256',
+      'x': _b64urlNoPad(_bigIntToFixedBytes(x, 32)),
+      'y': _b64urlNoPad(_bigIntToFixedBytes(y, 32)),
+    };
+  }
+
+  @override
+  Future<WrapKey> generateWrapKey() async {
+    final key = await _aesGcm.newSecretKey();
+    return WrapKey(key);
+  }
+
+  @override
+  Future<WrappedBlob> wrap(WrapKey key, List<int> plaintext) async {
+    final box = await _aesGcm.encrypt(plaintext, secretKey: key.secretKey);
+    // Pack MAC inside the returned ciphertext so [WrappedBlob] stays a
+    // 2-tuple `{iv, ciphertext}` matching the plan's interface. On
+    // unwrap we slice the trailing MAC back off.
+    final cipherText = box.cipherText;
+    final macBytes = box.mac.bytes;
+    final combined = Uint8List(cipherText.length + macBytes.length)
+      ..setRange(0, cipherText.length, cipherText)
+      ..setRange(cipherText.length, cipherText.length + macBytes.length,
+          macBytes);
+    return WrappedBlob(
+      iv: Uint8List.fromList(box.nonce),
+      ciphertext: combined,
+    );
+  }
+
+  @override
+  Future<Uint8List> unwrap(WrapKey key, WrappedBlob blob) async {
+    final macLen = _aesGcm.macAlgorithm.macLength;
+    if (blob.ciphertext.length < macLen) {
+      throw AuthError(
+        AuthErrorCode.storageCorruption,
+        'wrapped blob shorter than MAC length',
+      );
+    }
+    final cipherEnd = blob.ciphertext.length - macLen;
+    final cipherText = blob.ciphertext.sublist(0, cipherEnd);
+    final macBytes = blob.ciphertext.sublist(cipherEnd);
+    final box = SecretBox(
+      cipherText,
+      nonce: blob.iv,
+      mac: Mac(macBytes),
+    );
+    try {
+      final plain = await _aesGcm.decrypt(box, secretKey: key.secretKey);
+      return Uint8List.fromList(plain);
+    } catch (err) {
+      throw AuthError(
+        AuthErrorCode.storageCorruption,
+        'AES-GCM unwrap failed',
+        cause: err,
+      );
+    }
+  }
+}
+
+Uint8List _bigIntToFixedBytes(BigInt value, int size) {
+  final bytes = Uint8List(size);
+  var v = value;
+  for (var i = size - 1; i >= 0; i--) {
+    bytes[i] = (v & BigInt.from(0xff)).toInt();
+    v = v >> 8;
+  }
+  return bytes;
+}
+
+String _b64urlNoPad(List<int> bytes) =>
+    base64Url.encode(bytes).replaceAll('=', '');

--- a/ui/runtime/lib/src/crypto/default_key_manager.dart
+++ b/ui/runtime/lib/src/crypto/default_key_manager.dart
@@ -5,7 +5,7 @@ import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
 import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart' as dpop;
 import 'package:cryptography/cryptography.dart'
-    show AesGcm, Mac, SecretBox;
+    show AesGcm, Mac, SecretBox, SecretKey;
 import 'package:pointycastle/export.dart' as pc;
 
 /// Default [KeyManager] implementation.
@@ -73,9 +73,63 @@ class DefaultKeyManager implements KeyManager {
   }
 
   @override
+  Future<Uint8List> exportDpopPrivateKey(dpop.DpopKeyPair key) async {
+    final d = key.privateKey.d;
+    if (d == null) {
+      throw AuthError(
+        AuthErrorCode.cryptoUnsupported,
+        'DPoP private key missing scalar',
+      );
+    }
+    return _bigIntToFixedBytes(d, 32);
+  }
+
+  @override
+  Future<dpop.DpopKeyPair> importDpopPrivateKey(Uint8List dScalar) async {
+    if (dScalar.length != 32) {
+      throw AuthError(
+        AuthErrorCode.storageCorruption,
+        'DPoP private scalar must be 32 bytes (got ${dScalar.length})',
+      );
+    }
+    final params = pc.ECCurve_secp256r1();
+    final d = _bytesToBigInt(dScalar);
+    // Q = d * G: required because the on-disk schema only stores the
+    // scalar. `multiplier` defaults to `WTNAFMultiplier` which is fine for
+    // P-256.
+    final q = params.G * d;
+    if (q == null) {
+      throw AuthError(
+        AuthErrorCode.storageCorruption,
+        'failed to derive DPoP public point from scalar',
+      );
+    }
+    final priv = pc.ECPrivateKey(d, params);
+    final pub = pc.ECPublicKey(q, params);
+    return dpop.DpopKeyPair(privateKey: priv, publicKey: pub);
+  }
+
+  @override
   Future<WrapKey> generateWrapKey() async {
     final key = await _aesGcm.newSecretKey();
     return WrapKey(key);
+  }
+
+  @override
+  Future<WrapKey> importWrapKey(Uint8List rawKey) async {
+    if (rawKey.length != 32) {
+      throw AuthError(
+        AuthErrorCode.storageCorruption,
+        'wrap key must be 32 bytes (got ${rawKey.length})',
+      );
+    }
+    return WrapKey(SecretKey(List<int>.from(rawKey)));
+  }
+
+  @override
+  Future<Uint8List> exportWrapKey(WrapKey key) async {
+    final bytes = await key.secretKey.extractBytes();
+    return Uint8List.fromList(bytes);
   }
 
   @override
@@ -134,6 +188,14 @@ Uint8List _bigIntToFixedBytes(BigInt value, int size) {
     v = v >> 8;
   }
   return bytes;
+}
+
+BigInt _bytesToBigInt(Uint8List bytes) {
+  var result = BigInt.zero;
+  for (final b in bytes) {
+    result = (result << 8) | BigInt.from(b);
+  }
+  return result;
 }
 
 String _b64urlNoPad(List<int> bytes) =>

--- a/ui/runtime/lib/src/crypto/key_manager.dart
+++ b/ui/runtime/lib/src/crypto/key_manager.dart
@@ -47,8 +47,26 @@ abstract class KeyManager {
   /// embedding in the proof header.
   Future<Map<String, dynamic>> exportDpopPublicJwk(DpopKeyPair key);
 
+  /// Exports the DPoP private key's `d` scalar as a fixed 32-byte
+  /// big-endian buffer so the runtime can persist it (encrypted) and
+  /// reconstruct the key pair on cold start.
+  Future<Uint8List> exportDpopPrivateKey(DpopKeyPair key);
+
+  /// Rehydrates a [DpopKeyPair] from a 32-byte `d` scalar previously
+  /// produced by [exportDpopPrivateKey]. The matching public point is
+  /// recomputed as `Q = d * G` over P-256.
+  Future<DpopKeyPair> importDpopPrivateKey(Uint8List dScalar);
+
   /// Generates a fresh 256-bit AES-GCM wrap key.
   Future<WrapKey> generateWrapKey();
+
+  /// Wraps an arbitrary 32-byte AES-GCM key material buffer (e.g. the
+  /// root key persisted by `RootKeyStore`) into a [WrapKey] handle.
+  Future<WrapKey> importWrapKey(Uint8List rawKey);
+
+  /// Exports the raw 32-byte key material backing [key]. Intended for
+  /// persisting the wrap key encrypted under the root key.
+  Future<Uint8List> exportWrapKey(WrapKey key);
 
   /// Encrypts [plaintext] under [key] with a fresh random IV.
   Future<WrappedBlob> wrap(WrapKey key, List<int> plaintext);

--- a/ui/runtime/lib/src/crypto/key_manager.dart
+++ b/ui/runtime/lib/src/crypto/key_manager.dart
@@ -1,0 +1,58 @@
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart'
+    show DpopKeyPair;
+import 'package:cryptography/cryptography.dart' show SecretKey;
+
+/// Opaque handle to an AES-GCM wrap key.
+///
+/// Callers should treat [secretKey] as private — [KeyManager] is the only
+/// expected consumer. Kept as a wrapper (rather than exposing [SecretKey]
+/// directly) so the backend can change without rippling through call sites.
+class WrapKey {
+  const WrapKey(this.secretKey);
+
+  final SecretKey secretKey;
+}
+
+/// Ciphertext + IV tuple produced by [KeyManager.wrap].
+///
+/// `ciphertext` includes the AES-GCM authentication tag appended per the
+/// `package:cryptography` convention.
+class WrappedBlob {
+  const WrappedBlob({
+    required this.iv,
+    required this.ciphertext,
+  });
+
+  final Uint8List iv;
+  final Uint8List ciphertext;
+}
+
+/// Signer + wrapper abstraction used throughout the runtime.
+///
+/// Exists so the crypto backend (currently PointyCastle for ECDSA,
+/// `package:cryptography` for AES-GCM) can be swapped without touching
+/// DPoP or storage callers. All methods return `Future` so backends may
+/// delegate to platform channels without API churn.
+abstract class KeyManager {
+  /// Generates a fresh ECDSA P-256 key pair for DPoP proofs.
+  Future<DpopKeyPair> generateDpopKey();
+
+  /// Signs [signingInput] with the DPoP private key. Returns raw
+  /// `r || s` (64 bytes) matching JWS ES256.
+  Future<Uint8List> signDpopJws(DpopKeyPair key, String signingInput);
+
+  /// Exports the public portion of the DPoP key as a JWK suitable for
+  /// embedding in the proof header.
+  Future<Map<String, dynamic>> exportDpopPublicJwk(DpopKeyPair key);
+
+  /// Generates a fresh 256-bit AES-GCM wrap key.
+  Future<WrapKey> generateWrapKey();
+
+  /// Encrypts [plaintext] under [key] with a fresh random IV.
+  Future<WrappedBlob> wrap(WrapKey key, List<int> plaintext);
+
+  /// Decrypts a [blob] produced by [wrap]. Throws on auth-tag failure.
+  Future<Uint8List> unwrap(WrapKey key, WrappedBlob blob);
+}

--- a/ui/runtime/lib/src/crypto/root_key_store.dart
+++ b/ui/runtime/lib/src/crypto/root_key_store.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
+
+/// Persistent per-install root key ("KEK") used to encrypt the wrap key.
+///
+/// The root key itself lives in a hardware-backed keystore
+/// (`flutter_secure_storage`) under the key `"{namespace}::root-key"`.
+/// From the runtime's perspective this is simply 32 bytes of AES-GCM key
+/// material it can derive a [WrapKey]-equivalent from; security guarantees
+/// come from the underlying platform keychain.
+///
+/// Splitting this out as an interface lets tests substitute a pure
+/// in-memory implementation and lets future platform hardening (Android
+/// StrongBox / iOS Secure Enclave-bound keys) drop in without touching
+/// the rest of the runtime.
+abstract class RootKeyStore {
+  /// Returns the root key for [namespace], generating + persisting a fresh
+  /// one the first time it is requested. Always returns exactly 32 bytes.
+  Future<Uint8List> getOrCreate(String namespace);
+
+  /// Forces a rotation: generates a new root key and overwrites the stored
+  /// one. Used on security-wipe so any previously-wrapped material becomes
+  /// unreadable.
+  Future<void> rotate(String namespace);
+
+  /// Deletes the root key for [namespace]. Subsequent reads behave as if
+  /// the namespace had never been seen.
+  Future<void> clear(String namespace);
+}
+
+/// Default [RootKeyStore] that persists 32 bytes of random key material in
+/// a [KeyValueStore] (production: `flutter_secure_storage`).
+class DefaultRootKeyStore implements RootKeyStore {
+  DefaultRootKeyStore({required KeyValueStore kv, Random? random})
+      : _kv = kv,
+        _random = random ?? Random.secure();
+
+  final KeyValueStore _kv;
+  final Random _random;
+
+  String _keyFor(String namespace) => '$namespace::root-key';
+
+  @override
+  Future<Uint8List> getOrCreate(String namespace) async {
+    final existing = await _kv.read(_keyFor(namespace));
+    if (existing != null && existing.isNotEmpty) {
+      try {
+        final decoded = base64.decode(existing);
+        if (decoded.length == 32) {
+          return Uint8List.fromList(decoded);
+        }
+      } catch (_) {
+        // Corrupt entry — fall through and overwrite with a fresh key.
+      }
+    }
+    final fresh = _generate();
+    await _kv.write(_keyFor(namespace), base64.encode(fresh));
+    return fresh;
+  }
+
+  @override
+  Future<void> rotate(String namespace) async {
+    final fresh = _generate();
+    await _kv.write(_keyFor(namespace), base64.encode(fresh));
+  }
+
+  @override
+  Future<void> clear(String namespace) async {
+    await _kv.delete(_keyFor(namespace));
+  }
+
+  Uint8List _generate() {
+    final out = Uint8List(32);
+    for (var i = 0; i < out.length; i++) {
+      out[i] = _random.nextInt(256);
+    }
+    return out;
+  }
+}

--- a/ui/runtime/lib/src/errors/auth_error.dart
+++ b/ui/runtime/lib/src/errors/auth_error.dart
@@ -1,0 +1,86 @@
+/// Flat error taxonomy used by the auth runtime.
+///
+/// Mirrors the JS `@stawi/auth-runtime` codes with mobile-specific
+/// additions (see spec §4). Codes are grouped below for readability
+/// but are all peers in one enum.
+enum AuthErrorCode {
+  invalidConfig,
+
+  // Network / discovery
+  discoveryFailed,
+  networkTimeout,
+  networkError,
+  offline,
+
+  // OAuth
+  oauthFailed,
+  oauthUserCanceled,
+  oauthBrowserUnavailable,
+
+  // Token lifecycle
+  tokenExchangeFailed,
+  tokenRefreshFailed,
+  tokenExpired,
+
+  // DPoP
+  dpopNonceRequired,
+  dpopInvalidProof,
+
+  // Security
+  refreshReuseDetected,
+
+  // Storage / crypto
+  storageCorruption,
+  storageUnavailable,
+  cryptoUnsupported,
+
+  // Session invariants
+  loggedOutElsewhere,
+  securityWipe,
+
+  // API surface mapping
+  apiUnauthorized,
+  apiForbidden,
+  apiNotFound,
+  apiValidation,
+  apiServerError,
+
+  // Mobile specifics
+  deepLinkMismatch,
+  biometricRequired,
+  biometricUnavailable,
+}
+
+const Set<AuthErrorCode> _nonRetryable = {
+  AuthErrorCode.invalidConfig,
+  AuthErrorCode.refreshReuseDetected,
+  AuthErrorCode.cryptoUnsupported,
+  AuthErrorCode.deepLinkMismatch,
+  AuthErrorCode.securityWipe,
+};
+
+/// Non-fatal, structured error raised throughout the runtime.
+///
+/// `retryable` is derived from [code] so callers can implement uniform
+/// backoff/wipe policy without switching on every variant.
+class AuthError extends Error {
+  AuthError(
+    this.code,
+    this.message, {
+    this.cause,
+    this.traceId,
+  });
+
+  final AuthErrorCode code;
+  final String message;
+  final Object? cause;
+  final String? traceId;
+
+  bool get retryable => !_nonRetryable.contains(code);
+
+  @override
+  String toString() {
+    final trace = traceId == null ? '' : ' (trace=$traceId)';
+    return 'AuthError(${code.name}): $message$trace';
+  }
+}

--- a/ui/runtime/lib/src/factory.dart
+++ b/ui/runtime/lib/src/factory.dart
@@ -7,6 +7,10 @@ import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
+import 'package:antinvestor_auth_runtime/src/isolated_auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
 import 'package:antinvestor_auth_runtime/src/oauth/oauth_flow.dart';
 import 'package:antinvestor_auth_runtime/src/protocol/api_proxy.dart';
 import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
@@ -44,14 +48,20 @@ AuthRuntime createAuthRuntime(
   OAuthFlow? oauthFlow,
   Clock? clock,
 }) {
-  if (useIsolate) {
-    // F-G.2 introduces `IsolatedTokenWorkerProxy`; until then we refuse
-    // loudly so callers don't get silently downgraded.
-    throw UnsupportedError(
-      'useIsolate=true is not yet wired — see plan task F-G.2',
-    );
-  }
   final resolved = resolveConfig(config);
+  if (useIsolate) {
+    // v0.1 ships the isolate path in scaffolding form: lifecycle works
+    // end-to-end, data-plane methods throw `UnimplementedError` until the
+    // F-J integration pass wires the full transport. Callers who need
+    // production-grade access today should stick with the default
+    // in-thread runtime.
+    //
+    // The spawn is fire-and-forget here: `createAuthRuntime` stays
+    // synchronous (matching the in-thread path), and the returned shell
+    // routes all method calls through a `proxy` that awaits spawn
+    // completion transparently via its own `init()`.
+    return _LazyIsolatedAuthRuntime(resolved);
+  }
 
   final km = keyManager ?? DefaultKeyManager();
   final rootStore = rootKeyStore ??
@@ -87,5 +97,113 @@ AuthRuntime createAuthRuntime(
   // still wiring up.
   unawaited(runtime.init());
   return runtime;
+}
+
+/// Async-only variant for callers who can await spawn completion. The
+/// returned runtime has its isolate already alive and its lifecycle
+/// bootstrapped — useful for tests that want to observe errors during
+/// spawn eagerly.
+Future<AuthRuntime> createIsolatedAuthRuntime(
+  AuthConfig config, {
+  Duration readyTimeout = const Duration(seconds: 5),
+}) async {
+  final resolved = resolveConfig(config);
+  return spawnIsolatedAuthRuntime(resolved, readyTimeout: readyTimeout);
+}
+
+/// Thin shell that collapses async spawning behind a sync factory.
+///
+/// Every public method awaits [_ready] before delegating. The isolate is
+/// spawned exactly once at construction. [authStateStream] and
+/// [securityEventStream] use buffered controllers so early subscribers
+/// don't miss events that the spawned runtime emits before they attach.
+class _LazyIsolatedAuthRuntime implements AuthRuntime {
+  _LazyIsolatedAuthRuntime(this.config) {
+    _ready = _spawn();
+  }
+
+  final ResolvedConfig config;
+  late final Future<IsolatedAuthRuntime> _ready;
+  bool _disposed = false;
+
+  Future<IsolatedAuthRuntime> _spawn() =>
+      spawnIsolatedAuthRuntime(config);
+
+  @override
+  Future<void> ensureAuthenticated() async =>
+      (await _ready).ensureAuthenticated();
+
+  @override
+  Future<ApiResponse> fetch(
+    String path, {
+    String method = 'GET',
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async =>
+      (await _ready).fetch(path,
+          method: method, headers: headers, body: body, timeout: timeout);
+
+  @override
+  Future<ApiResponse> upload(
+    String path, {
+    required String fieldName,
+    required String filename,
+    required String contentType,
+    required Stream<List<int>> bytes,
+    required int length,
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async =>
+      (await _ready).upload(
+        path,
+        fieldName: fieldName,
+        filename: filename,
+        contentType: contentType,
+        bytes: bytes,
+        length: length,
+        headers: headers,
+        timeout: timeout,
+      );
+
+  @override
+  Future<Map<String, dynamic>> getClaims() async =>
+      (await _ready).getClaims();
+
+  @override
+  Future<List<String>> getRoles() async => (await _ready).getRoles();
+
+  @override
+  Future<void> logout() async => (await _ready).logout();
+
+  @override
+  Stream<AuthState> get authStateStream async* {
+    final rt = await _ready;
+    yield* rt.authStateStream;
+  }
+
+  @override
+  Stream<SecurityEvent> get securityEventStream async* {
+    final rt = await _ready;
+    yield* rt.securityEventStream;
+  }
+
+  @override
+  AuthState get state => AuthState.initializing;
+
+  @override
+  Future<void> prefetchDiscovery() async =>
+      (await _ready).prefetchDiscovery();
+
+  @override
+  String get version => authRuntimeVersion;
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    final rt = await _ready;
+    await rt.dispose();
+  }
 }
 

--- a/ui/runtime/lib/src/factory.dart
+++ b/ui/runtime/lib/src/factory.dart
@@ -1,0 +1,91 @@
+import 'dart:async';
+
+import 'package:antinvestor_auth_runtime/src/auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/auth_runtime_impl.dart';
+import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
+import 'package:antinvestor_auth_runtime/src/oauth/oauth_flow.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/api_proxy.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
+import 'package:antinvestor_auth_runtime/src/runtime/refresh_lock.dart';
+import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
+import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
+import 'package:antinvestor_auth_runtime/src/worker/token_worker.dart';
+
+/// Builds a production [AuthRuntime] wired against `flutter_secure_storage`
+/// (via [SecureStorageKeyValueStore]) and the default HTTP + crypto
+/// stacks.
+///
+/// The factory is the single public entry point — callers should never
+/// construct [AuthRuntimeImpl] directly so future rearchitecture (e.g.
+/// swapping to an isolate-backed worker) is opaque to consumers.
+///
+/// All collaborators are overridable so tests can inject
+/// `InMemoryKeyValueStore`, a `MockClient`, or a stubbed [OAuthFlow]
+/// without pulling in platform channels.
+///
+/// `useIsolate` is reserved for F-G.2 — today it must be `false`. When
+/// the isolate variant lands the factory starts honouring it.
+AuthRuntime createAuthRuntime(
+  AuthConfig config, {
+  bool useIsolate = false,
+  KeyManager? keyManager,
+  RootKeyStore? rootKeyStore,
+  TokenStore? tokenStore,
+  KeyValueStore? sessionKv,
+  KeyValueStore? rootKv,
+  DiscoveryClient? discoveryClient,
+  TokenExchange? tokenExchange,
+  ApiProxy? apiProxy,
+  RefreshLock? refreshLock,
+  OAuthFlow? oauthFlow,
+  Clock? clock,
+}) {
+  if (useIsolate) {
+    // F-G.2 introduces `IsolatedTokenWorkerProxy`; until then we refuse
+    // loudly so callers don't get silently downgraded.
+    throw UnsupportedError(
+      'useIsolate=true is not yet wired — see plan task F-G.2',
+    );
+  }
+  final resolved = resolveConfig(config);
+
+  final km = keyManager ?? DefaultKeyManager();
+  final rootStore = rootKeyStore ??
+      DefaultRootKeyStore(kv: rootKv ?? SecureStorageKeyValueStore());
+  final store = tokenStore ??
+      SecureTokenStore(kv: sessionKv ?? SecureStorageKeyValueStore());
+  final discovery = discoveryClient ?? DefaultDiscoveryClient();
+  final exchange = tokenExchange ??
+      TokenExchange(timeout: resolved.tokenTimeout);
+  final proxy = apiProxy ?? ApiProxy();
+  final lock = refreshLock ?? RefreshLock();
+  final flow = oauthFlow ?? OAuthFlow();
+
+  final worker = TokenWorker(
+    config: resolved,
+    keyManager: km,
+    rootKeyStore: rootStore,
+    tokenStore: store,
+    discoveryClient: discovery,
+    tokenExchange: exchange,
+    apiProxy: proxy,
+    refreshLock: lock,
+    clock: clock ?? DateTime.now,
+  );
+
+  final runtime = AuthRuntimeImpl(
+    config: resolved,
+    worker: worker,
+    oauthFlow: flow,
+  );
+  // Kick off session reload immediately so apps subscribing to
+  // `authStateStream` don't miss the first transition while they're
+  // still wiring up.
+  unawaited(runtime.init());
+  return runtime;
+}
+

--- a/ui/runtime/lib/src/isolated_auth_runtime.dart
+++ b/ui/runtime/lib/src/isolated_auth_runtime.dart
@@ -1,0 +1,191 @@
+import 'dart:async';
+
+import 'package:antinvestor_auth_runtime/src/auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/worker/messages.dart';
+import 'package:antinvestor_auth_runtime/src/worker/token_isolate.dart';
+
+/// Shell [AuthRuntime] that routes to an [IsolatedTokenWorkerProxy].
+///
+/// v0.1 wires only the lifecycle surface (init, destroy, state/security
+/// streams). The data-plane methods (`fetch`, `upload`, `logout`, …)
+/// throw `UnimplementedError` until F-J wires real HTTP + DPoP transports
+/// across the isolate boundary. Consumers who depend on those methods
+/// should stick with the default in-thread runtime via
+/// `createAuthRuntime(..., useIsolate: false)`.
+///
+/// The state + security streams are wired from correlated / broadcast
+/// events emitted by the isolate entry point. The default scaffolding
+/// entry point only emits a [ReadyEvent] at start-up — but the transport
+/// is ready to carry real state changes once a richer worker ships.
+class IsolatedAuthRuntime implements AuthRuntime {
+  IsolatedAuthRuntime({
+    required this.config,
+    required this.proxy,
+  })  : _stateController = StreamController<AuthState>.broadcast(),
+        _securityController = StreamController<SecurityEvent>.broadcast() {
+    _eventSubscription = proxy.events.listen(_onEvent);
+  }
+
+  final ResolvedConfig config;
+  final IsolatedTokenWorkerProxy proxy;
+
+  final StreamController<AuthState> _stateController;
+  final StreamController<SecurityEvent> _securityController;
+  late final StreamSubscription<WorkerEvent> _eventSubscription;
+
+  AuthState _state = AuthState.initializing;
+  bool _disposed = false;
+  bool _initialised = false;
+
+  void _onEvent(WorkerEvent ev) {
+    if (ev is StateEvent) {
+      _state = ev.state;
+      if (!_stateController.isClosed) _stateController.add(ev.state);
+      return;
+    }
+    if (ev is SecurityEventWire) {
+      if (!_securityController.isClosed) {
+        _securityController.add(ev.event);
+      }
+    }
+  }
+
+  Future<void> _ensureInit() async {
+    if (_initialised) return;
+    _initialised = true;
+    await proxy.init();
+  }
+
+  @override
+  Future<void> ensureAuthenticated() async {
+    _ensureAlive();
+    await _ensureInit();
+    // Full OAuth over the isolate boundary requires F-J's integration
+    // transport (platform plugin round-trips don't survive SendPort).
+    throw UnimplementedError(
+      'ensureAuthenticated via isolate is scheduled for F-J; '
+      'use createAuthRuntime(useIsolate: false) in v0.1',
+    );
+  }
+
+  @override
+  Future<ApiResponse> fetch(
+    String path, {
+    String method = 'GET',
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    _ensureAlive();
+    throw UnimplementedError(
+      'fetch via isolate is scheduled for F-J',
+    );
+  }
+
+  @override
+  Future<ApiResponse> upload(
+    String path, {
+    required String fieldName,
+    required String filename,
+    required String contentType,
+    required Stream<List<int>> bytes,
+    required int length,
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    _ensureAlive();
+    throw UnimplementedError(
+      'upload via isolate is scheduled for F-J',
+    );
+  }
+
+  @override
+  Future<Map<String, dynamic>> getClaims() async {
+    _ensureAlive();
+    return const <String, dynamic>{};
+  }
+
+  @override
+  Future<List<String>> getRoles() async {
+    _ensureAlive();
+    return const <String>[];
+  }
+
+  @override
+  Future<void> logout() async {
+    _ensureAlive();
+    throw UnimplementedError(
+      'logout via isolate is scheduled for F-J',
+    );
+  }
+
+  @override
+  Stream<AuthState> get authStateStream => _stateController.stream;
+
+  @override
+  Stream<SecurityEvent> get securityEventStream =>
+      _securityController.stream;
+
+  @override
+  AuthState get state => _state;
+
+  @override
+  Future<void> prefetchDiscovery() async {
+    _ensureAlive();
+    // No-op for the isolate shell: discovery is owned by the worker, and
+    // the scaffolding worker has no real HTTP client.
+  }
+
+  @override
+  String get version => authRuntimeVersion;
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _eventSubscription.cancel();
+    await proxy.destroy();
+    await _stateController.close();
+    await _securityController.close();
+  }
+
+  void _ensureAlive() {
+    if (_disposed) {
+      throw StateError('AuthRuntime has been disposed');
+    }
+  }
+}
+
+/// Spawns the default scaffolding isolate and wraps it in an
+/// [IsolatedAuthRuntime]. Exposed as the factory hook `useIsolate: true`
+/// routes through.
+Future<IsolatedAuthRuntime> spawnIsolatedAuthRuntime(
+  ResolvedConfig config, {
+  Duration readyTimeout = const Duration(seconds: 5),
+  void Function(dynamic)? entryPoint,
+}) async {
+  final handle = await TokenIsolateHandle.spawn(
+    readyTimeout: readyTimeout,
+    entryPoint: entryPoint == null
+        ? null
+        : (send) => entryPoint(send),
+  );
+  final proxy = IsolatedTokenWorkerProxy(handle);
+  // Propagate isolate-side errors as AuthError for caller ergonomics.
+  // ignore: avoid_catching_errors
+  try {
+    return IsolatedAuthRuntime(config: config, proxy: proxy);
+  } catch (err) {
+    await proxy.destroy();
+    throw AuthError(
+      AuthErrorCode.cryptoUnsupported,
+      'failed to construct IsolatedAuthRuntime',
+      cause: err,
+    );
+  }
+}

--- a/ui/runtime/lib/src/models/api_response.dart
+++ b/ui/runtime/lib/src/models/api_response.dart
@@ -1,0 +1,17 @@
+import 'dart:typed_data';
+
+/// Opaque response returned by [AuthRuntime.fetch] / [AuthRuntime.upload].
+///
+/// Callers never see access tokens or raw [http.Response] objects — only
+/// status, headers, and bytes.
+class ApiResponse {
+  ApiResponse({
+    required this.status,
+    required Map<String, String> headers,
+    required this.body,
+  }) : headers = Map<String, String>.unmodifiable(headers);
+
+  final int status;
+  final Map<String, String> headers;
+  final Uint8List body;
+}

--- a/ui/runtime/lib/src/models/auth_state.dart
+++ b/ui/runtime/lib/src/models/auth_state.dart
@@ -1,0 +1,11 @@
+/// Lifecycle state of an [AuthRuntime].
+///
+/// Transitions are driven by the pure reducer in
+/// `lib/src/runtime/state_machine.dart` (Group F-D).
+enum AuthState {
+  initializing,
+  authenticated,
+  unauthenticated,
+  refreshing,
+  error,
+}

--- a/ui/runtime/lib/src/models/security_event.dart
+++ b/ui/runtime/lib/src/models/security_event.dart
@@ -1,0 +1,47 @@
+/// Security signals emitted by the runtime.
+///
+/// Sealed hierarchy rather than enum so callers can exhaustively switch
+/// while remaining forward-compatible with future variants.
+sealed class SecurityEvent {
+  const SecurityEvent(this.at);
+
+  final DateTime at;
+
+  // ignore: prefer_const_constructors_in_immutables
+  factory SecurityEvent.refreshReuseDetected(DateTime at) =
+      RefreshReuseDetected;
+  // ignore: prefer_const_constructors_in_immutables
+  factory SecurityEvent.storageCorruption(DateTime at) = StorageCorruption;
+  // ignore: prefer_const_constructors_in_immutables
+  factory SecurityEvent.bindingInvalidated(DateTime at) = BindingInvalidated;
+  // ignore: prefer_const_constructors_in_immutables
+  factory SecurityEvent.loggedOutElsewhere(DateTime at) = LoggedOutElsewhere;
+
+  @override
+  bool operator ==(Object other) =>
+      other.runtimeType == runtimeType &&
+      other is SecurityEvent &&
+      other.at == at;
+
+  @override
+  int get hashCode => Object.hash(runtimeType, at);
+
+  @override
+  String toString() => '$runtimeType(at=$at)';
+}
+
+final class RefreshReuseDetected extends SecurityEvent {
+  const RefreshReuseDetected(super.at);
+}
+
+final class StorageCorruption extends SecurityEvent {
+  const StorageCorruption(super.at);
+}
+
+final class BindingInvalidated extends SecurityEvent {
+  const BindingInvalidated(super.at);
+}
+
+final class LoggedOutElsewhere extends SecurityEvent {
+  const LoggedOutElsewhere(super.at);
+}

--- a/ui/runtime/lib/src/models/token_set.dart
+++ b/ui/runtime/lib/src/models/token_set.dart
@@ -1,0 +1,46 @@
+import 'package:equatable/equatable.dart';
+
+/// Token presentation mode negotiated with the IdP.
+enum TokenType {
+  bearer,
+  dpop;
+
+  String get headerValue => switch (this) {
+        TokenType.bearer => 'Bearer',
+        TokenType.dpop => 'DPoP',
+      };
+
+  /// Parses a `token_type` response field; defaults to [TokenType.bearer]
+  /// on null/unknown values to match the JS runtime behaviour.
+  static TokenType fromString(String? v) {
+    if (v == null) return TokenType.bearer;
+    return v.toLowerCase() == 'dpop' ? TokenType.dpop : TokenType.bearer;
+  }
+}
+
+/// Immutable token bundle returned by the IdP.
+///
+/// [expiresAt] is the absolute clock-time the access token stops being
+/// valid. The refresh token lives long enough for rotation.
+class TokenSet extends Equatable {
+  const TokenSet({
+    required this.accessToken,
+    required this.refreshToken,
+    required this.expiresAt,
+    required this.tokenType,
+    this.idToken,
+  });
+
+  final String accessToken;
+  final String refreshToken;
+  final DateTime expiresAt;
+  final TokenType tokenType;
+  final String? idToken;
+
+  bool isExpiredAt(DateTime now) =>
+      !now.isBefore(expiresAt); // `now >= expiresAt`
+
+  @override
+  List<Object?> get props =>
+      [accessToken, refreshToken, expiresAt, tokenType, idToken];
+}

--- a/ui/runtime/lib/src/models/user_claims.dart
+++ b/ui/runtime/lib/src/models/user_claims.dart
@@ -1,0 +1,33 @@
+/// Thin wrapper around the claims map decoded from a JWT.
+///
+/// Only surfaces canonical OIDC fields as typed getters; callers needing
+/// custom claims can reach through [raw]. Role extraction matches the JS
+/// `extractRolesFromToken` — supporting both `roles` and
+/// `realm_access.roles`.
+class UserClaims {
+  const UserClaims(this.raw);
+
+  final Map<String, dynamic> raw;
+
+  String? get sub => _asString(raw['sub']);
+  String? get name => _asString(raw['name']);
+  String? get email => _asString(raw['email']);
+  String? get picture => _asString(raw['picture']);
+
+  List<String> get roles {
+    final direct = raw['roles'];
+    if (direct is List) {
+      return direct.whereType<String>().toList(growable: false);
+    }
+    final realm = raw['realm_access'];
+    if (realm is Map) {
+      final realmRoles = realm['roles'];
+      if (realmRoles is List) {
+        return realmRoles.whereType<String>().toList(growable: false);
+      }
+    }
+    return const [];
+  }
+
+  static String? _asString(Object? v) => v is String ? v : null;
+}

--- a/ui/runtime/lib/src/oauth/oauth_flow.dart
+++ b/ui/runtime/lib/src/oauth/oauth_flow.dart
@@ -1,0 +1,105 @@
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:flutter_appauth/flutter_appauth.dart';
+
+/// Result returned from a completed OAuth leg.
+///
+/// Callers hand this back to [TokenWorker.completeAuth] for the
+/// `authorization_code` grant. [verifier] is the PKCE verifier
+/// flutter_appauth generated and tracked end-to-end.
+class OAuthResult {
+  const OAuthResult({
+    required this.code,
+    required this.verifier,
+    this.state,
+    this.nonce,
+  });
+
+  final String code;
+  final String verifier;
+  final String? state;
+  final String? nonce;
+}
+
+/// Wraps `flutter_appauth` into the runtime's error model.
+///
+/// **Deviation from plan**: the plan originally sketched `authorize`
+/// taking the verifier + state from the runtime. `flutter_appauth`
+/// 8.0.0's `AuthorizationRequest` does not expose a `codeVerifier`
+/// parameter — it generates its own and returns it on the response. We
+/// therefore let the plugin own PKCE for the browser leg and surface the
+/// verifier via [OAuthResult.verifier]. The rest of the pipeline
+/// (TokenWorker.completeAuth) consumes that verifier verbatim.
+class OAuthFlow {
+  OAuthFlow({
+    FlutterAppAuth? appAuth,
+    DiscoveryClientFn? discoveryFn,
+  })  : _appAuth = appAuth ?? const FlutterAppAuth(),
+        _discoveryFn = discoveryFn ?? _defaultDiscoveryFn;
+
+  final FlutterAppAuth _appAuth;
+  final DiscoveryClientFn _discoveryFn;
+
+  /// Drives the browser leg: opens a system browser or authentication
+  /// session, returns the authorisation code + PKCE verifier.
+  ///
+  /// Maps `FlutterAppAuth` exceptions to runtime [AuthError]s:
+  /// - [FlutterAppAuthUserCancelledException] → `oauthUserCanceled`
+  /// - everything else → `oauthFailed`
+  Future<OAuthResult> authorize(ResolvedConfig cfg) async {
+    final discovery = await _discoveryFn(cfg);
+
+    final request = AuthorizationRequest(
+      cfg.clientId,
+      cfg.redirectUri,
+      serviceConfiguration: AuthorizationServiceConfiguration(
+        authorizationEndpoint: discovery.authorizationEndpoint,
+        tokenEndpoint: discovery.tokenEndpoint,
+        endSessionEndpoint: discovery.endSessionEndpoint,
+      ),
+      scopes: cfg.scopes,
+      allowInsecureConnections: false,
+    );
+
+    AuthorizationResponse response;
+    try {
+      response = await _appAuth.authorize(request);
+    } on FlutterAppAuthUserCancelledException catch (err) {
+      throw AuthError(
+        AuthErrorCode.oauthUserCanceled,
+        'user cancelled OAuth flow',
+        cause: err,
+      );
+    } catch (err) {
+      throw AuthError(
+        AuthErrorCode.oauthFailed,
+        'OAuth authorize failed',
+        cause: err,
+      );
+    }
+
+    final code = response.authorizationCode;
+    final verifier = response.codeVerifier;
+    if (code == null || verifier == null) {
+      throw AuthError(
+        AuthErrorCode.oauthFailed,
+        'OAuth response missing code or verifier',
+      );
+    }
+    return OAuthResult(
+      code: code,
+      verifier: verifier,
+      nonce: response.nonce,
+    );
+  }
+}
+
+/// Hook for injecting a discovery call in tests. Default implementation
+/// goes through the cached top-level [getDiscovery].
+typedef DiscoveryClientFn = Future<OidcDiscovery> Function(
+  ResolvedConfig cfg,
+);
+
+Future<OidcDiscovery> _defaultDiscoveryFn(ResolvedConfig cfg) =>
+    getDiscovery(cfg.idpBaseUrl, cfg.discoveryTimeout);

--- a/ui/runtime/lib/src/protocol/api_proxy.dart
+++ b/ui/runtime/lib/src/protocol/api_proxy.dart
@@ -286,7 +286,7 @@ Future<Uint8List> _drain(Stream<List<int>> stream, int length) async {
 
 List<int>? _normalizeBody(Object? body) {
   if (body == null) return null;
-  if (body is String) return body.codeUnits;
+  if (body is String) return utf8.encode(body);
   if (body is List<int>) return body;
   if (body is Uint8List) return body;
   throw AuthError(

--- a/ui/runtime/lib/src/protocol/api_proxy.dart
+++ b/ui/runtime/lib/src/protocol/api_proxy.dart
@@ -1,0 +1,321 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:antinvestor_auth_runtime/src/models/token_set.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:http/http.dart' as http;
+import 'package:http_parser/http_parser.dart' show MediaType;
+
+/// Snapshot returned by [TokenProvider.ensureFresh].
+class TokenSnapshot {
+  const TokenSnapshot({
+    required this.accessToken,
+    required this.tokenType,
+  });
+
+  final String accessToken;
+  final TokenType tokenType;
+}
+
+/// Interface implemented by the runtime's session-holder.
+///
+/// The proxy never sees the full [TokenSet] — only the access token and
+/// type. `onRefresh` is fired once per forced refresh so the runtime
+/// can emit telemetry.
+abstract class TokenProvider {
+  Future<TokenSnapshot> ensureFresh({bool force = false});
+
+  void onRefresh();
+}
+
+/// Authenticated HTTP client wrapper for JS parity.
+///
+/// Behaviour matches `@stawi/auth-runtime`'s `api-proxy.ts`:
+/// 1. Attach `Authorization: Bearer <token>` or `DPoP <token>` + `DPoP`
+///    proof header depending on [TokenSnapshot.tokenType].
+/// 2. On 401 with `DPoP-Nonce`, retry once using the refreshed nonce.
+/// 3. On persistent 401, force a token refresh and retry once.
+/// 4. Map HTTP status to `AuthError(apiXxx)` codes on failure.
+class ApiProxy {
+  ApiProxy({http.Client? client}) : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  /// Performs an authenticated HTTP call. Returns an [ApiResponse] on
+  /// success; throws [AuthError] otherwise.
+  Future<ApiResponse> fetch(
+    ResolvedConfig cfg,
+    DpopContext ctx,
+    TokenProvider tp, {
+    required String path,
+    required String method,
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    final url = '${cfg.apiBaseUrl}$path';
+    final uri = Uri.parse(url);
+    final effectiveTimeout = timeout ?? cfg.apiTimeout;
+    final methodUpper = method.toUpperCase();
+
+    Future<http.Response> doCall(TokenSnapshot snapshot) async {
+      final h = <String, String>{...?headers};
+      h['Authorization'] = '${snapshot.tokenType.headerValue} '
+          '${snapshot.accessToken}';
+      h.putIfAbsent('Accept', () => 'application/json');
+      if (snapshot.tokenType == TokenType.dpop) {
+        h['DPoP'] = await buildProof(
+          ctx,
+          htm: methodUpper,
+          htu: url,
+          accessToken: snapshot.accessToken,
+        );
+      }
+      if (body is String && !_hasContentType(h)) {
+        h['Content-Type'] = 'application/json';
+      }
+      final bodyBytes = _normalizeBody(body);
+      return _sendRequest(
+        method: methodUpper,
+        uri: uri,
+        headers: h,
+        body: bodyBytes,
+        timeout: effectiveTimeout,
+      );
+    }
+
+    try {
+      final initial = await tp.ensureFresh();
+      var res = await doCall(initial);
+      rememberNonce(ctx, url, res.headers);
+
+      if (res.statusCode == 401 &&
+          _headerIgnoreCase(res.headers, 'dpop-nonce') != null) {
+        res = await doCall(initial);
+        rememberNonce(ctx, url, res.headers);
+      }
+
+      if (res.statusCode == 401) {
+        final fresh = await tp.ensureFresh(force: true);
+        tp.onRefresh();
+        res = await doCall(fresh);
+        rememberNonce(ctx, url, res.headers);
+      }
+
+      return _mapResponse(res);
+    } on TimeoutException catch (err) {
+      throw AuthError(
+        AuthErrorCode.networkTimeout,
+        'API timeout $url',
+        cause: err,
+      );
+    } on AuthError {
+      rethrow;
+    } catch (err) {
+      throw AuthError(
+        AuthErrorCode.networkError,
+        'API network error $url',
+        cause: err,
+      );
+    }
+  }
+
+  /// Performs an authenticated multipart upload. Returns the same
+  /// [ApiResponse] contract as [fetch].
+  Future<ApiResponse> upload(
+    ResolvedConfig cfg,
+    DpopContext ctx,
+    TokenProvider tp, {
+    required String path,
+    required String fieldName,
+    required String filename,
+    required String contentType,
+    required Stream<List<int>> bytes,
+    required int length,
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    final url = '${cfg.apiBaseUrl}$path';
+    final uri = Uri.parse(url);
+    final effectiveTimeout = timeout ?? cfg.uploadTimeout;
+
+    // A stream can only be consumed once; buffer into memory so we can
+    // retry on 401. Production callers that need to avoid buffering
+    // large files should retry at a higher layer.
+    final buffered = await _drain(bytes, length);
+
+    Future<http.StreamedResponse> doCall(TokenSnapshot snapshot) async {
+      final req = http.MultipartRequest('POST', uri);
+      req.headers.addAll(headers ?? const {});
+      req.headers['Authorization'] = '${snapshot.tokenType.headerValue} '
+          '${snapshot.accessToken}';
+      if (snapshot.tokenType == TokenType.dpop) {
+        req.headers['DPoP'] = await buildProof(
+          ctx,
+          htm: 'POST',
+          htu: url,
+          accessToken: snapshot.accessToken,
+        );
+      }
+      req.files.add(http.MultipartFile.fromBytes(
+        fieldName,
+        buffered,
+        filename: filename,
+        contentType: _parseMediaType(contentType),
+      ));
+      return _client.send(req).timeout(effectiveTimeout);
+    }
+
+    try {
+      final initial = await tp.ensureFresh();
+      var streamed = await doCall(initial);
+      if (streamed.statusCode == 401) {
+        final fresh = await tp.ensureFresh(force: true);
+        tp.onRefresh();
+        streamed = await doCall(fresh);
+      }
+      final res = await http.Response.fromStream(streamed);
+      rememberNonce(ctx, url, res.headers);
+      return _mapResponse(res);
+    } on TimeoutException catch (err) {
+      throw AuthError(
+        AuthErrorCode.networkTimeout,
+        'upload timeout $url',
+        cause: err,
+      );
+    } on AuthError {
+      rethrow;
+    } catch (err) {
+      throw AuthError(
+        AuthErrorCode.networkError,
+        'upload network error $url',
+        cause: err,
+      );
+    }
+  }
+
+  Future<http.Response> _sendRequest({
+    required String method,
+    required Uri uri,
+    required Map<String, String> headers,
+    required List<int>? body,
+    required Duration timeout,
+  }) {
+    switch (method) {
+      case 'GET':
+        return _client.get(uri, headers: headers).timeout(timeout);
+      case 'DELETE':
+        return _client.delete(uri, headers: headers, body: body).timeout(timeout);
+      case 'HEAD':
+        return _client.head(uri, headers: headers).timeout(timeout);
+      case 'POST':
+        return _client.post(uri, headers: headers, body: body).timeout(timeout);
+      case 'PUT':
+        return _client.put(uri, headers: headers, body: body).timeout(timeout);
+      case 'PATCH':
+        return _client
+            .patch(uri, headers: headers, body: body)
+            .timeout(timeout);
+      default:
+        final req = http.Request(method, uri);
+        req.headers.addAll(headers);
+        if (body != null) req.bodyBytes = Uint8List.fromList(body);
+        return _client
+            .send(req)
+            .timeout(timeout)
+            .then(http.Response.fromStream);
+    }
+  }
+
+  ApiResponse _mapResponse(http.Response res) {
+    if (res.statusCode == 204) {
+      return ApiResponse(
+        status: 204,
+        headers: res.headers,
+        body: Uint8List(0),
+      );
+    }
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      return ApiResponse(
+        status: res.statusCode,
+        headers: res.headers,
+        body: Uint8List.fromList(res.bodyBytes),
+      );
+    }
+    final code = _mapErrorCode(res.statusCode);
+    throw AuthError(
+      code,
+      'API ${res.statusCode}: ${_truncate(res.body)}',
+      traceId: _headerIgnoreCase(res.headers, 'x-trace-id'),
+    );
+  }
+
+  AuthErrorCode _mapErrorCode(int status) {
+    if (status == 401) return AuthErrorCode.apiUnauthorized;
+    if (status == 403) return AuthErrorCode.apiForbidden;
+    if (status == 404) return AuthErrorCode.apiNotFound;
+    if (status >= 500) return AuthErrorCode.apiServerError;
+    return AuthErrorCode.apiValidation;
+  }
+}
+
+Future<Uint8List> _drain(Stream<List<int>> stream, int length) async {
+  final out = Uint8List(length);
+  var offset = 0;
+  await for (final chunk in stream) {
+    if (offset + chunk.length > length) {
+      throw AuthError(
+        AuthErrorCode.apiValidation,
+        'upload stream exceeded declared length',
+      );
+    }
+    out.setRange(offset, offset + chunk.length, chunk);
+    offset += chunk.length;
+  }
+  if (offset != length) {
+    throw AuthError(
+      AuthErrorCode.apiValidation,
+      'upload stream shorter than declared length',
+    );
+  }
+  return out;
+}
+
+List<int>? _normalizeBody(Object? body) {
+  if (body == null) return null;
+  if (body is String) return body.codeUnits;
+  if (body is List<int>) return body;
+  if (body is Uint8List) return body;
+  throw AuthError(
+    AuthErrorCode.apiValidation,
+    'unsupported body type: ${body.runtimeType}',
+  );
+}
+
+bool _hasContentType(Map<String, String> headers) {
+  for (final key in headers.keys) {
+    if (key.toLowerCase() == 'content-type') return true;
+  }
+  return false;
+}
+
+String? _headerIgnoreCase(Map<String, String> headers, String name) {
+  final lower = name.toLowerCase();
+  for (final e in headers.entries) {
+    if (e.key.toLowerCase() == lower) return e.value;
+  }
+  return null;
+}
+
+String _truncate(String s) => s.length > 200 ? s.substring(0, 200) : s;
+
+MediaType? _parseMediaType(String raw) {
+  try {
+    return MediaType.parse(raw);
+  } catch (_) {
+    return null;
+  }
+}

--- a/ui/runtime/lib/src/protocol/discovery.dart
+++ b/ui/runtime/lib/src/protocol/discovery.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:http/http.dart' as http;
+
+/// OIDC discovery document — only the fields the runtime consumes.
+class OidcDiscovery {
+  const OidcDiscovery({
+    required this.issuer,
+    required this.authorizationEndpoint,
+    required this.tokenEndpoint,
+    this.endSessionEndpoint,
+    this.revocationEndpoint,
+    this.userinfoEndpoint,
+    this.jwksUri,
+    this.dpopSigningAlgValuesSupported,
+  });
+
+  final String issuer;
+  final String authorizationEndpoint;
+  final String tokenEndpoint;
+  final String? endSessionEndpoint;
+  final String? revocationEndpoint;
+  final String? userinfoEndpoint;
+  final String? jwksUri;
+  final List<String>? dpopSigningAlgValuesSupported;
+
+  /// Parses a discovery JSON map. Returns null if a required field is
+  /// missing or of the wrong type.
+  static OidcDiscovery? tryFromJson(Map<String, dynamic> json) {
+    final issuer = json['issuer'];
+    final authz = json['authorization_endpoint'];
+    final tokenEp = json['token_endpoint'];
+    if (issuer is! String || authz is! String || tokenEp is! String) {
+      return null;
+    }
+    final dpop = json['dpop_signing_alg_values_supported'];
+    return OidcDiscovery(
+      issuer: issuer,
+      authorizationEndpoint: authz,
+      tokenEndpoint: tokenEp,
+      endSessionEndpoint: _asString(json['end_session_endpoint']),
+      revocationEndpoint: _asString(json['revocation_endpoint']),
+      userinfoEndpoint: _asString(json['userinfo_endpoint']),
+      jwksUri: _asString(json['jwks_uri']),
+      dpopSigningAlgValuesSupported:
+          dpop is List ? dpop.whereType<String>().toList() : null,
+    );
+  }
+
+  /// Throws on malformed input — use [tryFromJson] for soft parsing.
+  static OidcDiscovery fromJson(Map<String, dynamic> json) {
+    final d = tryFromJson(json);
+    if (d == null) {
+      throw const FormatException('discovery document missing required fields');
+    }
+    return d;
+  }
+
+  static String? _asString(Object? v) => v is String ? v : null;
+}
+
+/// Returns true iff the IdP advertises ES256 support for DPoP.
+bool supportsDpop(OidcDiscovery d) =>
+    (d.dpopSigningAlgValuesSupported ?? const []).contains('ES256');
+
+final Map<String, OidcDiscovery> _cache = {};
+final Map<String, Future<OidcDiscovery>> _inflight = {};
+
+/// Visible for testing — wipes module-level cache + in-flight map.
+void clearDiscoveryCache() {
+  _cache.clear();
+  _inflight.clear();
+}
+
+/// Fetches (and caches) the OIDC discovery document for [idpBaseUrl].
+///
+/// Concurrent callers for the same URL share one in-flight HTTP request.
+/// Failures are NOT cached. Pass a [http.Client] (typically
+/// `MockClient`) under test — production code uses `http.Client()`.
+Future<OidcDiscovery> getDiscovery(
+  String idpBaseUrl,
+  Duration timeout, {
+  http.Client? client,
+}) {
+  final key = _stripTrailingSlash(idpBaseUrl);
+  final cached = _cache[key];
+  if (cached != null) return Future.value(cached);
+  final pending = _inflight[key];
+  if (pending != null) return pending;
+
+  final future = _doFetch(key, timeout, client ?? http.Client())
+      .then<OidcDiscovery>((doc) {
+    _cache[key] = doc;
+    return doc;
+  }).whenComplete(() {
+    _inflight.remove(key);
+  });
+  _inflight[key] = future;
+  return future;
+}
+
+Future<OidcDiscovery> _doFetch(
+  String idp,
+  Duration timeout,
+  http.Client client,
+) async {
+  final url = Uri.parse('$idp/.well-known/openid-configuration');
+  http.Response res;
+  try {
+    res = await client.get(url).timeout(timeout);
+  } on TimeoutException catch (err) {
+    throw AuthError(
+      AuthErrorCode.networkTimeout,
+      'discovery timeout $url',
+      cause: err,
+    );
+  } catch (err) {
+    throw AuthError(
+      AuthErrorCode.discoveryFailed,
+      'discovery fetch failed $url',
+      cause: err,
+    );
+  }
+  if (res.statusCode < 200 || res.statusCode >= 300) {
+    throw AuthError(
+      AuthErrorCode.discoveryFailed,
+      'discovery HTTP ${res.statusCode} $url',
+    );
+  }
+  Map<String, dynamic> body;
+  try {
+    final decoded = json.decode(res.body);
+    if (decoded is! Map) {
+      throw const FormatException('discovery body is not a JSON object');
+    }
+    body = decoded.cast<String, dynamic>();
+  } catch (err) {
+    throw AuthError(
+      AuthErrorCode.discoveryFailed,
+      'discovery non-JSON $url',
+      cause: err,
+    );
+  }
+  final parsed = OidcDiscovery.tryFromJson(body);
+  if (parsed == null) {
+    throw AuthError(
+      AuthErrorCode.discoveryFailed,
+      'discovery missing fields $url',
+    );
+  }
+  return parsed;
+}
+
+String _stripTrailingSlash(String s) {
+  var end = s.length;
+  while (end > 0 && s.codeUnitAt(end - 1) == 0x2F) {
+    end--;
+  }
+  return s.substring(0, end);
+}

--- a/ui/runtime/lib/src/protocol/dpop.dart
+++ b/ui/runtime/lib/src/protocol/dpop.dart
@@ -1,0 +1,253 @@
+import 'dart:convert';
+import 'dart:io' show HttpDate;
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/protocol/pkce.dart'
+    show randomBytes;
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:pointycastle/export.dart' as pc;
+
+/// Opaque handle for a P-256 key pair owned by the runtime.
+///
+/// The concrete backing is [pc.ECPrivateKey] + [pc.ECPublicKey] from
+/// PointyCastle; callers should treat this as opaque — private material
+/// never leaves the runtime.
+class DpopKeyPair {
+  DpopKeyPair({
+    required this.privateKey,
+    required this.publicKey,
+  });
+
+  final pc.ECPrivateKey privateKey;
+  final pc.ECPublicKey publicKey;
+}
+
+/// Generates a fresh ECDSA P-256 key pair suitable for DPoP proofs.
+///
+/// The plan mandates ECDSA P-256 via `package:cryptography`'s
+/// `Ecdsa.p256(Sha256())`. That backend's pure-Dart implementation
+/// raises [UnimplementedError] for ECDSA (see `DartEcdsa`), so no
+/// signing is possible in `flutter_test` without a platform-native
+/// plugin. We therefore use `package:pointycastle` — a pure-Dart
+/// implementation that works uniformly across Dart VM, web, and native
+/// — and encode output to the same JWS ES256 (raw r||s) shape the plan
+/// requires. [DpopKeyPair] is the runtime's stable handle so the
+/// backend can be swapped without touching callers.
+DpopKeyPair generateDpopKeyPair() {
+  final keyGen = pc.ECKeyGenerator();
+  final random = _secureRandom();
+  keyGen.init(pc.ParametersWithRandom(
+    pc.ECKeyGeneratorParameters(pc.ECCurve_secp256r1()),
+    random,
+  ));
+  final pair = keyGen.generateKeyPair();
+  return DpopKeyPair(
+    privateKey: pair.privateKey as pc.ECPrivateKey,
+    publicKey: pair.publicKey as pc.ECPublicKey,
+  );
+}
+
+/// DPoP signing context held for the lifetime of an authenticated session.
+///
+/// Contains the private key used to sign proofs, the matching public JWK
+/// (embedded in every proof header), the accumulated `clockOffsetMs` from
+/// IdP-served `Date` headers, and the per-origin nonce cache.
+class DpopContext {
+  DpopContext({
+    required this.keyPair,
+    required this.publicJwk,
+  });
+
+  /// ECDSA P-256 key pair. Kept in memory only — never serialised by
+  /// this class.
+  final DpopKeyPair keyPair;
+
+  /// Public JWK `{kty, crv, x, y}` inserted into the proof header.
+  final Map<String, String> publicJwk;
+
+  /// Server-clock minus local-clock, in milliseconds. Applied to `iat`.
+  int clockOffsetMs = 0;
+
+  /// Nonce keyed by origin of the request URL.
+  final Map<String, String> nonceByOrigin = {};
+}
+
+/// Derives a [DpopContext] from an existing P-256 key pair.
+DpopContext makeDpopContext(DpopKeyPair kp) {
+  final q = kp.publicKey.Q!;
+  // P-256 component size: 32 bytes. Left-pad BigInts to fixed width so
+  // JWK encoding matches RFC 7518 §6.2.1.
+  final xBytes = _bigIntToFixedBytes(q.x!.toBigInteger()!, 32);
+  final yBytes = _bigIntToFixedBytes(q.y!.toBigInteger()!, 32);
+  final jwk = <String, String>{
+    'kty': 'EC',
+    'crv': 'P-256',
+    'x': _b64urlNoPad(xBytes),
+    'y': _b64urlNoPad(yBytes),
+  };
+  return DpopContext(keyPair: kp, publicJwk: jwk);
+}
+
+/// Remembers a server-issued DPoP nonce for later proofs aimed at the
+/// same origin. Accepts both `DPoP-Nonce` casings.
+void rememberNonce(
+  DpopContext ctx,
+  String audienceUrl,
+  Map<String, String> headers,
+) {
+  final value = _headerIgnoreCase(headers, 'dpop-nonce');
+  if (value == null) return;
+  ctx.nonceByOrigin[_originOf(audienceUrl)] = value;
+}
+
+/// Adjusts [DpopContext.clockOffsetMs] based on the HTTP `Date` response
+/// header. Malformed/absent headers are ignored.
+void rememberClockOffset(
+  DpopContext ctx,
+  Map<String, String> headers,
+) {
+  final dateHeader = _headerIgnoreCase(headers, 'date');
+  if (dateHeader == null) return;
+  final parsed = _tryParseHttpDate(dateHeader);
+  if (parsed == null) return;
+  ctx.clockOffsetMs = parsed.millisecondsSinceEpoch -
+      DateTime.now().millisecondsSinceEpoch;
+}
+
+/// Builds a DPoP proof JWT for the given request.
+///
+/// When [accessToken] is supplied the `ath` claim (access-token hash) is
+/// included — required for resource-server requests per the DPoP RFC.
+/// When a nonce has been remembered for the URL's origin it is embedded.
+Future<String> buildProof(
+  DpopContext ctx, {
+  required String htm,
+  required String htu,
+  String? accessToken,
+}) async {
+  final header = <String, dynamic>{
+    'typ': 'dpop+jwt',
+    'alg': 'ES256',
+    'jwk': ctx.publicJwk,
+  };
+
+  final nowMs = DateTime.now().millisecondsSinceEpoch + ctx.clockOffsetMs;
+  final payload = <String, dynamic>{
+    'htm': htm.toUpperCase(),
+    'htu': htu,
+    'iat': nowMs ~/ 1000,
+    'jti': _b64urlNoPad(randomBytes(16)),
+  };
+  if (accessToken != null) {
+    payload['ath'] =
+        _b64urlNoPad(crypto.sha256.convert(utf8.encode(accessToken)).bytes);
+  }
+  final nonce = ctx.nonceByOrigin[_originOf(htu)];
+  if (nonce != null) {
+    payload['nonce'] = nonce;
+  }
+
+  final headerB64 = _b64urlNoPad(utf8.encode(json.encode(header)));
+  final payloadB64 = _b64urlNoPad(utf8.encode(json.encode(payload)));
+  final signingInput = '$headerB64.$payloadB64';
+
+  final signature = _signEcdsa(
+    ctx.keyPair.privateKey,
+    Uint8List.fromList(utf8.encode(signingInput)),
+  );
+  return '$signingInput.${_b64urlNoPad(signature)}';
+}
+
+/// Signs [message] with SHA-256 ECDSA over P-256 using RFC 6979
+/// deterministic k, returning the JWS-compatible raw r||s encoding.
+Uint8List _signEcdsa(pc.ECPrivateKey priv, Uint8List message) {
+  final signer = pc.ECDSASigner(
+    pc.SHA256Digest(),
+    pc.HMac.withDigest(pc.SHA256Digest()),
+  )..init(
+      true,
+      pc.PrivateKeyParameter<pc.ECPrivateKey>(priv),
+    );
+  final sig = signer.generateSignature(message) as pc.ECSignature;
+  // JWS ES256 format: 32-byte r || 32-byte s, left-padded.
+  return Uint8List.fromList([
+    ..._bigIntToFixedBytes(sig.r, 32),
+    ..._bigIntToFixedBytes(sig.s, 32),
+  ]);
+}
+
+/// Verifies a raw r||s ECDSA signature against [message] using the
+/// public key. Exposed so the runtime's tests can self-check the
+/// builder output without a real IdP.
+bool verifyEcdsaRaw(
+  pc.ECPublicKey pub,
+  Uint8List message,
+  Uint8List signature,
+) {
+  if (signature.length != 64) return false;
+  final r = _bytesToBigInt(signature.sublist(0, 32));
+  final s = _bytesToBigInt(signature.sublist(32, 64));
+  final verifier = pc.ECDSASigner(pc.SHA256Digest())
+    ..init(false, pc.PublicKeyParameter<pc.ECPublicKey>(pub));
+  return verifier.verifySignature(message, pc.ECSignature(r, s));
+}
+
+/// Left-pads a positive [BigInt] to exactly [size] bytes.
+Uint8List _bigIntToFixedBytes(BigInt value, int size) {
+  final bytes = Uint8List(size);
+  var v = value;
+  for (var i = size - 1; i >= 0; i--) {
+    bytes[i] = (v & BigInt.from(0xff)).toInt();
+    v = v >> 8;
+  }
+  return bytes;
+}
+
+BigInt _bytesToBigInt(Uint8List bytes) {
+  var result = BigInt.zero;
+  for (final b in bytes) {
+    result = (result << 8) | BigInt.from(b);
+  }
+  return result;
+}
+
+String _b64urlNoPad(List<int> bytes) =>
+    base64Url.encode(bytes).replaceAll('=', '');
+
+String _originOf(String url) {
+  try {
+    final uri = Uri.parse(url);
+    final port = uri.hasPort ? ':${uri.port}' : '';
+    return '${uri.scheme}://${uri.host}$port';
+  } catch (_) {
+    return url;
+  }
+}
+
+String? _headerIgnoreCase(Map<String, String> headers, String name) {
+  final lower = name.toLowerCase();
+  for (final e in headers.entries) {
+    if (e.key.toLowerCase() == lower) return e.value;
+  }
+  return null;
+}
+
+DateTime? _tryParseHttpDate(String s) {
+  try {
+    return HttpDate.parse(s);
+  } catch (_) {
+    try {
+      return DateTime.parse(s);
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+/// Seeds a PointyCastle CSPRNG from `Random.secure()`.
+pc.SecureRandom _secureRandom() {
+  final rand = pc.SecureRandom('Fortuna');
+  final seed = randomBytes(32);
+  rand.seed(pc.KeyParameter(seed));
+  return rand;
+}

--- a/ui/runtime/lib/src/protocol/dpop.dart
+++ b/ui/runtime/lib/src/protocol/dpop.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io' show HttpDate;
 import 'dart:typed_data';
 
+import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/protocol/pkce.dart'
     show randomBytes;
 import 'package:crypto/crypto.dart' as crypto;
@@ -52,10 +53,16 @@ DpopKeyPair generateDpopKeyPair() {
 /// Contains the private key used to sign proofs, the matching public JWK
 /// (embedded in every proof header), the accumulated `clockOffsetMs` from
 /// IdP-served `Date` headers, and the per-origin nonce cache.
+///
+/// An optional [keyManager] may be supplied to delegate signing to an
+/// injected backend. When absent, [buildProof] falls back to the built-in
+/// PointyCastle signer — preserving the original F-B.4 call path so
+/// pre-KeyManager callers keep working.
 class DpopContext {
   DpopContext({
     required this.keyPair,
     required this.publicJwk,
+    this.keyManager,
   });
 
   /// ECDSA P-256 key pair. Kept in memory only — never serialised by
@@ -63,7 +70,11 @@ class DpopContext {
   final DpopKeyPair keyPair;
 
   /// Public JWK `{kty, crv, x, y}` inserted into the proof header.
-  final Map<String, String> publicJwk;
+  final Map<String, dynamic> publicJwk;
+
+  /// Optional injected signer. When non-null, [buildProof] delegates
+  /// ECDSA signing to `keyManager.signDpopJws`.
+  final KeyManager? keyManager;
 
   /// Server-clock minus local-clock, in milliseconds. Applied to `iat`.
   int clockOffsetMs = 0;
@@ -73,19 +84,42 @@ class DpopContext {
 }
 
 /// Derives a [DpopContext] from an existing P-256 key pair.
+///
+/// If [keyManager] is supplied it is stored on the context and used
+/// for subsequent signing operations. The JWK export also goes through
+/// the key manager so tests can swap in synthetic backends.
+Future<DpopContext> makeDpopContextAsync(
+  DpopKeyPair kp, {
+  KeyManager? keyManager,
+}) async {
+  final Map<String, dynamic> jwk;
+  if (keyManager != null) {
+    jwk = await keyManager.exportDpopPublicJwk(kp);
+  } else {
+    jwk = _localExportJwk(kp);
+  }
+  return DpopContext(keyPair: kp, publicJwk: jwk, keyManager: keyManager);
+}
+
+/// Synchronous convenience factory preserved for callers that predate
+/// F-C.1's [KeyManager] injection. Uses the built-in PointyCastle path
+/// for JWK export.
 DpopContext makeDpopContext(DpopKeyPair kp) {
+  return DpopContext(keyPair: kp, publicJwk: _localExportJwk(kp));
+}
+
+Map<String, String> _localExportJwk(DpopKeyPair kp) {
   final q = kp.publicKey.Q!;
   // P-256 component size: 32 bytes. Left-pad BigInts to fixed width so
   // JWK encoding matches RFC 7518 §6.2.1.
   final xBytes = _bigIntToFixedBytes(q.x!.toBigInteger()!, 32);
   final yBytes = _bigIntToFixedBytes(q.y!.toBigInteger()!, 32);
-  final jwk = <String, String>{
+  return <String, String>{
     'kty': 'EC',
     'crv': 'P-256',
     'x': _b64urlNoPad(xBytes),
     'y': _b64urlNoPad(yBytes),
   };
-  return DpopContext(keyPair: kp, publicJwk: jwk);
 }
 
 /// Remembers a server-issued DPoP nonce for later proofs aimed at the
@@ -151,10 +185,16 @@ Future<String> buildProof(
   final payloadB64 = _b64urlNoPad(utf8.encode(json.encode(payload)));
   final signingInput = '$headerB64.$payloadB64';
 
-  final signature = _signEcdsa(
-    ctx.keyPair.privateKey,
-    Uint8List.fromList(utf8.encode(signingInput)),
-  );
+  final Uint8List signature;
+  final km = ctx.keyManager;
+  if (km != null) {
+    signature = await km.signDpopJws(ctx.keyPair, signingInput);
+  } else {
+    signature = _signEcdsa(
+      ctx.keyPair.privateKey,
+      Uint8List.fromList(utf8.encode(signingInput)),
+    );
+  }
   return '$signingInput.${_b64urlNoPad(signature)}';
 }
 

--- a/ui/runtime/lib/src/protocol/jwt.dart
+++ b/ui/runtime/lib/src/protocol/jwt.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+/// Decodes the payload segment of a compact-serialised JWT.
+///
+/// Does NOT verify signature — verification is the IdP's job; we only
+/// read claims. Matches the JS runtime's base64url padding recovery.
+Map<String, dynamic> decodeJwtPayload(String token) {
+  final parts = token.split('.');
+  if (parts.length != 3) {
+    throw const FormatException('Invalid JWT: expected 3 parts');
+  }
+  final normalized = _padBase64Url(parts[1]);
+  final bytes = base64Url.decode(normalized);
+  final decoded = json.decode(utf8.decode(bytes));
+  if (decoded is! Map) {
+    throw const FormatException('Invalid JWT payload: not a JSON object');
+  }
+  return decoded.cast<String, dynamic>();
+}
+
+/// Extracts roles using Hydra-compatible claim paths.
+///
+/// Looks at `roles` first, then `realm_access.roles`. Returns an empty
+/// list on any decode failure — role extraction is best-effort.
+List<String> extractRolesFromToken(String token) {
+  try {
+    final payload = decodeJwtPayload(token);
+    final direct = payload['roles'];
+    if (direct is List) {
+      return direct.whereType<String>().toList(growable: false);
+    }
+    final realm = payload['realm_access'];
+    if (realm is Map) {
+      final realmRoles = realm['roles'];
+      if (realmRoles is List) {
+        return realmRoles.whereType<String>().toList(growable: false);
+      }
+    }
+    return const [];
+  } on FormatException {
+    return const [];
+  } catch (_) {
+    return const [];
+  }
+}
+
+String _padBase64Url(String input) {
+  final mod = input.length % 4;
+  if (mod == 0) return input;
+  if (mod == 2) return '$input==';
+  if (mod == 3) return '$input=';
+  throw const FormatException('Invalid base64url length');
+}

--- a/ui/runtime/lib/src/protocol/pkce.dart
+++ b/ui/runtime/lib/src/protocol/pkce.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+/// PKCE verifier + `S256` challenge pair.
+class PkcePair {
+  const PkcePair({required this.verifier, required this.challenge});
+
+  final String verifier;
+  final String challenge;
+}
+
+/// Returns [n] bytes sourced from `Random.secure()` — the only
+/// cryptographic RNG exposed by the Dart core library.
+Uint8List randomBytes(int n) {
+  final rng = Random.secure();
+  final out = Uint8List(n);
+  for (var i = 0; i < n; i++) {
+    out[i] = rng.nextInt(256);
+  }
+  return out;
+}
+
+/// Generates a PKCE verifier. Default 64 bytes matches the JS runtime
+/// and yields a 43-char base64url output (minimum size allowed by RFC 7636).
+String generateVerifier([int length = 64]) {
+  return _base64Url(randomBytes(length));
+}
+
+/// Computes the S256 challenge for [verifier].
+Future<String> computeChallenge(String verifier) async {
+  final digest = sha256.convert(utf8.encode(verifier));
+  return _base64Url(Uint8List.fromList(digest.bytes));
+}
+
+/// Convenience: verifier + matching challenge.
+Future<PkcePair> generatePkcePair() async {
+  final verifier = generateVerifier();
+  final challenge = await computeChallenge(verifier);
+  return PkcePair(verifier: verifier, challenge: challenge);
+}
+
+String _base64Url(Uint8List bytes) {
+  return base64Url.encode(bytes).replaceAll('=', '');
+}

--- a/ui/runtime/lib/src/protocol/token_exchange.dart
+++ b/ui/runtime/lib/src/protocol/token_exchange.dart
@@ -1,0 +1,248 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/token_set.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:http/http.dart' as http;
+
+/// Sealed outcome of a refresh-token call. Callers should pattern-match.
+sealed class RefreshOutcome {
+  const RefreshOutcome();
+
+  const factory RefreshOutcome.rotated(TokenSet tokens) = RefreshRotated;
+  const factory RefreshOutcome.reuseDetected() = RefreshReuseDetectedOutcome;
+  const factory RefreshOutcome.networkError(AuthError error) =
+      RefreshNetworkError;
+}
+
+final class RefreshRotated extends RefreshOutcome {
+  const RefreshRotated(this.tokens);
+
+  final TokenSet tokens;
+}
+
+final class RefreshReuseDetectedOutcome extends RefreshOutcome {
+  const RefreshReuseDetectedOutcome();
+}
+
+final class RefreshNetworkError extends RefreshOutcome {
+  const RefreshNetworkError(this.error);
+
+  final AuthError error;
+}
+
+/// Wraps the IdP `/token` endpoint.
+///
+/// An injectable [http.Client] is the seam for unit tests — `MockClient`
+/// from `package:http/testing.dart` handles both discovery and token
+/// roundtrips. [timeout] is applied to every underlying request.
+class TokenExchange {
+  TokenExchange({
+    http.Client? client,
+    required this.timeout,
+  }) : _client = client ?? http.Client();
+
+  final http.Client _client;
+  final Duration timeout;
+
+  /// `authorization_code` grant after a successful OAuth leg.
+  Future<TokenSet> exchangeCode(
+    ResolvedConfig cfg,
+    DpopContext ctx, {
+    required String code,
+    required String verifier,
+  }) async {
+    final form = <String, String>{
+      'grant_type': 'authorization_code',
+      'client_id': cfg.clientId,
+      'code': code,
+      'redirect_uri': cfg.redirectUri,
+      'code_verifier': verifier,
+    };
+    final res = await _postForm(cfg, ctx, form);
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw AuthError(
+        AuthErrorCode.tokenExchangeFailed,
+        'token exchange failed ${res.statusCode} ${_truncate(res.body)}',
+      );
+    }
+    return _parseTokenBody(res.body);
+  }
+
+  /// `refresh_token` grant with rotation + reuse-detection semantics.
+  Future<RefreshOutcome> refresh(
+    ResolvedConfig cfg,
+    DpopContext ctx,
+    String refreshToken,
+  ) async {
+    try {
+      final form = <String, String>{
+        'grant_type': 'refresh_token',
+        'client_id': cfg.clientId,
+        'refresh_token': refreshToken,
+      };
+      final res = await _postForm(cfg, ctx, form);
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        return RefreshOutcome.rotated(_parseTokenBody(res.body));
+      }
+      if (res.statusCode == 400 && _mentionsReuse(res.body)) {
+        return const RefreshOutcome.reuseDetected();
+      }
+      return RefreshOutcome.networkError(AuthError(
+        AuthErrorCode.tokenRefreshFailed,
+        'refresh failed ${res.statusCode} ${_truncate(res.body)}',
+      ));
+    } on AuthError catch (e) {
+      return RefreshOutcome.networkError(e);
+    } catch (e) {
+      return RefreshOutcome.networkError(AuthError(
+        AuthErrorCode.tokenRefreshFailed,
+        'refresh failed',
+        cause: e,
+      ));
+    }
+  }
+
+  /// Posts [form] to the IdP token endpoint. Applies DPoP when the IdP
+  /// advertises support; implements the nonce-challenge and clock-skew
+  /// retries described in spec §6.
+  Future<http.Response> _postForm(
+    ResolvedConfig cfg,
+    DpopContext ctx,
+    Map<String, String> form,
+  ) async {
+    final discovery = await getDiscovery(
+      cfg.idpBaseUrl,
+      cfg.discoveryTimeout,
+      client: _client,
+    );
+    final useDpop = supportsDpop(discovery);
+    final tokenUri = Uri.parse(discovery.tokenEndpoint);
+
+    final body = _encodeForm(form);
+    Map<String, String> headers() => {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Accept': 'application/json',
+        };
+
+    Future<http.Response> send({String? dpopProof}) async {
+      final h = headers();
+      if (dpopProof != null) h['DPoP'] = dpopProof;
+      return _client
+          .post(tokenUri, headers: h, body: body)
+          .timeout(timeout);
+    }
+
+    http.Response res;
+    try {
+      final initialProof = useDpop
+          ? await buildProof(ctx, htm: 'POST', htu: discovery.tokenEndpoint)
+          : null;
+      res = await send(dpopProof: initialProof);
+
+      if (useDpop && res.statusCode == 401 &&
+          _headerIgnoreCase(res.headers, 'dpop-nonce') != null) {
+        rememberNonce(ctx, discovery.tokenEndpoint, res.headers);
+        final retryProof = await buildProof(
+          ctx,
+          htm: 'POST',
+          htu: discovery.tokenEndpoint,
+        );
+        res = await send(dpopProof: retryProof);
+      }
+
+      if (useDpop && res.statusCode == 400 &&
+          _mentionsInvalidDpopProof(res.body)) {
+        rememberClockOffset(ctx, res.headers);
+        final retryProof = await buildProof(
+          ctx,
+          htm: 'POST',
+          htu: discovery.tokenEndpoint,
+        );
+        res = await send(dpopProof: retryProof);
+      }
+
+      rememberNonce(ctx, discovery.tokenEndpoint, res.headers);
+      return res;
+    } on TimeoutException catch (err) {
+      throw AuthError(
+        AuthErrorCode.networkTimeout,
+        'token endpoint timeout',
+        cause: err,
+      );
+    } on AuthError {
+      rethrow;
+    } catch (err) {
+      throw AuthError(
+        AuthErrorCode.tokenExchangeFailed,
+        'token endpoint error',
+        cause: err,
+      );
+    }
+  }
+}
+
+TokenSet _parseTokenBody(String body) {
+  final Map<String, dynamic> data;
+  try {
+    final decoded = json.decode(body);
+    if (decoded is! Map) {
+      throw AuthError(
+        AuthErrorCode.tokenExchangeFailed,
+        'token response is not a JSON object',
+      );
+    }
+    data = decoded.cast<String, dynamic>();
+  } on FormatException catch (e) {
+    throw AuthError(
+      AuthErrorCode.tokenExchangeFailed,
+      'token response is not JSON',
+      cause: e,
+    );
+  }
+  final accessToken = data['access_token'];
+  final refreshToken = data['refresh_token'];
+  if (accessToken is! String || refreshToken is! String) {
+    throw AuthError(
+      AuthErrorCode.tokenExchangeFailed,
+      'missing access_token or refresh_token',
+    );
+  }
+  final expiresIn =
+      data['expires_in'] is int ? data['expires_in'] as int : 300;
+  final tokenType = TokenType.fromString(data['token_type'] as String?);
+  final idToken = data['id_token'] is String ? data['id_token'] as String : null;
+  return TokenSet(
+    accessToken: accessToken,
+    refreshToken: refreshToken,
+    expiresAt: DateTime.now().add(Duration(seconds: expiresIn)),
+    tokenType: tokenType,
+    idToken: idToken,
+  );
+}
+
+bool _mentionsReuse(String body) {
+  return RegExp(r'invalid_grant|reuse', caseSensitive: false).hasMatch(body);
+}
+
+bool _mentionsInvalidDpopProof(String body) {
+  return RegExp(r'invalid_dpop_proof', caseSensitive: false).hasMatch(body);
+}
+
+String _encodeForm(Map<String, String> form) => form.entries
+    .map((e) =>
+        '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}')
+    .join('&');
+
+String _truncate(String s) => s.length > 200 ? s.substring(0, 200) : s;
+
+String? _headerIgnoreCase(Map<String, String> headers, String name) {
+  final lower = name.toLowerCase();
+  for (final e in headers.entries) {
+    if (e.key.toLowerCase() == lower) return e.value;
+  }
+  return null;
+}

--- a/ui/runtime/lib/src/providers/auth_providers.dart
+++ b/ui/runtime/lib/src/providers/auth_providers.dart
@@ -1,0 +1,79 @@
+import 'package:antinvestor_auth_runtime/src/auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Entry point for reaching the [AuthRuntime] from a Riverpod tree.
+///
+/// Apps MUST override this provider at the root, typically like:
+///
+/// ```dart
+/// ProviderScope(
+///   overrides: [
+///     authRuntimeProvider.overrideWithValue(createAuthRuntime(cfg)),
+///   ],
+///   child: const MyApp(),
+/// )
+/// ```
+///
+/// The default throws so usage without the override surfaces
+/// immediately rather than silently yielding nulls.
+final authRuntimeProvider = Provider<AuthRuntime>(
+  (ref) => throw UnimplementedError(
+    'Override authRuntimeProvider at the app root with a concrete '
+    'AuthRuntime built via createAuthRuntime().',
+  ),
+);
+
+/// Current [AuthState] as a stream.
+///
+/// The stream is the runtime's own `authStateStream`. Callers can
+/// `watch` this provider to rebuild on state transitions without
+/// reaching into the runtime directly.
+final authStateProvider = StreamProvider<AuthState>(
+  (ref) => ref.watch(authRuntimeProvider).authStateStream,
+);
+
+/// `true` iff the current [AuthState] is [AuthState.authenticated].
+///
+/// While the stream is loading (pre-first-event) we conservatively
+/// report `false`: widgets built on this provider should assume the user
+/// is not signed in until the stream emits.
+final isAuthenticatedProvider = Provider<bool>(
+  (ref) {
+    final snap = ref.watch(authStateProvider);
+    return snap.value == AuthState.authenticated;
+  },
+);
+
+/// Decoded ID-token claims. Returns `{}` while unauthenticated so
+/// widgets don't have to special-case the pre-sign-in state.
+final userClaimsProvider = FutureProvider<Map<String, dynamic>>(
+  (ref) async {
+    final rt = ref.watch(authRuntimeProvider);
+    final snap = ref.watch(authStateProvider);
+    if (snap.value != AuthState.authenticated) {
+      return const <String, dynamic>{};
+    }
+    return rt.getClaims();
+  },
+);
+
+/// Roles extracted from the access token. Returns `[]` while
+/// unauthenticated.
+final rolesProvider = FutureProvider<List<String>>(
+  (ref) async {
+    final rt = ref.watch(authRuntimeProvider);
+    final snap = ref.watch(authStateProvider);
+    if (snap.value != AuthState.authenticated) {
+      return const <String>[];
+    }
+    return rt.getRoles();
+  },
+);
+
+/// Security events (refresh reuse, storage corruption, …). Typically
+/// piped into `AuthEventListener` to surface SnackBars / Dialogs.
+final securityEventsProvider = StreamProvider<SecurityEvent>(
+  (ref) => ref.watch(authRuntimeProvider).securityEventStream,
+);

--- a/ui/runtime/lib/src/providers/auth_runtime_scope.dart
+++ b/ui/runtime/lib/src/providers/auth_runtime_scope.dart
@@ -1,0 +1,47 @@
+import 'package:antinvestor_auth_runtime/src/auth_runtime.dart';
+import 'package:flutter/widgets.dart';
+
+/// Non-Riverpod alternative for exposing an [AuthRuntime] to descendants.
+///
+/// Apps that don't want a Riverpod root can wrap their widget tree in
+/// [AuthRuntimeScope] and pull the runtime out with
+/// `AuthRuntimeScope.of(context)`.
+///
+/// Updating the runtime after mount is supported: the scope fires a
+/// rebuild only when [runtime] actually differs, so hot-reloading with
+/// a fresh factory is cheap.
+class AuthRuntimeScope extends InheritedWidget {
+  const AuthRuntimeScope({
+    required this.runtime,
+    required super.child,
+    super.key,
+  });
+
+  final AuthRuntime runtime;
+
+  /// Retrieves the nearest [AuthRuntime] ancestor. Throws if missing so
+  /// usage bugs surface at call-site rather than later as a null deref.
+  static AuthRuntime of(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<AuthRuntimeScope>();
+    if (scope == null) {
+      throw FlutterError(
+        'AuthRuntimeScope.of(context) called without an ancestor '
+        'AuthRuntimeScope. Wrap your app with AuthRuntimeScope or use '
+        'Riverpod via authRuntimeProvider.',
+      );
+    }
+    return scope.runtime;
+  }
+
+  /// Non-throwing lookup. Returns `null` when no ancestor scope exists.
+  static AuthRuntime? maybeOf(BuildContext context) {
+    final scope =
+        context.dependOnInheritedWidgetOfExactType<AuthRuntimeScope>();
+    return scope?.runtime;
+  }
+
+  @override
+  bool updateShouldNotify(AuthRuntimeScope oldWidget) =>
+      !identical(runtime, oldWidget.runtime);
+}

--- a/ui/runtime/lib/src/runtime/refresh_lock.dart
+++ b/ui/runtime/lib/src/runtime/refresh_lock.dart
@@ -1,0 +1,20 @@
+import 'package:synchronized/synchronized.dart';
+
+/// Keyed async mutex used to serialize refresh-token calls per session.
+///
+/// A refresh-token grant must never race against itself for the same
+/// session: two concurrent rotations would cause the IdP to return
+/// `invalid_grant` on the loser (RT reuse). All operations keyed the same
+/// are serialised; different keys proceed in parallel so unrelated
+/// runtime instances don't block each other.
+///
+/// The lock is released even if [fn] throws so a failed refresh doesn't
+/// wedge subsequent attempts.
+class RefreshLock {
+  final Map<String, Lock> _locks = {};
+
+  Future<T> withLock<T>(String key, Future<T> Function() fn) {
+    final lock = _locks.putIfAbsent(key, Lock.new);
+    return lock.synchronized<T>(fn);
+  }
+}

--- a/ui/runtime/lib/src/runtime/state_machine.dart
+++ b/ui/runtime/lib/src/runtime/state_machine.dart
@@ -1,0 +1,128 @@
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+
+/// Input to the [reduce] function.
+///
+/// Sealed so the reducer can exhaustively switch and the compiler catches
+/// new variants at their call sites.
+sealed class StateInput {
+  const StateInput();
+
+  const factory StateInput.initDone({required bool hasTokens}) = InitDone;
+  const factory StateInput.signInStart() = SignInStart;
+  const factory StateInput.signInDone() = SignInDone;
+  const factory StateInput.signInFail(AuthError error) = SignInFail;
+  const factory StateInput.refreshStart() = RefreshStart;
+  const factory StateInput.refreshDone() = RefreshDone;
+  const factory StateInput.refreshFail({
+    required AuthError error,
+    required bool wipe,
+  }) = RefreshFail;
+  const factory StateInput.logout() = Logout;
+  const factory StateInput.securityWipe(String reason) = SecurityWipe;
+}
+
+final class InitDone extends StateInput {
+  const InitDone({required this.hasTokens});
+
+  final bool hasTokens;
+}
+
+final class SignInStart extends StateInput {
+  const SignInStart();
+}
+
+final class SignInDone extends StateInput {
+  const SignInDone();
+}
+
+final class SignInFail extends StateInput {
+  const SignInFail(this.error);
+
+  final AuthError error;
+}
+
+final class RefreshStart extends StateInput {
+  const RefreshStart();
+}
+
+final class RefreshDone extends StateInput {
+  const RefreshDone();
+}
+
+final class RefreshFail extends StateInput {
+  const RefreshFail({required this.error, required this.wipe});
+
+  final AuthError error;
+  final bool wipe;
+}
+
+final class Logout extends StateInput {
+  const Logout();
+}
+
+final class SecurityWipe extends StateInput {
+  const SecurityWipe(this.reason);
+
+  final String reason;
+}
+
+/// Pure reducer: given a current [state] and an [input], returns the next
+/// state. No side effects. Invariants enforced here:
+///
+/// * `securityWipe` always lands in `unauthenticated` regardless of the
+///   prior state (spec §8 wipe rule).
+/// * `refreshDone` only applies while `refreshing` (no-ops otherwise so
+///   late events from a cancelled refresh can't spuriously revive an
+///   authenticated session).
+/// * `initDone` is only honoured from `initializing` (the worker should
+///   never init twice; defensively ignore).
+AuthState reduce(AuthState state, StateInput input) {
+  // Security wipe short-circuits every transition.
+  if (input is SecurityWipe) {
+    return AuthState.unauthenticated;
+  }
+
+  switch (state) {
+    case AuthState.initializing:
+      return switch (input) {
+        InitDone(hasTokens: final t) =>
+          t ? AuthState.authenticated : AuthState.unauthenticated,
+        SignInDone() => AuthState.authenticated,
+        SignInFail() => AuthState.unauthenticated,
+        // Ignore stray inputs while initializing.
+        _ => state,
+      };
+
+    case AuthState.unauthenticated:
+      return switch (input) {
+        SignInStart() => AuthState.initializing,
+        // Everything else is a no-op from unauthenticated.
+        _ => state,
+      };
+
+    case AuthState.authenticated:
+      return switch (input) {
+        RefreshStart() => AuthState.refreshing,
+        Logout() => AuthState.unauthenticated,
+        // Ignore sign-in variants once authenticated.
+        _ => state,
+      };
+
+    case AuthState.refreshing:
+      return switch (input) {
+        RefreshDone() => AuthState.authenticated,
+        RefreshFail() => AuthState.unauthenticated,
+        Logout() => AuthState.unauthenticated,
+        _ => state,
+      };
+
+    case AuthState.error:
+      // Error is a terminal-ish state — only securityWipe (handled
+      // above) or an explicit sign-in start can leave it.
+      return switch (input) {
+        SignInStart() => AuthState.initializing,
+        _ => state,
+      };
+  }
+}

--- a/ui/runtime/lib/src/storage/secure_token_store.dart
+++ b/ui/runtime/lib/src/storage/secure_token_store.dart
@@ -1,0 +1,95 @@
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+/// Minimal KV contract over opaque strings.
+///
+/// Introduced so the test harness can inject an in-memory implementation
+/// without touching `flutter_secure_storage`'s platform channels.
+abstract class KeyValueStore {
+  Future<String?> read(String key);
+  Future<void> write(String key, String value);
+  Future<void> delete(String key);
+}
+
+/// Production-backed [KeyValueStore] using `flutter_secure_storage`.
+///
+/// The underlying plugin applies OS-specific hardware-backed encryption
+/// (iOS Keychain, Android Keystore, macOS Keychain, Linux libsecret).
+class SecureStorageKeyValueStore implements KeyValueStore {
+  SecureStorageKeyValueStore({FlutterSecureStorage? storage})
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<String?> read(String key) => _storage.read(key: key);
+
+  @override
+  Future<void> write(String key, String value) =>
+      _storage.write(key: key, value: value);
+
+  @override
+  Future<void> delete(String key) => _storage.delete(key: key);
+}
+
+/// In-memory [KeyValueStore] for tests. NOT suitable for production —
+/// values live only as long as the process.
+class InMemoryKeyValueStore implements KeyValueStore {
+  final Map<String, String> _store = {};
+
+  @override
+  Future<String?> read(String key) async => _store[key];
+
+  @override
+  Future<void> write(String key, String value) async {
+    _store[key] = value;
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    _store.remove(key);
+  }
+}
+
+/// [TokenStore] backed by a [KeyValueStore] containing JSON-encoded
+/// [StoredSession]s.
+///
+/// A fixed `auth:` prefix namespaces our entries inside the shared
+/// keychain partition.
+class SecureTokenStore implements TokenStore {
+  SecureTokenStore({KeyValueStore? kv})
+      : _kv = kv ?? SecureStorageKeyValueStore();
+
+  final KeyValueStore _kv;
+
+  String _keyFor(String namespace) => 'auth:$namespace';
+
+  @override
+  Future<StoredSession?> load(String namespace) async {
+    final raw = await _kv.read(_keyFor(namespace));
+    if (raw == null || raw.isEmpty) return null;
+    try {
+      final decoded = json.decode(raw);
+      if (decoded is! Map) return null;
+      return StoredSession.tryFromJson(decoded.cast<String, dynamic>());
+    } catch (_) {
+      // Corrupt JSON: surface as "no session" rather than crashing the
+      // caller. Higher-level security policy (e.g. wipe-on-corruption)
+      // is owned by the runtime layer.
+      return null;
+    }
+  }
+
+  @override
+  Future<void> save(String namespace, StoredSession session) async {
+    final payload = json.encode(session.toJson());
+    await _kv.write(_keyFor(namespace), payload);
+  }
+
+  @override
+  Future<void> clear(String namespace) async {
+    await _kv.delete(_keyFor(namespace));
+  }
+}

--- a/ui/runtime/lib/src/storage/token_store.dart
+++ b/ui/runtime/lib/src/storage/token_store.dart
@@ -6,47 +6,76 @@ import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
 /// Persisted session snapshot for a single namespace.
 ///
 /// Everything sensitive is wrapped or encrypted before it reaches this
-/// struct. The refresh token is wrapped under an AES-GCM key
-/// ([wrappedRefreshToken]); the wrap key itself + DPoP private key are
-/// serialised as ciphertext blobs whose encryption layer is chosen by the
-/// concrete [TokenStore] implementation (typically the OS keychain via
-/// `flutter_secure_storage`).
+/// struct. Concretely:
+///
+/// - The *wrap key* itself (AES-GCM 256) is encrypted with the root key
+///   held by `RootKeyStore` and stored as [wrapKeyCiphertext].
+/// - The *DPoP private key* (ECDSA P-256 `d` scalar, 32 bytes) is
+///   encrypted under the wrap key and stored as [dpopPrivateKeyCiphertext].
+/// - The *refresh token* is encrypted under the wrap key and stored as
+///   [refreshTokenCiphertext] (a [WrappedBlob]).
+/// - The *ID token* is stored in plaintext because it is short-lived and
+///   already public by OIDC design (the client is the intended audience).
+///
+/// Forward-compatible: older schemas that stored raw `dpopKeyEncrypted` /
+/// `wrapKeyEncrypted` bytes without an IV are silently ignored by
+/// [tryFromJson], which returns null so the runtime falls back to a fresh
+/// sign-in.
 class StoredSession {
   const StoredSession({
-    required this.wrappedRefreshToken,
-    required this.dpopKeyEncrypted,
-    required this.wrapKeyEncrypted,
+    required this.wrapKeyCiphertext,
+    required this.dpopPrivateKeyCiphertext,
+    required this.refreshTokenCiphertext,
+    required this.accessToken,
+    required this.accessTokenExpiresAt,
+    required this.tokenType,
     required this.updatedAt,
-    this.lastIdToken,
+    this.idToken,
   });
 
-  /// AES-GCM blob whose key is [wrapKeyEncrypted].
-  final WrappedBlob wrappedRefreshToken;
+  /// AES-GCM blob containing the wrap key material (32 bytes), encrypted
+  /// with the root key from `RootKeyStore`.
+  final WrappedBlob wrapKeyCiphertext;
 
-  /// Encrypted DPoP private key (format is backend-defined).
-  final Uint8List dpopKeyEncrypted;
+  /// AES-GCM blob containing the DPoP private key's `d` scalar (raw 32
+  /// bytes, big-endian), encrypted with the unwrapped wrap key.
+  final WrappedBlob dpopPrivateKeyCiphertext;
 
-  /// Encrypted AES-GCM wrap key (format is backend-defined).
-  final Uint8List wrapKeyEncrypted;
+  /// AES-GCM blob containing the UTF-8-encoded refresh token, encrypted
+  /// with the unwrapped wrap key.
+  final WrappedBlob refreshTokenCiphertext;
 
-  /// Last observed `id_token`, stored for quick claim extraction on
-  /// cold start. Not required for session continuity.
-  final String? lastIdToken;
+  /// Access token in plaintext. Short-lived and only useful for the
+  /// remaining seconds before [accessTokenExpiresAt]; the refresh token is
+  /// what actually lets an attacker maintain access.
+  final String accessToken;
 
-  /// Wall-clock timestamp of the most recent save. Used by UIs that
-  /// want to display "last seen" and by integrity checks.
+  /// Absolute expiry of [accessToken].
+  final DateTime accessTokenExpiresAt;
+
+  /// `token_type` negotiated with the IdP. Persisted so reload picks up
+  /// DPoP-bound sessions without a discovery round-trip.
+  final String tokenType;
+
+  /// Last observed `id_token`. OIDC id tokens are inherently non-secret
+  /// (they are intended for the client) so they live in plaintext.
+  final String? idToken;
+
+  /// Wall-clock timestamp of the most recent save. Used by UIs that want
+  /// to display "last seen" and by integrity checks.
   final DateTime updatedAt;
 
   /// JSON-encodable representation. Binary fields are base64-encoded.
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'v': 1,
-        'wrappedRt': <String, String>{
-          'iv': base64.encode(wrappedRefreshToken.iv),
-          'ct': base64.encode(wrappedRefreshToken.ciphertext),
-        },
-        'dpopKeyEnc': base64.encode(dpopKeyEncrypted),
-        'wrapKeyEnc': base64.encode(wrapKeyEncrypted),
-        'idToken': lastIdToken,
+        'v': 2,
+        'wrapKey': _blobToJson(wrapKeyCiphertext),
+        'dpopKey': _blobToJson(dpopPrivateKeyCiphertext),
+        'refreshToken': _blobToJson(refreshTokenCiphertext),
+        'accessToken': accessToken,
+        'accessExpiresAt':
+            accessTokenExpiresAt.toUtc().toIso8601String(),
+        'tokenType': tokenType,
+        'idToken': idToken,
         'updatedAt': updatedAt.toUtc().toIso8601String(),
       };
 
@@ -54,27 +83,32 @@ class StoredSession {
   /// error — callers treat null as "no session stored".
   static StoredSession? tryFromJson(Map<String, dynamic> json) {
     try {
-      if (json['v'] != 1) return null;
-      final rt = json['wrappedRt'];
-      if (rt is! Map) return null;
-      final iv = rt['iv'];
-      final ct = rt['ct'];
-      final dk = json['dpopKeyEnc'];
-      final wk = json['wrapKeyEnc'];
-      final ua = json['updatedAt'];
-      if (iv is! String || ct is! String || dk is! String || wk is! String ||
-          ua is! String) {
+      if (json['v'] != 2) return null;
+      final wrapKey = _blobFromJson(json['wrapKey']);
+      final dpopKey = _blobFromJson(json['dpopKey']);
+      final refresh = _blobFromJson(json['refreshToken']);
+      final access = json['accessToken'];
+      final expiresAt = json['accessExpiresAt'];
+      final tokenType = json['tokenType'];
+      final updated = json['updatedAt'];
+      if (wrapKey == null ||
+          dpopKey == null ||
+          refresh == null ||
+          access is! String ||
+          expiresAt is! String ||
+          tokenType is! String ||
+          updated is! String) {
         return null;
       }
       return StoredSession(
-        wrappedRefreshToken: WrappedBlob(
-          iv: Uint8List.fromList(base64.decode(iv)),
-          ciphertext: Uint8List.fromList(base64.decode(ct)),
-        ),
-        dpopKeyEncrypted: Uint8List.fromList(base64.decode(dk)),
-        wrapKeyEncrypted: Uint8List.fromList(base64.decode(wk)),
-        lastIdToken: json['idToken'] is String ? json['idToken'] as String : null,
-        updatedAt: DateTime.parse(ua),
+        wrapKeyCiphertext: wrapKey,
+        dpopPrivateKeyCiphertext: dpopKey,
+        refreshTokenCiphertext: refresh,
+        accessToken: access,
+        accessTokenExpiresAt: DateTime.parse(expiresAt),
+        tokenType: tokenType,
+        idToken: json['idToken'] is String ? json['idToken'] as String : null,
+        updatedAt: DateTime.parse(updated),
       );
     } catch (_) {
       return null;
@@ -97,4 +131,24 @@ abstract class TokenStore {
 
   /// Removes any session stored under [namespace].
   Future<void> clear(String namespace);
+}
+
+Map<String, String> _blobToJson(WrappedBlob blob) => <String, String>{
+      'iv': base64.encode(blob.iv),
+      'ct': base64.encode(blob.ciphertext),
+    };
+
+WrappedBlob? _blobFromJson(Object? raw) {
+  if (raw is! Map) return null;
+  final iv = raw['iv'];
+  final ct = raw['ct'];
+  if (iv is! String || ct is! String) return null;
+  try {
+    return WrappedBlob(
+      iv: Uint8List.fromList(base64.decode(iv)),
+      ciphertext: Uint8List.fromList(base64.decode(ct)),
+    );
+  } catch (_) {
+    return null;
+  }
 }

--- a/ui/runtime/lib/src/storage/token_store.dart
+++ b/ui/runtime/lib/src/storage/token_store.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
+
+/// Persisted session snapshot for a single namespace.
+///
+/// Everything sensitive is wrapped or encrypted before it reaches this
+/// struct. The refresh token is wrapped under an AES-GCM key
+/// ([wrappedRefreshToken]); the wrap key itself + DPoP private key are
+/// serialised as ciphertext blobs whose encryption layer is chosen by the
+/// concrete [TokenStore] implementation (typically the OS keychain via
+/// `flutter_secure_storage`).
+class StoredSession {
+  const StoredSession({
+    required this.wrappedRefreshToken,
+    required this.dpopKeyEncrypted,
+    required this.wrapKeyEncrypted,
+    required this.updatedAt,
+    this.lastIdToken,
+  });
+
+  /// AES-GCM blob whose key is [wrapKeyEncrypted].
+  final WrappedBlob wrappedRefreshToken;
+
+  /// Encrypted DPoP private key (format is backend-defined).
+  final Uint8List dpopKeyEncrypted;
+
+  /// Encrypted AES-GCM wrap key (format is backend-defined).
+  final Uint8List wrapKeyEncrypted;
+
+  /// Last observed `id_token`, stored for quick claim extraction on
+  /// cold start. Not required for session continuity.
+  final String? lastIdToken;
+
+  /// Wall-clock timestamp of the most recent save. Used by UIs that
+  /// want to display "last seen" and by integrity checks.
+  final DateTime updatedAt;
+
+  /// JSON-encodable representation. Binary fields are base64-encoded.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'v': 1,
+        'wrappedRt': <String, String>{
+          'iv': base64.encode(wrappedRefreshToken.iv),
+          'ct': base64.encode(wrappedRefreshToken.ciphertext),
+        },
+        'dpopKeyEnc': base64.encode(dpopKeyEncrypted),
+        'wrapKeyEnc': base64.encode(wrapKeyEncrypted),
+        'idToken': lastIdToken,
+        'updatedAt': updatedAt.toUtc().toIso8601String(),
+      };
+
+  /// Parses a map produced by [toJson]. Returns null on any schema/shape
+  /// error — callers treat null as "no session stored".
+  static StoredSession? tryFromJson(Map<String, dynamic> json) {
+    try {
+      if (json['v'] != 1) return null;
+      final rt = json['wrappedRt'];
+      if (rt is! Map) return null;
+      final iv = rt['iv'];
+      final ct = rt['ct'];
+      final dk = json['dpopKeyEnc'];
+      final wk = json['wrapKeyEnc'];
+      final ua = json['updatedAt'];
+      if (iv is! String || ct is! String || dk is! String || wk is! String ||
+          ua is! String) {
+        return null;
+      }
+      return StoredSession(
+        wrappedRefreshToken: WrappedBlob(
+          iv: Uint8List.fromList(base64.decode(iv)),
+          ciphertext: Uint8List.fromList(base64.decode(ct)),
+        ),
+        dpopKeyEncrypted: Uint8List.fromList(base64.decode(dk)),
+        wrapKeyEncrypted: Uint8List.fromList(base64.decode(wk)),
+        lastIdToken: json['idToken'] is String ? json['idToken'] as String : null,
+        updatedAt: DateTime.parse(ua),
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+/// Namespaced, durable store for [StoredSession] values.
+///
+/// Implementations must be safe against corruption: [load] returns `null`
+/// rather than throwing when the backing blob is unreadable, and [clear]
+/// is idempotent.
+abstract class TokenStore {
+  /// Loads the session for [namespace]. Returns `null` when absent or
+  /// unreadable.
+  Future<StoredSession?> load(String namespace);
+
+  /// Persists [session] under [namespace], replacing any prior value.
+  Future<void> save(String namespace, StoredSession session);
+
+  /// Removes any session stored under [namespace].
+  Future<void> clear(String namespace);
+}

--- a/ui/runtime/lib/src/widgets/auth_event_listener.dart
+++ b/ui/runtime/lib/src/widgets/auth_event_listener.dart
@@ -1,0 +1,89 @@
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/providers/auth_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Listens for [SecurityEvent]s and surfaces them in the UI.
+///
+/// By default each event produces a [SnackBar] via the enclosing
+/// [ScaffoldMessenger]. Apps that need richer UX (dialogs, telemetry,
+/// logging) can supply a [builder] which receives the event and a
+/// "default widget" helper they can either discard, wrap, or return as-is.
+///
+/// The listener itself is invisible: it renders [child] and reacts to
+/// events as a side-effect. Place it high in the widget tree — typically
+/// under [MaterialApp] but inside the [ProviderScope].
+class AuthEventListener extends ConsumerStatefulWidget {
+  const AuthEventListener({
+    required this.child,
+    this.builder,
+    super.key,
+  });
+
+  final Widget child;
+
+  /// Optional customisation hook.
+  ///
+  /// Receives the current [BuildContext], the emitted [SecurityEvent], and
+  /// the default [SnackBar]-shaped widget the listener would have shown.
+  /// Return null to suppress the default; return a widget to display an
+  /// alternative (e.g. a [Dialog]).
+  final Widget? Function(
+    BuildContext context,
+    SecurityEvent event,
+    Widget defaultSnackBarChild,
+  )? builder;
+
+  @override
+  ConsumerState<AuthEventListener> createState() =>
+      _AuthEventListenerState();
+}
+
+class _AuthEventListenerState extends ConsumerState<AuthEventListener> {
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<AsyncValue<SecurityEvent>>(
+      securityEventsProvider,
+      (prev, next) {
+        next.whenData((event) => _onEvent(context, event));
+      },
+    );
+    return widget.child;
+  }
+
+  void _onEvent(BuildContext context, SecurityEvent event) {
+    if (!mounted) return;
+    final messenger = ScaffoldMessenger.maybeOf(context);
+    if (messenger == null) return;
+    final defaultChild = _defaultSnackBarChild(event);
+    final customBuilder = widget.builder;
+    if (customBuilder == null) {
+      messenger.showSnackBar(SnackBar(content: defaultChild));
+      return;
+    }
+    // Caller opted in to custom UX. They get three choices:
+    // - return null → suppress entirely (silent handling / telemetry only)
+    // - return `defaultChild` → keep the default message
+    // - return a new widget → show an alternative
+    final override = customBuilder(context, event, defaultChild);
+    if (override == null) return;
+    messenger.showSnackBar(SnackBar(content: override));
+  }
+}
+
+Widget _defaultSnackBarChild(SecurityEvent event) {
+  return Text(_messageFor(event));
+}
+
+String _messageFor(SecurityEvent event) {
+  return switch (event) {
+    RefreshReuseDetected() =>
+      'We detected suspicious session activity and signed you out for safety.',
+    StorageCorruption() =>
+      'Your saved session could not be read; please sign in again.',
+    BindingInvalidated() =>
+      'Your device credentials expired; please sign in again.',
+    LoggedOutElsewhere() =>
+      'You were signed out on another device.',
+  };
+}

--- a/ui/runtime/lib/src/widgets/auth_gate.dart
+++ b/ui/runtime/lib/src/widgets/auth_gate.dart
@@ -1,0 +1,137 @@
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/providers/auth_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Renders [child] only when authenticated.
+///
+/// Matches the shape sketched in the design spec §4.1: three optional
+/// builders let apps customize the loading / unauthenticated / error
+/// affordances without sub-classing.
+///
+/// Defaults:
+/// - [loadingBuilder] → centered [CircularProgressIndicator]
+/// - [unauthenticatedBuilder] → centered [ElevatedButton] labelled "Sign
+///   in" that calls `authRuntimeProvider.read().ensureAuthenticated()`
+///   on tap. F-I.2 replaces this with the richer `SignInButton` widget.
+/// - [errorBuilder] → centered error message + "Retry" button that
+///   invalidates the state provider so the next frame re-subscribes.
+class AuthGate extends ConsumerWidget {
+  const AuthGate({
+    required this.child,
+    this.unauthenticatedBuilder,
+    this.loadingBuilder,
+    this.errorBuilder,
+    super.key,
+  });
+
+  final Widget child;
+  final WidgetBuilder? unauthenticatedBuilder;
+  final WidgetBuilder? loadingBuilder;
+  final Widget Function(BuildContext, AuthError)? errorBuilder;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final snap = ref.watch(authStateProvider);
+    return snap.when(
+      loading: () => (loadingBuilder ?? _defaultLoading)(context),
+      error: (err, _) {
+        final authErr = err is AuthError
+            ? err
+            : AuthError(
+                AuthErrorCode.networkError,
+                err.toString(),
+              );
+        return (errorBuilder ?? _defaultError)(context, authErr);
+      },
+      data: (state) {
+        switch (state) {
+          case AuthState.authenticated:
+            return child;
+          case AuthState.initializing:
+          case AuthState.refreshing:
+            return (loadingBuilder ?? _defaultLoading)(context);
+          case AuthState.error:
+            return (errorBuilder ?? _defaultError)(
+              context,
+              AuthError(AuthErrorCode.networkError, 'authentication error'),
+            );
+          case AuthState.unauthenticated:
+            return (unauthenticatedBuilder ?? _defaultUnauthenticated)(
+              context,
+            );
+        }
+      },
+    );
+  }
+}
+
+Widget _defaultLoading(BuildContext context) =>
+    const Center(child: CircularProgressIndicator());
+
+Widget _defaultUnauthenticated(BuildContext context) =>
+    const Center(child: _InlineSignInFallback());
+
+Widget _defaultError(BuildContext context, AuthError err) {
+  return Center(
+    child: Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Text(err.message, textAlign: TextAlign.center),
+        const SizedBox(height: 12),
+        _RetryButton(),
+      ],
+    ),
+  );
+}
+
+/// Minimal "Sign in" button used until F-I.2 ships `SignInButton`. Kept
+/// private so the richer widget takes over cleanly in the next commit.
+class _InlineSignInFallback extends ConsumerStatefulWidget {
+  const _InlineSignInFallback();
+
+  @override
+  ConsumerState<_InlineSignInFallback> createState() =>
+      _InlineSignInFallbackState();
+}
+
+class _InlineSignInFallbackState
+    extends ConsumerState<_InlineSignInFallback> {
+  bool _pending = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: _pending
+          ? null
+          : () async {
+              setState(() => _pending = true);
+              try {
+                await ref
+                    .read(authRuntimeProvider)
+                    .ensureAuthenticated();
+              } finally {
+                if (mounted) setState(() => _pending = false);
+              }
+            },
+      child: const Text('Sign in'),
+    );
+  }
+}
+
+class _RetryButton extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return TextButton(
+      onPressed: () {
+        // Invalidating the stream provider forces Riverpod to
+        // re-subscribe to the runtime's `authStateStream` on the next
+        // frame, giving the UI another shot at settling.
+        ref.invalidate(authStateProvider);
+      },
+      child: const Text('Retry'),
+    );
+  }
+}

--- a/ui/runtime/lib/src/widgets/auth_gate.dart
+++ b/ui/runtime/lib/src/widgets/auth_gate.dart
@@ -1,6 +1,7 @@
 import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
 import 'package:antinvestor_auth_runtime/src/providers/auth_providers.dart';
+import 'package:antinvestor_auth_runtime/src/widgets/sign_in_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -71,7 +72,7 @@ Widget _defaultLoading(BuildContext context) =>
     const Center(child: CircularProgressIndicator());
 
 Widget _defaultUnauthenticated(BuildContext context) =>
-    const Center(child: _InlineSignInFallback());
+    const Center(child: SignInButton());
 
 Widget _defaultError(BuildContext context, AuthError err) {
   return Center(
@@ -85,40 +86,6 @@ Widget _defaultError(BuildContext context, AuthError err) {
       ],
     ),
   );
-}
-
-/// Minimal "Sign in" button used until F-I.2 ships `SignInButton`. Kept
-/// private so the richer widget takes over cleanly in the next commit.
-class _InlineSignInFallback extends ConsumerStatefulWidget {
-  const _InlineSignInFallback();
-
-  @override
-  ConsumerState<_InlineSignInFallback> createState() =>
-      _InlineSignInFallbackState();
-}
-
-class _InlineSignInFallbackState
-    extends ConsumerState<_InlineSignInFallback> {
-  bool _pending = false;
-
-  @override
-  Widget build(BuildContext context) {
-    return ElevatedButton(
-      onPressed: _pending
-          ? null
-          : () async {
-              setState(() => _pending = true);
-              try {
-                await ref
-                    .read(authRuntimeProvider)
-                    .ensureAuthenticated();
-              } finally {
-                if (mounted) setState(() => _pending = false);
-              }
-            },
-      child: const Text('Sign in'),
-    );
-  }
 }
 
 class _RetryButton extends ConsumerWidget {

--- a/ui/runtime/lib/src/widgets/auth_state_builder.dart
+++ b/ui/runtime/lib/src/widgets/auth_state_builder.dart
@@ -1,0 +1,31 @@
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/providers/auth_providers.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Rebuilds its [builder] every time the [AuthState] transitions.
+///
+/// Thin wrapper around `authStateProvider` — inlineable in one line at
+/// the call site, but documenting and testing the pattern in one place
+/// keeps the reactive plumbing out of app code.
+///
+/// While the stream is still loading (pre-first-event) or encounters an
+/// error the widget forwards [AuthState.initializing]; callers that need
+/// to distinguish loading/error from a real state transition should
+/// subscribe to `authStateProvider` directly.
+class AuthStateBuilder extends ConsumerWidget {
+  const AuthStateBuilder({required this.builder, super.key});
+
+  final Widget Function(BuildContext context, AuthState state) builder;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final snap = ref.watch(authStateProvider);
+    final state = snap.when(
+      data: (s) => s,
+      loading: () => AuthState.initializing,
+      error: (_, _) => AuthState.initializing,
+    );
+    return builder(context, state);
+  }
+}

--- a/ui/runtime/lib/src/widgets/profile_avatar.dart
+++ b/ui/runtime/lib/src/widgets/profile_avatar.dart
@@ -1,0 +1,87 @@
+import 'package:antinvestor_auth_runtime/src/providers/auth_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Renders the signed-in user's avatar:
+///
+/// - If claims contain a non-empty `picture` URL, uses it.
+/// - Otherwise falls back to initials derived from `name` (first letter
+///   of each whitespace-separated word, up to two) or `email` (first
+///   letter of the local part).
+/// - While claims are still resolving renders a neutral circle.
+class ProfileAvatar extends ConsumerWidget {
+  const ProfileAvatar({
+    this.radius = 20,
+    this.backgroundColor,
+    this.foregroundColor,
+    super.key,
+  });
+
+  final double radius;
+  final Color? backgroundColor;
+  final Color? foregroundColor;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+    final bg = backgroundColor ?? theme.colorScheme.primaryContainer;
+    final fg = foregroundColor ?? theme.colorScheme.onPrimaryContainer;
+    final async = ref.watch(userClaimsProvider);
+    return async.when(
+      loading: () => CircleAvatar(
+        radius: radius,
+        backgroundColor: bg,
+      ),
+      error: (_, _) => CircleAvatar(
+        radius: radius,
+        backgroundColor: bg,
+        foregroundColor: fg,
+        child: const Icon(Icons.person_outline),
+      ),
+      data: (claims) {
+        final picture = claims['picture'];
+        if (picture is String && picture.isNotEmpty) {
+          return CircleAvatar(
+            radius: radius,
+            backgroundImage: NetworkImage(picture),
+            backgroundColor: bg,
+          );
+        }
+        final initials = _initialsFrom(claims);
+        return CircleAvatar(
+          radius: radius,
+          backgroundColor: bg,
+          foregroundColor: fg,
+          child: initials.isEmpty
+              ? const Icon(Icons.person_outline)
+              : Text(initials),
+        );
+      },
+    );
+  }
+}
+
+/// Visible for testing — derives initials using the same priority chain
+/// as [ProfileAvatar].
+String initialsFromClaims(Map<String, dynamic> claims) =>
+    _initialsFrom(claims);
+
+String _initialsFrom(Map<String, dynamic> claims) {
+  final name = claims['name'];
+  if (name is String && name.trim().isNotEmpty) {
+    final parts = name
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((p) => p.isNotEmpty)
+        .toList();
+    final first = parts.isNotEmpty ? parts.first[0] : '';
+    final second = parts.length > 1 ? parts[1][0] : '';
+    return (first + second).toUpperCase();
+  }
+  final email = claims['email'];
+  if (email is String && email.isNotEmpty) {
+    final local = email.split('@').first;
+    if (local.isNotEmpty) return local[0].toUpperCase();
+  }
+  return '';
+}

--- a/ui/runtime/lib/src/widgets/sign_in_button.dart
+++ b/ui/runtime/lib/src/widgets/sign_in_button.dart
@@ -1,0 +1,65 @@
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/providers/auth_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Material button that calls [AuthRuntime.ensureAuthenticated] on tap.
+///
+/// The button disables itself while a sign-in is in flight so users
+/// can't stack concurrent OAuth flows. Errors surface through [onError]
+/// when supplied; otherwise they propagate up the default `FlutterError`
+/// path. Success is signalled via [onAuthenticated] after
+/// `ensureAuthenticated` returns.
+class SignInButton extends ConsumerStatefulWidget {
+  const SignInButton({
+    this.label = 'Sign in',
+    this.style,
+    this.onAuthenticated,
+    this.onError,
+    super.key,
+  });
+
+  final String label;
+  final ButtonStyle? style;
+  final VoidCallback? onAuthenticated;
+  final void Function(AuthError error)? onError;
+
+  @override
+  ConsumerState<SignInButton> createState() => _SignInButtonState();
+}
+
+class _SignInButtonState extends ConsumerState<SignInButton> {
+  bool _pending = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      style: widget.style,
+      onPressed: _pending ? null : _onTap,
+      child: _pending
+          ? const SizedBox(
+              height: 16,
+              width: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Text(widget.label),
+    );
+  }
+
+  Future<void> _onTap() async {
+    setState(() => _pending = true);
+    try {
+      await ref.read(authRuntimeProvider).ensureAuthenticated();
+      widget.onAuthenticated?.call();
+    } on AuthError catch (err) {
+      final cb = widget.onError;
+      if (cb != null) {
+        cb(err);
+      } else {
+        rethrow;
+      }
+    } finally {
+      if (mounted) setState(() => _pending = false);
+    }
+  }
+}

--- a/ui/runtime/lib/src/widgets/sign_out_button.dart
+++ b/ui/runtime/lib/src/widgets/sign_out_button.dart
@@ -1,0 +1,62 @@
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/providers/auth_providers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Material button that calls [AuthRuntime.logout] on tap.
+///
+/// Disables itself while logout is in flight to avoid double-invocations
+/// during slow end-session round-trips.
+class SignOutButton extends ConsumerStatefulWidget {
+  const SignOutButton({
+    this.label = 'Sign out',
+    this.style,
+    this.onSignedOut,
+    this.onError,
+    super.key,
+  });
+
+  final String label;
+  final ButtonStyle? style;
+  final VoidCallback? onSignedOut;
+  final void Function(AuthError error)? onError;
+
+  @override
+  ConsumerState<SignOutButton> createState() => _SignOutButtonState();
+}
+
+class _SignOutButtonState extends ConsumerState<SignOutButton> {
+  bool _pending = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      style: widget.style,
+      onPressed: _pending ? null : _onTap,
+      child: _pending
+          ? const SizedBox(
+              height: 16,
+              width: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : Text(widget.label),
+    );
+  }
+
+  Future<void> _onTap() async {
+    setState(() => _pending = true);
+    try {
+      await ref.read(authRuntimeProvider).logout();
+      widget.onSignedOut?.call();
+    } on AuthError catch (err) {
+      final cb = widget.onError;
+      if (cb != null) {
+        cb(err);
+      } else {
+        rethrow;
+      }
+    } finally {
+      if (mounted) setState(() => _pending = false);
+    }
+  }
+}

--- a/ui/runtime/lib/src/worker/messages.dart
+++ b/ui/runtime/lib/src/worker/messages.dart
@@ -1,0 +1,481 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+
+/// Wire-format key for the discriminator field used by every message.
+const String _kind = 'kind';
+const String _corrId = 'correlationId';
+
+/// Union of all requests the main isolate sends to the token worker.
+///
+/// Every variant is serialisable via [toMap] / [fromMap] so it can travel
+/// across a `SendPort` (only primitives + maps + lists survive isolate
+/// boundaries). A [correlationId] is attached by the caller so the
+/// matching [WorkerEvent] can be routed back.
+sealed class WorkerRequest {
+  const WorkerRequest({required this.correlationId});
+
+  final String correlationId;
+
+  Map<String, Object?> toMap();
+
+  /// Dispatches on the `kind` field.
+  static WorkerRequest fromMap(Map<String, Object?> map) {
+    final kind = map[_kind];
+    return switch (kind) {
+      'init' => InitRequest._fromMap(map),
+      'prepareAuth' => PrepareAuthRequest._fromMap(map),
+      'completeAuth' => CompleteAuthRequest._fromMap(map),
+      'fetch' => FetchRequest._fromMap(map),
+      'upload' => UploadRequest._fromMap(map),
+      'getRoles' => GetRolesRequest._fromMap(map),
+      'getClaims' => GetClaimsRequest._fromMap(map),
+      'logout' => LogoutRequest._fromMap(map),
+      'destroy' => DestroyRequest._fromMap(map),
+      _ => throw FormatException('unknown WorkerRequest kind: $kind'),
+    };
+  }
+}
+
+final class InitRequest extends WorkerRequest {
+  const InitRequest({required super.correlationId});
+
+  @override
+  Map<String, Object?> toMap() => {_kind: 'init', _corrId: correlationId};
+
+  factory InitRequest._fromMap(Map<String, Object?> map) =>
+      InitRequest(correlationId: map[_corrId] as String);
+}
+
+final class PrepareAuthRequest extends WorkerRequest {
+  const PrepareAuthRequest({required super.correlationId});
+
+  @override
+  Map<String, Object?> toMap() =>
+      {_kind: 'prepareAuth', _corrId: correlationId};
+
+  factory PrepareAuthRequest._fromMap(Map<String, Object?> map) =>
+      PrepareAuthRequest(correlationId: map[_corrId] as String);
+}
+
+final class CompleteAuthRequest extends WorkerRequest {
+  const CompleteAuthRequest({
+    required super.correlationId,
+    required this.code,
+    required this.verifier,
+    required this.state,
+    required this.nonce,
+  });
+
+  final String code;
+  final String verifier;
+  final String state;
+  final String nonce;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'completeAuth',
+        _corrId: correlationId,
+        'code': code,
+        'verifier': verifier,
+        'state': state,
+        'nonce': nonce,
+      };
+
+  factory CompleteAuthRequest._fromMap(Map<String, Object?> map) =>
+      CompleteAuthRequest(
+        correlationId: map[_corrId] as String,
+        code: map['code'] as String,
+        verifier: map['verifier'] as String,
+        state: map['state'] as String,
+        nonce: map['nonce'] as String,
+      );
+}
+
+final class FetchRequest extends WorkerRequest {
+  const FetchRequest({
+    required super.correlationId,
+    required this.path,
+    required this.method,
+    this.headers,
+    this.body,
+    this.timeoutMs,
+  });
+
+  final String path;
+  final String method;
+  final Map<String, String>? headers;
+
+  /// [body] is serialised as base64 when binary, raw string when text.
+  /// Null when there is no body.
+  final String? body;
+  final int? timeoutMs;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'fetch',
+        _corrId: correlationId,
+        'path': path,
+        'method': method,
+        if (headers != null) 'headers': headers,
+        if (body != null) 'body': body,
+        if (timeoutMs != null) 'timeoutMs': timeoutMs,
+      };
+
+  factory FetchRequest._fromMap(Map<String, Object?> map) => FetchRequest(
+        correlationId: map[_corrId] as String,
+        path: map['path'] as String,
+        method: map['method'] as String,
+        headers: _mapOfString(map['headers']),
+        body: map['body'] as String?,
+        timeoutMs: map['timeoutMs'] as int?,
+      );
+}
+
+final class UploadRequest extends WorkerRequest {
+  const UploadRequest({
+    required super.correlationId,
+    required this.path,
+    required this.fieldName,
+    required this.filename,
+    required this.contentType,
+    required this.bytes,
+    this.headers,
+    this.timeoutMs,
+  });
+
+  final String path;
+  final String fieldName;
+  final String filename;
+  final String contentType;
+
+  /// Raw bytes — the buffer travels as `TransferableTypedData` at the
+  /// isolate boundary; here we keep [Uint8List] for typing.
+  final Uint8List bytes;
+  final Map<String, String>? headers;
+  final int? timeoutMs;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'upload',
+        _corrId: correlationId,
+        'path': path,
+        'fieldName': fieldName,
+        'filename': filename,
+        'contentType': contentType,
+        'bytes': bytes,
+        if (headers != null) 'headers': headers,
+        if (timeoutMs != null) 'timeoutMs': timeoutMs,
+      };
+
+  factory UploadRequest._fromMap(Map<String, Object?> map) => UploadRequest(
+        correlationId: map[_corrId] as String,
+        path: map['path'] as String,
+        fieldName: map['fieldName'] as String,
+        filename: map['filename'] as String,
+        contentType: map['contentType'] as String,
+        bytes: _asBytes(map['bytes']),
+        headers: _mapOfString(map['headers']),
+        timeoutMs: map['timeoutMs'] as int?,
+      );
+}
+
+final class GetRolesRequest extends WorkerRequest {
+  const GetRolesRequest({required super.correlationId});
+
+  @override
+  Map<String, Object?> toMap() =>
+      {_kind: 'getRoles', _corrId: correlationId};
+
+  factory GetRolesRequest._fromMap(Map<String, Object?> map) =>
+      GetRolesRequest(correlationId: map[_corrId] as String);
+}
+
+final class GetClaimsRequest extends WorkerRequest {
+  const GetClaimsRequest({required super.correlationId});
+
+  @override
+  Map<String, Object?> toMap() =>
+      {_kind: 'getClaims', _corrId: correlationId};
+
+  factory GetClaimsRequest._fromMap(Map<String, Object?> map) =>
+      GetClaimsRequest(correlationId: map[_corrId] as String);
+}
+
+final class LogoutRequest extends WorkerRequest {
+  const LogoutRequest({required super.correlationId});
+
+  @override
+  Map<String, Object?> toMap() => {_kind: 'logout', _corrId: correlationId};
+
+  factory LogoutRequest._fromMap(Map<String, Object?> map) =>
+      LogoutRequest(correlationId: map[_corrId] as String);
+}
+
+final class DestroyRequest extends WorkerRequest {
+  const DestroyRequest({required super.correlationId});
+
+  @override
+  Map<String, Object?> toMap() =>
+      {_kind: 'destroy', _corrId: correlationId};
+
+  factory DestroyRequest._fromMap(Map<String, Object?> map) =>
+      DestroyRequest(correlationId: map[_corrId] as String);
+}
+
+/// Union of all events the worker emits. Some events are correlated (they
+/// answer a specific [WorkerRequest]); others are broadcast (state
+/// changes, security signals).
+sealed class WorkerEvent {
+  const WorkerEvent({this.correlationId});
+
+  final String? correlationId;
+
+  Map<String, Object?> toMap();
+
+  static WorkerEvent fromMap(Map<String, Object?> map) {
+    final kind = map[_kind];
+    return switch (kind) {
+      'ready' => ReadyEvent._fromMap(map),
+      'state' => StateEvent._fromMap(map),
+      'authUrl' => AuthUrlEvent._fromMap(map),
+      'response' => ResponseEvent._fromMap(map),
+      'error' => ErrorEvent._fromMap(map),
+      'ok' => OkEvent._fromMap(map),
+      'roles' => RolesEvent._fromMap(map),
+      'claims' => ClaimsEvent._fromMap(map),
+      'securityEvent' => SecurityEventWire._fromMap(map),
+      _ => throw FormatException('unknown WorkerEvent kind: $kind'),
+    };
+  }
+}
+
+final class ReadyEvent extends WorkerEvent {
+  const ReadyEvent({super.correlationId});
+
+  @override
+  Map<String, Object?> toMap() => {_kind: 'ready', _corrId: correlationId};
+
+  factory ReadyEvent._fromMap(Map<String, Object?> map) =>
+      ReadyEvent(correlationId: map[_corrId] as String?);
+}
+
+final class StateEvent extends WorkerEvent {
+  const StateEvent({required this.state, super.correlationId});
+
+  final AuthState state;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'state',
+        _corrId: correlationId,
+        'state': state.name,
+      };
+
+  factory StateEvent._fromMap(Map<String, Object?> map) => StateEvent(
+        state: AuthState.values.firstWhere((s) => s.name == map['state']),
+        correlationId: map[_corrId] as String?,
+      );
+}
+
+final class AuthUrlEvent extends WorkerEvent {
+  const AuthUrlEvent({
+    required this.url,
+    required this.verifier,
+    required this.state,
+    required this.nonce,
+    super.correlationId,
+  });
+
+  final String url;
+  final String verifier;
+  final String state;
+  final String nonce;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'authUrl',
+        _corrId: correlationId,
+        'url': url,
+        'verifier': verifier,
+        'state': state,
+        'nonce': nonce,
+      };
+
+  factory AuthUrlEvent._fromMap(Map<String, Object?> map) => AuthUrlEvent(
+        correlationId: map[_corrId] as String?,
+        url: map['url'] as String,
+        verifier: map['verifier'] as String,
+        state: map['state'] as String,
+        nonce: map['nonce'] as String,
+      );
+}
+
+final class ResponseEvent extends WorkerEvent {
+  const ResponseEvent({required this.response, super.correlationId});
+
+  final ApiResponse response;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'response',
+        _corrId: correlationId,
+        'status': response.status,
+        'headers': response.headers,
+        'body': response.body,
+      };
+
+  factory ResponseEvent._fromMap(Map<String, Object?> map) => ResponseEvent(
+        correlationId: map[_corrId] as String?,
+        response: ApiResponse(
+          status: map['status'] as int,
+          headers: _mapOfString(map['headers']) ?? const {},
+          body: _asBytes(map['body']),
+        ),
+      );
+}
+
+final class ErrorEvent extends WorkerEvent {
+  const ErrorEvent({
+    required this.code,
+    required this.message,
+    this.traceId,
+    super.correlationId,
+  });
+
+  final AuthErrorCode code;
+  final String message;
+  final String? traceId;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'error',
+        _corrId: correlationId,
+        'code': code.name,
+        'message': message,
+        if (traceId != null) 'traceId': traceId,
+      };
+
+  factory ErrorEvent._fromMap(Map<String, Object?> map) => ErrorEvent(
+        correlationId: map[_corrId] as String?,
+        code: AuthErrorCode.values.firstWhere((c) => c.name == map['code']),
+        message: map['message'] as String,
+        traceId: map['traceId'] as String?,
+      );
+
+  /// Converts back into a throwable [AuthError]. Useful on the caller side
+  /// when translating isolate errors into ordinary exceptions.
+  AuthError toAuthError() =>
+      AuthError(code, message, traceId: traceId);
+}
+
+final class OkEvent extends WorkerEvent {
+  const OkEvent({super.correlationId});
+
+  @override
+  Map<String, Object?> toMap() => {_kind: 'ok', _corrId: correlationId};
+
+  factory OkEvent._fromMap(Map<String, Object?> map) =>
+      OkEvent(correlationId: map[_corrId] as String?);
+}
+
+final class RolesEvent extends WorkerEvent {
+  const RolesEvent({required this.roles, super.correlationId});
+
+  final List<String> roles;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'roles',
+        _corrId: correlationId,
+        'roles': roles,
+      };
+
+  factory RolesEvent._fromMap(Map<String, Object?> map) => RolesEvent(
+        correlationId: map[_corrId] as String?,
+        roles: (map['roles'] as List).cast<String>(),
+      );
+}
+
+final class ClaimsEvent extends WorkerEvent {
+  const ClaimsEvent({required this.claims, super.correlationId});
+
+  final Map<String, dynamic> claims;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'claims',
+        _corrId: correlationId,
+        // Stringify to guarantee the map survives SendPort on every
+        // platform; some contents (e.g. nested DateTime) aren't
+        // transferable otherwise.
+        'claimsJson': json.encode(claims),
+      };
+
+  factory ClaimsEvent._fromMap(Map<String, Object?> map) => ClaimsEvent(
+        correlationId: map[_corrId] as String?,
+        claims:
+            (json.decode(map['claimsJson'] as String) as Map<String, dynamic>),
+      );
+}
+
+/// Wire mirror of [SecurityEvent]. We carry a kind discriminator plus an
+/// ISO-8601 timestamp; the caller reconstructs the sealed hierarchy on
+/// receipt. Kept separate from the domain class to avoid coupling
+/// serialisation to public model invariants.
+final class SecurityEventWire extends WorkerEvent {
+  const SecurityEventWire({
+    required this.event,
+    super.correlationId,
+  });
+
+  final SecurityEvent event;
+
+  @override
+  Map<String, Object?> toMap() {
+    final kind = switch (event) {
+      RefreshReuseDetected() => 'refreshReuseDetected',
+      StorageCorruption() => 'storageCorruption',
+      BindingInvalidated() => 'bindingInvalidated',
+      LoggedOutElsewhere() => 'loggedOutElsewhere',
+    };
+    return {
+      _kind: 'securityEvent',
+      _corrId: correlationId,
+      'eventKind': kind,
+      'at': event.at.toUtc().toIso8601String(),
+    };
+  }
+
+  factory SecurityEventWire._fromMap(Map<String, Object?> map) {
+    final at = DateTime.parse(map['at'] as String);
+    final eventKind = map['eventKind'] as String;
+    final ev = switch (eventKind) {
+      'refreshReuseDetected' => SecurityEvent.refreshReuseDetected(at),
+      'storageCorruption' => SecurityEvent.storageCorruption(at),
+      'bindingInvalidated' => SecurityEvent.bindingInvalidated(at),
+      'loggedOutElsewhere' => SecurityEvent.loggedOutElsewhere(at),
+      _ => throw FormatException('unknown security event kind: $eventKind'),
+    };
+    return SecurityEventWire(
+      event: ev,
+      correlationId: map[_corrId] as String?,
+    );
+  }
+}
+
+Map<String, String>? _mapOfString(Object? raw) {
+  if (raw is! Map) return null;
+  return raw.map((k, v) => MapEntry(k.toString(), v.toString()));
+}
+
+Uint8List _asBytes(Object? raw) {
+  if (raw is Uint8List) return raw;
+  if (raw is List<int>) return Uint8List.fromList(raw);
+  if (raw is List) return Uint8List.fromList(raw.cast<int>());
+  throw const FormatException('expected byte buffer');
+}

--- a/ui/runtime/lib/src/worker/token_isolate.dart
+++ b/ui/runtime/lib/src/worker/token_isolate.dart
@@ -1,0 +1,295 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/worker/messages.dart';
+
+/// Handle to a spawned token isolate.
+///
+/// Owns the [Isolate] reference, the bi-directional ports, and lifecycle
+/// bookkeeping. Callers typically go through [IsolatedTokenWorkerProxy]
+/// rather than the handle directly.
+///
+/// ## Why "scaffolding"?
+///
+/// v0.1 ships the isolate path disabled by default (`useIsolate: false`
+/// on `createAuthRuntime`). Passing real dependencies — HTTP clients,
+/// [FlutterAppAuth], a [KeyManager] — through an isolate boundary is
+/// intentionally non-trivial: most are non-transferable (closures, plugin
+/// channels). The v0.1 scaffolding exercises only the message plumbing
+/// and lifecycle; end-to-end OAuth + refresh through the isolate is
+/// validated in the F-J integration pass where a real HTTP server is
+/// available.
+class TokenIsolateHandle {
+  TokenIsolateHandle._({
+    required this.isolate,
+    required this.sendPort,
+    required ReceivePort responsePort,
+    required ReceivePort errorPort,
+    required ReceivePort exitPort,
+    required Stream<WorkerEvent> eventStream,
+    required StreamSubscription<dynamic> responseSubscription,
+    required StreamSubscription<dynamic> errorSubscription,
+    required StreamSubscription<dynamic> exitSubscription,
+    required StreamController<WorkerEvent> controller,
+  })  : _responsePort = responsePort,
+        _errorPort = errorPort,
+        _exitPort = exitPort,
+        _eventStream = eventStream,
+        _responseSubscription = responseSubscription,
+        _errorSubscription = errorSubscription,
+        _exitSubscription = exitSubscription,
+        _controller = controller;
+
+  final Isolate isolate;
+  final SendPort sendPort;
+  final ReceivePort _responsePort;
+  final ReceivePort _errorPort;
+  final ReceivePort _exitPort;
+  final Stream<WorkerEvent> _eventStream;
+  final StreamSubscription<dynamic> _responseSubscription;
+  final StreamSubscription<dynamic> _errorSubscription;
+  final StreamSubscription<dynamic> _exitSubscription;
+  final StreamController<WorkerEvent> _controller;
+
+  /// Broadcast stream of everything the isolate has sent back. Events
+  /// without a [WorkerEvent.correlationId] are drop-ins for the worker's
+  /// state/security channels; correlated events answer specific
+  /// [WorkerRequest]s.
+  Stream<WorkerEvent> get events => _eventStream;
+
+  bool _disposed = false;
+
+  /// Spawns a fresh token isolate and awaits its ready signal.
+  ///
+  /// The default [entryPoint] boots a minimal scaffolding worker that
+  /// answers [InitRequest] and [DestroyRequest] only; richer entry
+  /// points (integration tests, F-J production wiring) can be injected.
+  static Future<TokenIsolateHandle> spawn({
+    void Function(SendPort)? entryPoint,
+    Duration readyTimeout = const Duration(seconds: 5),
+  }) async {
+    final responsePort = ReceivePort();
+    final errorPort = ReceivePort();
+    final exitPort = ReceivePort();
+    final ready = Completer<SendPort>();
+    final controller = StreamController<WorkerEvent>.broadcast();
+
+    final responseSubscription = responsePort.listen((dynamic msg) {
+      if (!ready.isCompleted) {
+        if (msg is SendPort) {
+          ready.complete(msg);
+          return;
+        }
+        ready.completeError(
+          StateError('first isolate message was not a SendPort: $msg'),
+        );
+        return;
+      }
+      if (msg is Map) {
+        try {
+          controller.add(WorkerEvent.fromMap(msg.cast<String, Object?>()));
+        } catch (err, st) {
+          controller.addError(err, st);
+        }
+      }
+    });
+    final errorSubscription = errorPort.listen((dynamic err) {
+      controller.addError(StateError('isolate error: $err'));
+    });
+    final exitSubscription = exitPort.listen((_) {
+      if (!controller.isClosed) controller.close();
+    });
+
+    final isolate = await Isolate.spawn<SendPort>(
+      entryPoint ?? defaultTokenIsolateEntryPoint,
+      responsePort.sendPort,
+      onError: errorPort.sendPort,
+      onExit: exitPort.sendPort,
+      errorsAreFatal: false,
+      debugName: 'antinvestor-auth-token-worker',
+    );
+
+    SendPort sendPort;
+    try {
+      sendPort = await ready.future.timeout(readyTimeout);
+    } catch (err) {
+      isolate.kill(priority: Isolate.immediate);
+      await responseSubscription.cancel();
+      await errorSubscription.cancel();
+      await exitSubscription.cancel();
+      responsePort.close();
+      errorPort.close();
+      exitPort.close();
+      if (!controller.isClosed) await controller.close();
+      rethrow;
+    }
+
+    return TokenIsolateHandle._(
+      isolate: isolate,
+      sendPort: sendPort,
+      responsePort: responsePort,
+      errorPort: errorPort,
+      exitPort: exitPort,
+      eventStream: controller.stream,
+      responseSubscription: responseSubscription,
+      errorSubscription: errorSubscription,
+      exitSubscription: exitSubscription,
+      controller: controller,
+    );
+  }
+
+  /// Fire-and-forget send. Callers correlate responses on [events] by
+  /// matching [WorkerRequest.correlationId] to [WorkerEvent.correlationId].
+  void send(WorkerRequest request) {
+    if (_disposed) {
+      throw StateError('TokenIsolateHandle has been disposed');
+    }
+    sendPort.send(request.toMap());
+  }
+
+  /// Sends [request] and awaits the first matching event. Raises
+  /// [TimeoutException] if [timeout] elapses first.
+  Future<WorkerEvent> request(
+    WorkerRequest request, {
+    Duration timeout = const Duration(seconds: 5),
+  }) {
+    final completer = Completer<WorkerEvent>();
+    late final StreamSubscription<WorkerEvent> sub;
+    sub = events.listen(
+      (ev) {
+        if (ev.correlationId == request.correlationId &&
+            !completer.isCompleted) {
+          completer.complete(ev);
+          sub.cancel();
+        }
+      },
+      onError: (Object err, StackTrace st) {
+        if (!completer.isCompleted) completer.completeError(err, st);
+        sub.cancel();
+      },
+    );
+    send(request);
+    return completer.future.timeout(timeout, onTimeout: () {
+      sub.cancel();
+      throw TimeoutException('isolate request timed out', timeout);
+    });
+  }
+
+  /// Kills the isolate, drains ports, cancels subscriptions. Idempotent.
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    isolate.kill(priority: Isolate.immediate);
+    await _responseSubscription.cancel();
+    await _errorSubscription.cancel();
+    await _exitSubscription.cancel();
+    _responsePort.close();
+    _errorPort.close();
+    _exitPort.close();
+    if (!_controller.isClosed) await _controller.close();
+  }
+}
+
+/// Main-thread proxy that forwards [TokenWorker]-shaped calls through a
+/// [TokenIsolateHandle].
+///
+/// The v0.1 surface only wires [init] + [destroy] end-to-end — enough to
+/// validate the isolate lifecycle. The remaining methods (`prepareAuth`,
+/// `completeAuth`, `fetch`, `upload`, …) are declared for API parity and
+/// will be completed in F-J when the integration harness supplies a
+/// real HTTP surface the isolate can talk to.
+class IsolatedTokenWorkerProxy {
+  IsolatedTokenWorkerProxy(this.handle);
+
+  final TokenIsolateHandle handle;
+
+  /// Broadcasted events (state changes, security signals) from the
+  /// worker. Correlated events (answers to [request]s) also flow here.
+  Stream<WorkerEvent> get events => handle.events;
+
+  /// Sends an [InitRequest] and awaits the matching [OkEvent].
+  Future<void> init({
+    Duration timeout = const Duration(seconds: 5),
+    String correlationId = 'init',
+  }) async {
+    final ev = await handle.request(
+      InitRequest(correlationId: correlationId),
+      timeout: timeout,
+    );
+    if (ev is ErrorEvent) throw ev.toAuthError();
+    if (ev is OkEvent) return;
+    throw StateError('unexpected init response: $ev');
+  }
+
+  /// Sends a [DestroyRequest], awaits the ack, then tears down the
+  /// isolate. Swallowing the timeout is intentional — we kill the
+  /// isolate either way so a hung worker doesn't wedge shutdown.
+  Future<void> destroy({
+    Duration timeout = const Duration(seconds: 5),
+    String correlationId = 'destroy',
+  }) async {
+    try {
+      await handle.request(
+        DestroyRequest(correlationId: correlationId),
+        timeout: timeout,
+      );
+    } on TimeoutException {
+      // Fall through to kill.
+    } catch (_) {
+      // Same: we still own the kill.
+    }
+    await handle.dispose();
+  }
+}
+
+/// Scaffolding entry point used by [TokenIsolateHandle.spawn] when no
+/// custom one is supplied. Answers [InitRequest] and [DestroyRequest];
+/// every other request produces an [ErrorEvent] tagged
+/// [AuthErrorCode.cryptoUnsupported] as a placeholder for "not wired".
+///
+/// Kept deliberately small so lifecycle tests don't drag in the full
+/// [TokenWorker] stack.
+void defaultTokenIsolateEntryPoint(SendPort main) {
+  final receive = ReceivePort();
+  main.send(receive.sendPort);
+  // Broadcast a ready transition so the main isolate can observe the
+  // worker settling into 'initializing'.
+  main.send(const ReadyEvent().toMap());
+
+  receive.listen((dynamic raw) {
+    if (raw is! Map) return;
+    final map = raw.cast<String, Object?>();
+    final WorkerRequest req;
+    try {
+      req = WorkerRequest.fromMap(map);
+    } catch (err) {
+      main.send(
+        ErrorEvent(
+          code: AuthErrorCode.cryptoUnsupported,
+          message: 'malformed request: $err',
+        ).toMap(),
+      );
+      return;
+    }
+    switch (req) {
+      case InitRequest():
+        main.send(OkEvent(correlationId: req.correlationId).toMap());
+        break;
+      case DestroyRequest():
+        main.send(OkEvent(correlationId: req.correlationId).toMap());
+        receive.close();
+        Isolate.current.kill(priority: Isolate.immediate);
+        break;
+      default:
+        main.send(
+          ErrorEvent(
+            code: AuthErrorCode.cryptoUnsupported,
+            message: 'scaffolding entry point does not implement '
+                '${req.runtimeType}; see F-J integration pass',
+            correlationId: req.correlationId,
+          ).toMap(),
+        );
+    }
+  });
+}

--- a/ui/runtime/lib/src/worker/token_worker.dart
+++ b/ui/runtime/lib/src/worker/token_worker.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
 import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
@@ -73,6 +74,7 @@ class TokenWorker implements TokenProvider {
   TokenWorker({
     required this.config,
     required this.keyManager,
+    required this.rootKeyStore,
     required this.tokenStore,
     required this.discoveryClient,
     required this.tokenExchange,
@@ -86,6 +88,7 @@ class TokenWorker implements TokenProvider {
 
   final ResolvedConfig config;
   final KeyManager keyManager;
+  final RootKeyStore rootKeyStore;
   final TokenStore tokenStore;
   final DiscoveryClient discoveryClient;
   final TokenExchange tokenExchange;
@@ -113,6 +116,20 @@ class TokenWorker implements TokenProvider {
   /// Initializes the worker: loads and decrypts any stored session, then
   /// settles into `authenticated` or `unauthenticated`. Safe to call
   /// once per instance.
+  ///
+  /// Decryption chain on cold start:
+  ///
+  /// 1. Pull the root key from [rootKeyStore] — lives in the OS keychain.
+  /// 2. Decrypt [StoredSession.wrapKeyCiphertext] under the root key to
+  ///    recover the AES-GCM wrap key.
+  /// 3. Decrypt [StoredSession.dpopPrivateKeyCiphertext] and
+  ///    [StoredSession.refreshTokenCiphertext] under the wrap key.
+  /// 4. Rehydrate the [DpopContext] from the `d` scalar.
+  ///
+  /// Any failure along the way is treated as storage corruption: the
+  /// session is wiped, a [SecurityEvent.storageCorruption] is emitted,
+  /// and the runtime settles in `unauthenticated` so the caller can
+  /// prompt a fresh sign-in.
   Future<void> init() async {
     _ensureAlive();
     try {
@@ -121,20 +138,76 @@ class TokenWorker implements TokenProvider {
         _transition(const StateInput.initDone(hasTokens: false));
         return;
       }
-      // Storage is present but the DPoP/wrap layer is stubbed for a
-      // later task. Without the ability to decrypt the wrap key, treat
-      // this as an empty session rather than failing hard.
-      // TODO(F-E.3 hardening): decrypt wrapKeyEncrypted + dpopKeyEncrypted
-      //   via hardware-backed keystore and unwrap the refresh token.
-      //   Until that lands, initializing from persisted storage lands in
-      //   `unauthenticated` so the worker falls back to a fresh sign-in.
-      _transition(const StateInput.initDone(hasTokens: false));
-    } catch (err) {
-      // Corrupt storage: wipe + fall through to unauthenticated.
-      await tokenStore.clear(config.namespace);
-      _emitSecurity(SecurityEvent.storageCorruption(clock()));
-      _transition(const StateInput.initDone(hasTokens: false));
+      final restored = await _rehydrate(stored);
+      if (restored == null) {
+        await _wipeCorruptSession();
+        return;
+      }
+      _tokens = restored.tokens;
+      _wrapKey = restored.wrapKey;
+      final kp = restored.dpopKeyPair;
+      _dpop = await makeDpopContextAsync(kp, keyManager: keyManager);
+      _transition(const StateInput.initDone(hasTokens: true));
+    } catch (_) {
+      await _wipeCorruptSession();
     }
+  }
+
+  Future<_RehydratedSession?> _rehydrate(StoredSession stored) async {
+    final rootKey = await rootKeyStore.getOrCreate(config.namespace);
+    final rootKeyAsWrap = await keyManager.importWrapKey(rootKey);
+    Uint8List wrapKeyBytes;
+    try {
+      wrapKeyBytes =
+          await keyManager.unwrap(rootKeyAsWrap, stored.wrapKeyCiphertext);
+    } catch (_) {
+      return null;
+    }
+    if (wrapKeyBytes.length != 32) return null;
+    final wrapKey = await keyManager.importWrapKey(wrapKeyBytes);
+
+    final Uint8List dScalar;
+    final Uint8List refreshBytes;
+    try {
+      dScalar =
+          await keyManager.unwrap(wrapKey, stored.dpopPrivateKeyCiphertext);
+      refreshBytes =
+          await keyManager.unwrap(wrapKey, stored.refreshTokenCiphertext);
+    } catch (_) {
+      return null;
+    }
+    if (dScalar.length != 32) return null;
+
+    final DpopKeyPair kp;
+    try {
+      kp = await keyManager.importDpopPrivateKey(dScalar);
+    } catch (_) {
+      return null;
+    }
+    final refreshToken = utf8.decode(refreshBytes, allowMalformed: false);
+    final tokens = TokenSet(
+      accessToken: stored.accessToken,
+      refreshToken: refreshToken,
+      expiresAt: stored.accessTokenExpiresAt,
+      tokenType: TokenType.fromString(stored.tokenType),
+      idToken: stored.idToken,
+    );
+    return _RehydratedSession(
+      tokens: tokens,
+      wrapKey: wrapKey,
+      dpopKeyPair: kp,
+    );
+  }
+
+  Future<void> _wipeCorruptSession() async {
+    try {
+      await tokenStore.clear(config.namespace);
+    } catch (_) {/* best-effort */}
+    _tokens = null;
+    _dpop = null;
+    _wrapKey = null;
+    _emitSecurity(SecurityEvent.storageCorruption(clock()));
+    _transition(const StateInput.initDone(hasTokens: false));
   }
 
   /// Builds a PKCE/state/nonce triple and the authorization URL the UI
@@ -434,27 +507,37 @@ class TokenWorker implements TokenProvider {
   Future<void> _persistSession(TokenSet tokens) async {
     final wrapKey = _wrapKey ??= await keyManager.generateWrapKey();
     final dpop = await _ensureDpop();
-    final wrappedRt = await keyManager.wrap(
+
+    // Wrap key: encrypt its raw bytes under the root key (persistent,
+    // keychain-backed).
+    final rootKeyBytes = await rootKeyStore.getOrCreate(config.namespace);
+    final rootKey = await keyManager.importWrapKey(rootKeyBytes);
+    final wrapKeyBytes = await keyManager.exportWrapKey(wrapKey);
+    final wrapKeyBlob = await keyManager.wrap(rootKey, wrapKeyBytes);
+
+    // DPoP private key: encrypt the 32-byte `d` scalar under the wrap key.
+    final dScalar = await keyManager.exportDpopPrivateKey(dpop.keyPair);
+    final dpopBlob = await keyManager.wrap(wrapKey, dScalar);
+
+    // Refresh token: encrypt UTF-8 bytes under the wrap key.
+    final refreshBlob = await keyManager.wrap(
       wrapKey,
       utf8.encode(tokens.refreshToken),
     );
-    // NOTE: proper wrapKey / DPoP private-key encryption is wired in a
-    // later task (requires a keychain-backed KEK). For now we persist
-    // empty placeholders so the schema is forward-compatible without
-    // leaking plaintext key material.
+
     await tokenStore.save(
       config.namespace,
       StoredSession(
-        wrappedRefreshToken: wrappedRt,
-        dpopKeyEncrypted: Uint8List(0),
-        wrapKeyEncrypted: Uint8List(0),
-        lastIdToken: tokens.idToken,
+        wrapKeyCiphertext: wrapKeyBlob,
+        dpopPrivateKeyCiphertext: dpopBlob,
+        refreshTokenCiphertext: refreshBlob,
+        accessToken: tokens.accessToken,
+        accessTokenExpiresAt: tokens.expiresAt,
+        tokenType: tokens.tokenType.headerValue,
+        idToken: tokens.idToken,
         updatedAt: clock(),
       ),
     );
-    // Touch `dpop` so the analyzer doesn't flag it — the real
-    // serialisation of the DPoP key lives in the next task.
-    assert(dpop.keyPair.privateKey.d != null);
   }
 
   Future<DpopContext> _ensureDpop() async {
@@ -468,6 +551,14 @@ class TokenWorker implements TokenProvider {
 
   Future<void> _securityWipe(String reason) async {
     await tokenStore.clear(config.namespace);
+    // Rotate the persistent root key so any leaked on-disk ciphertext is
+    // now undecryptable — even if the caller somehow bypasses
+    // [tokenStore.clear].
+    try {
+      await rootKeyStore.rotate(config.namespace);
+    } catch (_) {
+      // Best-effort: a failure here shouldn't block the wipe.
+    }
     _tokens = null;
     _dpop = null;
     _wrapKey = null;
@@ -515,6 +606,18 @@ class AuthorizeRequest {
 
 /// Used while a UserClaims-returning API stays in flux.
 UserClaims userClaimsFrom(Map<String, dynamic> raw) => UserClaims(raw);
+
+class _RehydratedSession {
+  const _RehydratedSession({
+    required this.tokens,
+    required this.wrapKey,
+    required this.dpopKeyPair,
+  });
+
+  final TokenSet tokens;
+  final WrapKey wrapKey;
+  final DpopKeyPair dpopKeyPair;
+}
 
 DateTime _defaultClock() => DateTime.now();
 

--- a/ui/runtime/lib/src/worker/token_worker.dart
+++ b/ui/runtime/lib/src/worker/token_worker.dart
@@ -1,0 +1,527 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/models/token_set.dart';
+import 'package:antinvestor_auth_runtime/src/models/user_claims.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/api_proxy.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/jwt.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/pkce.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
+import 'package:antinvestor_auth_runtime/src/runtime/refresh_lock.dart';
+import 'package:antinvestor_auth_runtime/src/runtime/state_machine.dart';
+import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
+import 'package:http/http.dart' as http;
+
+/// Signature for the injected clock. Default is [DateTime.now].
+typedef Clock = DateTime Function();
+
+/// Wraps [getDiscovery] behind an interface so tests can stub the
+/// discovery document without exercising the module-level cache.
+abstract class DiscoveryClient {
+  Future<OidcDiscovery> getDiscovery(
+    String idpBaseUrl,
+    Duration timeout,
+  );
+}
+
+/// Production [DiscoveryClient] that delegates to the real
+/// [getDiscovery] function. An optional [http.Client] hook is provided
+/// so integration tests can inject a [MockClient].
+class DefaultDiscoveryClient implements DiscoveryClient {
+  DefaultDiscoveryClient({http.Client? client}) : _client = client;
+
+  final http.Client? _client;
+
+  @override
+  Future<OidcDiscovery> getDiscovery(String idpBaseUrl, Duration timeout) =>
+      // ignore: invalid_use_of_internal_member
+      // `getDiscovery` is a top-level function in protocol/discovery.dart.
+      _fetch(idpBaseUrl, timeout);
+
+  Future<OidcDiscovery> _fetch(String url, Duration t) {
+    return (_client == null)
+        ? getDiscoveryCompat(url, t)
+        : getDiscoveryCompat(url, t, client: _client);
+  }
+}
+
+/// Thin alias so the (top-level) function name doesn't collide with the
+/// `DiscoveryClient.getDiscovery` method.
+Future<OidcDiscovery> getDiscoveryCompat(
+  String idpBaseUrl,
+  Duration timeout, {
+  http.Client? client,
+}) =>
+    getDiscovery(idpBaseUrl, timeout, client: client);
+
+/// Pure, testable core of the token worker.
+///
+/// Owns the session state-machine, refresh serialisation, crypto, storage
+/// and API proxy. All dependencies are injected via constructor so every
+/// edge can be stubbed in a unit test. Not yet bound to an Isolate — the
+/// Isolate harness is added in F-E.3.
+class TokenWorker implements TokenProvider {
+  TokenWorker({
+    required this.config,
+    required this.keyManager,
+    required this.tokenStore,
+    required this.discoveryClient,
+    required this.tokenExchange,
+    required this.apiProxy,
+    required this.refreshLock,
+    this.clock = _defaultClock,
+    this.accessTokenRefreshBuffer = const Duration(seconds: 60),
+  })  : _stateController = StreamController<AuthState>.broadcast(),
+        _securityController =
+            StreamController<SecurityEvent>.broadcast();
+
+  final ResolvedConfig config;
+  final KeyManager keyManager;
+  final TokenStore tokenStore;
+  final DiscoveryClient discoveryClient;
+  final TokenExchange tokenExchange;
+  final ApiProxy apiProxy;
+  final RefreshLock refreshLock;
+  final Clock clock;
+
+  /// How close to [TokenSet.expiresAt] we proactively refresh. Set to 60s
+  /// to cover typical 2xx latency + any clock skew within our tolerance.
+  final Duration accessTokenRefreshBuffer;
+
+  final StreamController<AuthState> _stateController;
+  final StreamController<SecurityEvent> _securityController;
+
+  AuthState _state = AuthState.initializing;
+  TokenSet? _tokens;
+  DpopContext? _dpop;
+  WrapKey? _wrapKey;
+  bool _destroyed = false;
+
+  Stream<AuthState> get authStateStream => _stateController.stream;
+  Stream<SecurityEvent> get securityEventStream => _securityController.stream;
+  AuthState get state => _state;
+
+  /// Initializes the worker: loads and decrypts any stored session, then
+  /// settles into `authenticated` or `unauthenticated`. Safe to call
+  /// once per instance.
+  Future<void> init() async {
+    _ensureAlive();
+    try {
+      final stored = await tokenStore.load(config.namespace);
+      if (stored == null) {
+        _transition(const StateInput.initDone(hasTokens: false));
+        return;
+      }
+      // Storage is present but the DPoP/wrap layer is stubbed for a
+      // later task. Without the ability to decrypt the wrap key, treat
+      // this as an empty session rather than failing hard.
+      // TODO(F-E.3 hardening): decrypt wrapKeyEncrypted + dpopKeyEncrypted
+      //   via hardware-backed keystore and unwrap the refresh token.
+      //   Until that lands, initializing from persisted storage lands in
+      //   `unauthenticated` so the worker falls back to a fresh sign-in.
+      _transition(const StateInput.initDone(hasTokens: false));
+    } catch (err) {
+      // Corrupt storage: wipe + fall through to unauthenticated.
+      await tokenStore.clear(config.namespace);
+      _emitSecurity(SecurityEvent.storageCorruption(clock()));
+      _transition(const StateInput.initDone(hasTokens: false));
+    }
+  }
+
+  /// Builds a PKCE/state/nonce triple and the authorization URL the UI
+  /// layer should open in a browser. Returns an opaque [AuthorizeRequest]
+  /// bundle so callers pass the same `verifier` back into [completeAuth].
+  Future<AuthorizeRequest> prepareAuth() async {
+    _ensureAlive();
+    final pkce = await generatePkcePair();
+    final state = _b64urlNoPad(randomBytes(16));
+    final nonce = _b64urlNoPad(randomBytes(16));
+
+    final discovery = await discoveryClient.getDiscovery(
+      config.idpBaseUrl,
+      config.discoveryTimeout,
+    );
+    final params = <String, String>{
+      'response_type': 'code',
+      'client_id': config.clientId,
+      'redirect_uri': config.redirectUri,
+      'scope': config.scopes.join(' '),
+      'code_challenge': pkce.challenge,
+      'code_challenge_method': 'S256',
+      'state': state,
+      'nonce': nonce,
+    };
+    final sep = discovery.authorizationEndpoint.contains('?') ? '&' : '?';
+    final qs = params.entries
+        .map((e) =>
+            '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}')
+        .join('&');
+    final url = '${discovery.authorizationEndpoint}$sep$qs';
+
+    return AuthorizeRequest(
+      url: url,
+      verifier: pkce.verifier,
+      state: state,
+      nonce: nonce,
+    );
+  }
+
+  /// Exchanges an OAuth [code] for tokens and persists the session.
+  ///
+  /// The [state] returned by the OAuth callback must match what
+  /// [prepareAuth] issued. [nonce] is recorded for a future id-token
+  /// check (skipped in this revision — see the plan).
+  Future<void> completeAuth({
+    required String code,
+    required String verifier,
+    required String state,
+    required String nonce,
+    required String expectedState,
+  }) async {
+    _ensureAlive();
+    if (state != expectedState) {
+      throw AuthError(
+        AuthErrorCode.oauthFailed,
+        'OAuth state mismatch',
+      );
+    }
+
+    // Build (or reuse) the DPoP context used for the exchange.
+    final ctx = await _ensureDpop();
+    // A completeAuth call implies the UI has already driven the
+    // browser leg, so transition through `initializing` to satisfy the
+    // spec §8 path `unauthenticated -> initializing -> authenticated`.
+    _transition(const StateInput.signInStart());
+    try {
+      final tokens = await tokenExchange.exchangeCode(
+        config,
+        ctx,
+        code: code,
+        verifier: verifier,
+      );
+      _tokens = tokens;
+
+      await _persistSession(tokens);
+      _transition(const StateInput.signInDone());
+    } catch (err) {
+      final ae = err is AuthError
+          ? err
+          : AuthError(AuthErrorCode.tokenExchangeFailed, 'sign-in failed',
+              cause: err);
+      _transition(StateInput.signInFail(ae));
+      rethrow;
+    }
+  }
+
+  /// Returns a fresh access token snapshot, triggering a refresh when the
+  /// current token is absent, near-expiry, or [force] is true.
+  @override
+  Future<TokenSnapshot> ensureFresh({bool force = false}) async {
+    _ensureAlive();
+    final current = _tokens;
+    if (current == null) {
+      throw AuthError(AuthErrorCode.tokenExpired, 'no session');
+    }
+    final now = clock();
+    final needs =
+        force || !now.isBefore(current.expiresAt.subtract(accessTokenRefreshBuffer));
+    if (!needs) {
+      return TokenSnapshot(
+        accessToken: current.accessToken,
+        tokenType: current.tokenType,
+      );
+    }
+    await refreshLock.withLock<void>(config.namespace, () async {
+      // Re-check under the lock: another task might have refreshed while
+      // we were waiting for acquisition.
+      final snap = _tokens;
+      if (snap != null &&
+          !force &&
+          now.isBefore(snap.expiresAt.subtract(accessTokenRefreshBuffer))) {
+        return;
+      }
+      await _doRefreshLocked();
+    });
+    final after = _tokens;
+    if (after == null) {
+      throw AuthError(
+        AuthErrorCode.tokenRefreshFailed,
+        'refresh did not produce a token',
+      );
+    }
+    return TokenSnapshot(
+      accessToken: after.accessToken,
+      tokenType: after.tokenType,
+    );
+  }
+
+  @override
+  void onRefresh() {
+    // Hook — downstream telemetry wires up in a later task.
+  }
+
+  /// Authenticated GET/POST/PUT/etc.
+  Future<ApiResponse> fetch({
+    required String path,
+    required String method,
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    _ensureAlive();
+    final ctx = await _ensureDpop();
+    return apiProxy.fetch(
+      config,
+      ctx,
+      this,
+      path: path,
+      method: method,
+      headers: headers,
+      body: body,
+      timeout: timeout,
+    );
+  }
+
+  /// Authenticated multipart upload.
+  Future<ApiResponse> upload({
+    required String path,
+    required String fieldName,
+    required String filename,
+    required String contentType,
+    required Stream<List<int>> bytes,
+    required int length,
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    _ensureAlive();
+    final ctx = await _ensureDpop();
+    return apiProxy.upload(
+      config,
+      ctx,
+      this,
+      path: path,
+      fieldName: fieldName,
+      filename: filename,
+      contentType: contentType,
+      bytes: bytes,
+      length: length,
+      headers: headers,
+      timeout: timeout,
+    );
+  }
+
+  /// Returns the decoded ID-token claims. Returns an empty map when no
+  /// ID token is known (e.g. sign-in used scopes without `openid`).
+  Future<Map<String, dynamic>> getClaims() async {
+    _ensureAlive();
+    final t = _tokens;
+    final id = t?.idToken;
+    if (id == null) return const <String, dynamic>{};
+    try {
+      return decodeJwtPayload(id);
+    } catch (_) {
+      return const <String, dynamic>{};
+    }
+  }
+
+  /// Role list extracted from the access token (Hydra-style).
+  Future<List<String>> getRoles() async {
+    _ensureAlive();
+    final t = _tokens;
+    if (t == null) return const <String>[];
+    return extractRolesFromToken(t.accessToken);
+  }
+
+  /// Best-effort logout: revoke refresh token + hit end_session, then
+  /// wipe all local state regardless of network outcome.
+  Future<void> logout() async {
+    _ensureAlive();
+    final t = _tokens;
+    OidcDiscovery? discovery;
+    try {
+      discovery = await discoveryClient.getDiscovery(
+        config.idpBaseUrl,
+        config.discoveryTimeout,
+      );
+    } catch (_) {
+      discovery = null;
+    }
+
+    if (t != null && discovery?.revocationEndpoint != null) {
+      try {
+        final body = _encodeForm(<String, String>{
+          'token': t.refreshToken,
+          'token_type_hint': 'refresh_token',
+          'client_id': config.clientId,
+        });
+        await http
+            .post(
+              Uri.parse(discovery!.revocationEndpoint!),
+              headers: const {
+                'Content-Type': 'application/x-www-form-urlencoded',
+              },
+              body: body,
+            )
+            .timeout(config.tokenTimeout);
+      } catch (_) {
+        // Best-effort only.
+      }
+    }
+
+    if (discovery?.endSessionEndpoint != null) {
+      try {
+        final uri = Uri.parse(discovery!.endSessionEndpoint!);
+        await http.get(uri).timeout(config.tokenTimeout);
+      } catch (_) {
+        // Best-effort only.
+      }
+    }
+
+    await tokenStore.clear(config.namespace);
+    _tokens = null;
+    _dpop = null;
+    _wrapKey = null;
+    _transition(const StateInput.logout());
+  }
+
+  /// Stops the worker: closes streams and releases ephemeral state.
+  Future<void> destroy() async {
+    if (_destroyed) return;
+    _destroyed = true;
+    _tokens = null;
+    _dpop = null;
+    _wrapKey = null;
+    await _stateController.close();
+    await _securityController.close();
+  }
+
+  // ---- internal helpers ---------------------------------------------------
+
+  Future<void> _doRefreshLocked() async {
+    final refresh = _tokens?.refreshToken;
+    if (refresh == null) {
+      throw AuthError(AuthErrorCode.tokenExpired, 'no refresh token');
+    }
+    _transition(const StateInput.refreshStart());
+    final ctx = await _ensureDpop();
+    final outcome = await tokenExchange.refresh(config, ctx, refresh);
+    switch (outcome) {
+      case RefreshRotated(:final tokens):
+        _tokens = tokens;
+        await _persistSession(tokens);
+        _transition(const StateInput.refreshDone());
+      case RefreshReuseDetectedOutcome():
+        await _securityWipe('refresh-reuse');
+        throw AuthError(
+          AuthErrorCode.refreshReuseDetected,
+          'refresh token reuse detected',
+        );
+      case RefreshNetworkError(:final error):
+        _transition(StateInput.refreshFail(error: error, wipe: false));
+        throw error;
+    }
+  }
+
+  Future<void> _persistSession(TokenSet tokens) async {
+    final wrapKey = _wrapKey ??= await keyManager.generateWrapKey();
+    final dpop = await _ensureDpop();
+    final wrappedRt = await keyManager.wrap(
+      wrapKey,
+      utf8.encode(tokens.refreshToken),
+    );
+    // NOTE: proper wrapKey / DPoP private-key encryption is wired in a
+    // later task (requires a keychain-backed KEK). For now we persist
+    // empty placeholders so the schema is forward-compatible without
+    // leaking plaintext key material.
+    await tokenStore.save(
+      config.namespace,
+      StoredSession(
+        wrappedRefreshToken: wrappedRt,
+        dpopKeyEncrypted: Uint8List(0),
+        wrapKeyEncrypted: Uint8List(0),
+        lastIdToken: tokens.idToken,
+        updatedAt: clock(),
+      ),
+    );
+    // Touch `dpop` so the analyzer doesn't flag it — the real
+    // serialisation of the DPoP key lives in the next task.
+    assert(dpop.keyPair.privateKey.d != null);
+  }
+
+  Future<DpopContext> _ensureDpop() async {
+    final existing = _dpop;
+    if (existing != null) return existing;
+    final kp = await keyManager.generateDpopKey();
+    final ctx = await makeDpopContextAsync(kp, keyManager: keyManager);
+    _dpop = ctx;
+    return ctx;
+  }
+
+  Future<void> _securityWipe(String reason) async {
+    await tokenStore.clear(config.namespace);
+    _tokens = null;
+    _dpop = null;
+    _wrapKey = null;
+    _emitSecurity(SecurityEvent.refreshReuseDetected(clock()));
+    _transition(StateInput.securityWipe(reason));
+  }
+
+  void _transition(StateInput input) {
+    final next = reduce(_state, input);
+    if (next != _state) {
+      _state = next;
+      if (!_stateController.isClosed) {
+        _stateController.add(next);
+      }
+    }
+  }
+
+  void _emitSecurity(SecurityEvent ev) {
+    if (!_securityController.isClosed) {
+      _securityController.add(ev);
+    }
+  }
+
+  void _ensureAlive() {
+    if (_destroyed) {
+      throw StateError('TokenWorker has been destroyed');
+    }
+  }
+}
+
+/// Opaque bundle returned by [TokenWorker.prepareAuth].
+class AuthorizeRequest {
+  const AuthorizeRequest({
+    required this.url,
+    required this.verifier,
+    required this.state,
+    required this.nonce,
+  });
+
+  final String url;
+  final String verifier;
+  final String state;
+  final String nonce;
+}
+
+/// Used while a UserClaims-returning API stays in flux.
+UserClaims userClaimsFrom(Map<String, dynamic> raw) => UserClaims(raw);
+
+DateTime _defaultClock() => DateTime.now();
+
+String _b64urlNoPad(List<int> bytes) =>
+    base64Url.encode(bytes).replaceAll('=', '');
+
+String _encodeForm(Map<String, String> form) => form.entries
+    .map((e) =>
+        '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}')
+    .join('&');

--- a/ui/runtime/pubspec.yaml
+++ b/ui/runtime/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   http_parser: ^4.1.0
   crypto: ^3.0.6
   async: ^2.11.0
+  synchronized: ^3.1.0+1
   equatable: ^2.0.7
   uuid: ^4.5.1
   meta: ^1.15.0

--- a/ui/runtime/pubspec.yaml
+++ b/ui/runtime/pubspec.yaml
@@ -1,0 +1,45 @@
+name: antinvestor_auth_runtime
+description: >
+  Auth runtime for Antinvestor Flutter apps. OAuth2 + PKCE, adaptive DPoP,
+  rotating refresh tokens with reuse detection, Isolate-isolated tokens,
+  hardware-backed storage, Riverpod providers, Material widgets.
+version: 0.1.0
+repository: https://github.com/antinvestor/service-authentication
+homepage: https://github.com/antinvestor/service-authentication/tree/main/ui/runtime
+issue_tracker: https://github.com/antinvestor/service-authentication/issues
+topics:
+  - flutter
+  - authentication
+  - oauth2
+  - dpop
+  - antinvestor
+
+environment:
+  sdk: ^3.11.0
+  flutter: ">=3.24.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^3.3.1
+  flutter_secure_storage: ^9.2.2
+  flutter_appauth: ^8.0.0+1
+  cryptography: ^2.7.0
+  http: ^1.2.2
+  crypto: ^3.0.6
+  async: ^2.11.0
+  equatable: ^2.0.7
+  uuid: ^4.5.1
+  meta: ^1.15.0
+  collection: ^1.18.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^6.0.0
+  mocktail: ^1.0.4
+  shelf: ^1.4.1
+  shelf_router: ^1.1.4
+
+flutter:
+  uses-material-design: true

--- a/ui/runtime/pubspec.yaml
+++ b/ui/runtime/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   flutter_secure_storage: ^9.2.2
   flutter_appauth: ^8.0.0+1
   cryptography: ^2.7.0
+  pointycastle: ^3.9.1
   http: ^1.2.2
   crypto: ^3.0.6
   async: ^2.11.0

--- a/ui/runtime/pubspec.yaml
+++ b/ui/runtime/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   cryptography: ^2.7.0
   pointycastle: ^3.9.1
   http: ^1.2.2
+  http_parser: ^4.1.0
   crypto: ^3.0.6
   async: ^2.11.0
   equatable: ^2.0.7

--- a/ui/runtime/test/auth_runtime_test.dart
+++ b/ui/runtime/test/auth_runtime_test.dart
@@ -322,11 +322,14 @@ void main() {
     await rt.dispose();
   });
 
-  test('useIsolate: true is rejected in v0.1 baseline', () {
-    expect(
-      () => createAuthRuntime(_config, useIsolate: true),
-      throwsA(isA<UnsupportedError>()),
-    );
+  test('useIsolate: true returns an IsolatedAuthRuntime-backed shell',
+      () async {
+    // The shell spawns the scaffolding isolate entry point and only
+    // implements lifecycle in v0.1; data-plane calls throw
+    // UnimplementedError (covered by test/worker/token_isolate_test.dart).
+    final rt = createAuthRuntime(_config, useIsolate: true);
+    expect(rt.version, authRuntimeVersion);
+    await rt.dispose();
   });
 
   test('concrete type is AuthRuntimeImpl (in-thread baseline)', () async {

--- a/ui/runtime/test/auth_runtime_test.dart
+++ b/ui/runtime/test/auth_runtime_test.dart
@@ -1,0 +1,337 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/auth_runtime_impl.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
+import 'package:antinvestor_auth_runtime/src/oauth/oauth_flow.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/api_proxy.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
+import 'package:antinvestor_auth_runtime/src/runtime/refresh_lock.dart';
+import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
+import 'package:antinvestor_auth_runtime/src/worker/token_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class _FakeDiscoveryClient implements DiscoveryClient {
+  @override
+  Future<OidcDiscovery> getDiscovery(String idpBaseUrl, Duration timeout) async {
+    return OidcDiscovery(
+      issuer: idpBaseUrl,
+      authorizationEndpoint: '$idpBaseUrl/oauth2/auth',
+      tokenEndpoint: '$idpBaseUrl/oauth2/token',
+      endSessionEndpoint: '$idpBaseUrl/oauth2/sessions/logout',
+      revocationEndpoint: '$idpBaseUrl/oauth2/revoke',
+    );
+  }
+}
+
+class _FakeTokenExchange extends TokenExchange {
+  _FakeTokenExchange() : super(timeout: const Duration(seconds: 5));
+
+  final List<TokenSet> queue = [];
+  int calls = 0;
+
+  @override
+  Future<TokenSet> exchangeCode(
+    ResolvedConfig cfg,
+    DpopContext ctx, {
+    required String code,
+    required String verifier,
+  }) async {
+    calls++;
+    if (queue.isEmpty) {
+      throw AuthError(AuthErrorCode.tokenExchangeFailed, 'no token queued');
+    }
+    return queue.removeAt(0);
+  }
+}
+
+class _FakeApiProxy extends ApiProxy {
+  _FakeApiProxy();
+
+  int fetchCalls = 0;
+  String? seenPath;
+  String? seenMethod;
+
+  @override
+  Future<ApiResponse> fetch(
+    ResolvedConfig cfg,
+    DpopContext ctx,
+    TokenProvider tp, {
+    required String path,
+    required String method,
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    fetchCalls++;
+    seenPath = path;
+    seenMethod = method;
+    await tp.ensureFresh();
+    return ApiResponse(
+      status: 200,
+      headers: const {'content-type': 'application/json'},
+      body: Uint8List.fromList(utf8.encode('{"ok":true}')),
+    );
+  }
+}
+
+class _FakeOAuthFlow extends OAuthFlow {
+  _FakeOAuthFlow({required this.code, required this.verifier});
+
+  final String code;
+  final String verifier;
+  int authorizeCalls = 0;
+
+  @override
+  Future<OAuthResult> authorize(ResolvedConfig cfg) async {
+    authorizeCalls++;
+    return OAuthResult(
+      code: code,
+      verifier: verifier,
+      state: null,
+      nonce: null,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const _config = AuthConfig(
+  clientId: 'runtime-client',
+  idpBaseUrl: 'https://idp.example.com',
+  apiBaseUrl: 'https://api.example.com',
+  redirectScheme: 'com.example.app',
+);
+
+TokenSet _tokens({
+  String access = 'at-1',
+  String refresh = 'rt-1',
+  String? id,
+  DateTime? expiresAt,
+}) =>
+    TokenSet(
+      accessToken: access,
+      refreshToken: refresh,
+      expiresAt: expiresAt ?? DateTime.utc(2030, 1, 1),
+      tokenType: TokenType.bearer,
+      idToken: id,
+    );
+
+String _makeJwt(Map<String, dynamic> payload) {
+  String strip(String s) => s.replaceAll('=', '');
+  final header = strip(base64Url.encode(utf8.encode(json.encode({'alg': 'RS256'}))));
+  final body = strip(base64Url.encode(utf8.encode(json.encode(payload))));
+  final sig = strip(base64Url.encode([1, 2, 3]));
+  return '$header.$body.$sig';
+}
+
+class _Harness {
+  _Harness({
+    TokenSet? initialTokens,
+    _FakeOAuthFlow? flow,
+    InMemoryKeyValueStore? sessionKv,
+    InMemoryKeyValueStore? rootKv,
+  })  : sessionKv = sessionKv ?? InMemoryKeyValueStore(),
+        rootKv = rootKv ?? InMemoryKeyValueStore(),
+        oauthFlow = flow ??
+            _FakeOAuthFlow(code: 'code-1', verifier: 'verif-1') {
+    exchange = _FakeTokenExchange();
+    if (initialTokens != null) exchange.queue.add(initialTokens);
+  }
+
+  final _FakeOAuthFlow oauthFlow;
+  final InMemoryKeyValueStore sessionKv;
+  final InMemoryKeyValueStore rootKv;
+  late final _FakeTokenExchange exchange;
+  final _FakeApiProxy apiProxy = _FakeApiProxy();
+
+  AuthRuntime build() => createAuthRuntime(
+        _config,
+        keyManager: DefaultKeyManager(),
+        rootKeyStore: DefaultRootKeyStore(kv: rootKv),
+        tokenStore: SecureTokenStore(kv: sessionKv),
+        discoveryClient: _FakeDiscoveryClient(),
+        tokenExchange: exchange,
+        apiProxy: apiProxy,
+        refreshLock: RefreshLock(),
+        oauthFlow: oauthFlow,
+      );
+}
+
+void main() {
+  tearDown(clearDiscoveryCache);
+
+  test('fresh runtime starts in unauthenticated', () async {
+    final h = _Harness();
+    final rt = h.build();
+    // Allow init() to settle.
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    expect(rt.state, AuthState.unauthenticated);
+    await rt.dispose();
+  });
+
+  test('ensureAuthenticated drives OAuth and transitions to authenticated',
+      () async {
+    final h = _Harness(initialTokens: _tokens(access: 'at-fresh'));
+    final rt = h.build();
+    final states = <AuthState>[];
+    rt.authStateStream.listen(states.add);
+
+    await rt.ensureAuthenticated();
+    await Future<void>.delayed(Duration.zero);
+
+    expect(rt.state, AuthState.authenticated);
+    expect(h.oauthFlow.authorizeCalls, 1);
+    expect(h.exchange.calls, 1);
+    expect(states.last, AuthState.authenticated);
+    await rt.dispose();
+  });
+
+  test('ensureAuthenticated is a no-op when already authenticated', () async {
+    final h = _Harness(initialTokens: _tokens());
+    final rt = h.build();
+    await rt.ensureAuthenticated();
+    expect(h.oauthFlow.authorizeCalls, 1);
+
+    await rt.ensureAuthenticated();
+    expect(h.oauthFlow.authorizeCalls, 1,
+        reason: 'a second call with live session must not reopen the browser');
+    await rt.dispose();
+  });
+
+  test('concurrent ensureAuthenticated callers share one OAuth flow',
+      () async {
+    final h = _Harness(initialTokens: _tokens());
+    final rt = h.build();
+    final a = rt.ensureAuthenticated();
+    final b = rt.ensureAuthenticated();
+    await Future.wait([a, b]);
+    expect(h.oauthFlow.authorizeCalls, 1);
+    await rt.dispose();
+  });
+
+  test(
+      'second runtime instance over the same storage starts authenticated '
+      'without re-doing OAuth', () async {
+    final sessionKv = InMemoryKeyValueStore();
+    final rootKv = InMemoryKeyValueStore();
+
+    final h1 = _Harness(
+      initialTokens: _tokens(access: 'at-persisted'),
+      sessionKv: sessionKv,
+      rootKv: rootKv,
+    );
+    final rt1 = h1.build();
+    await rt1.ensureAuthenticated();
+    expect(rt1.state, AuthState.authenticated);
+    await rt1.dispose();
+
+    final h2 = _Harness(sessionKv: sessionKv, rootKv: rootKv);
+    final rt2 = h2.build();
+    // Allow init() to finish decrypting.
+    await Future<void>.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
+    expect(rt2.state, AuthState.authenticated);
+    // OAuth must NOT have been reopened.
+    expect(h2.oauthFlow.authorizeCalls, 0);
+    expect(h2.exchange.calls, 0);
+    await rt2.dispose();
+  });
+
+  test('fetch proxies through to the worker/ApiProxy', () async {
+    final h = _Harness(initialTokens: _tokens());
+    final rt = h.build();
+    await rt.ensureAuthenticated();
+
+    final res = await rt.fetch('/users/me', method: 'GET');
+    expect(res.status, 200);
+    expect(h.apiProxy.fetchCalls, 1);
+    expect(h.apiProxy.seenPath, '/users/me');
+    expect(h.apiProxy.seenMethod, 'GET');
+    await rt.dispose();
+  });
+
+  test('getClaims returns empty map when unauthenticated', () async {
+    final h = _Harness();
+    final rt = h.build();
+    await Future<void>.delayed(Duration.zero);
+    final claims = await rt.getClaims();
+    expect(claims, isEmpty);
+    final roles = await rt.getRoles();
+    expect(roles, isEmpty);
+    await rt.dispose();
+  });
+
+  test('getClaims / getRoles after auth', () async {
+    final id = _makeJwt({'sub': 'u-42', 'email': 'alice@example.com'});
+    final access = _makeJwt({
+      'sub': 'u-42',
+      'roles': ['admin', 'staff'],
+    });
+    final h = _Harness(initialTokens: _tokens(access: access, id: id));
+    final rt = h.build();
+    await rt.ensureAuthenticated();
+
+    final claims = await rt.getClaims();
+    expect(claims['sub'], 'u-42');
+    expect(claims['email'], 'alice@example.com');
+
+    final roles = await rt.getRoles();
+    expect(roles, ['admin', 'staff']);
+    await rt.dispose();
+  });
+
+  test('logout clears local state and transitions to unauthenticated',
+      () async {
+    final h = _Harness(initialTokens: _tokens());
+    final rt = h.build();
+    await rt.ensureAuthenticated();
+    expect(rt.state, AuthState.authenticated);
+
+    await rt.logout();
+    expect(rt.state, AuthState.unauthenticated);
+    await rt.dispose();
+  });
+
+  test('dispose is idempotent and subsequent operations throw', () async {
+    final h = _Harness();
+    final rt = h.build();
+    await Future<void>.delayed(Duration.zero);
+    await rt.dispose();
+    await rt.dispose(); // no throw
+    expect(() => rt.fetch('/x'), throwsStateError);
+    expect(() => rt.ensureAuthenticated(), throwsStateError);
+  });
+
+  test('version exposes authRuntimeVersion constant', () async {
+    final rt = _Harness().build();
+    expect(rt.version, authRuntimeVersion);
+    expect(rt.version, '0.1.0');
+    await rt.dispose();
+  });
+
+  test('useIsolate: true is rejected in v0.1 baseline', () {
+    expect(
+      () => createAuthRuntime(_config, useIsolate: true),
+      throwsA(isA<UnsupportedError>()),
+    );
+  });
+
+  test('concrete type is AuthRuntimeImpl (in-thread baseline)', () async {
+    final rt = _Harness().build();
+    expect(rt, isA<AuthRuntimeImpl>());
+    await rt.dispose();
+  });
+}

--- a/ui/runtime/test/config/resolve_config_test.dart
+++ b/ui/runtime/test/config/resolve_config_test.dart
@@ -1,0 +1,123 @@
+import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('throws invalidConfig when clientId is empty', () {
+    expect(
+      () => resolveConfig(const AuthConfig(
+        clientId: '',
+        idpBaseUrl: 'https://i',
+        apiBaseUrl: 'https://a',
+        redirectScheme: 'x',
+      )),
+      throwsA(isA<AuthError>()
+          .having((e) => e.code, 'code', AuthErrorCode.invalidConfig)),
+    );
+  });
+
+  test('throws invalidConfig when idpBaseUrl is empty', () {
+    expect(
+      () => resolveConfig(const AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: '',
+        apiBaseUrl: 'https://a',
+        redirectScheme: 'x',
+      )),
+      throwsA(isA<AuthError>()
+          .having((e) => e.code, 'code', AuthErrorCode.invalidConfig)),
+    );
+  });
+
+  test('throws invalidConfig when apiBaseUrl is empty', () {
+    expect(
+      () => resolveConfig(const AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: 'https://i',
+        apiBaseUrl: '',
+        redirectScheme: 'x',
+      )),
+      throwsA(isA<AuthError>()
+          .having((e) => e.code, 'code', AuthErrorCode.invalidConfig)),
+    );
+  });
+
+  test('throws invalidConfig when redirectScheme is empty', () {
+    expect(
+      () => resolveConfig(const AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: 'https://i',
+        apiBaseUrl: 'https://a',
+        redirectScheme: '',
+      )),
+      throwsA(isA<AuthError>()
+          .having((e) => e.code, 'code', AuthErrorCode.invalidConfig)),
+    );
+  });
+
+  test('strips trailing slashes and namespaces', () {
+    final cfg = resolveConfig(const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://i/',
+      apiBaseUrl: 'https://a/',
+      redirectScheme: 'com.example.app',
+    ));
+    expect(cfg.idpBaseUrl, 'https://i');
+    expect(cfg.apiBaseUrl, 'https://a');
+    expect(cfg.namespace, 'c::https://i');
+    expect(cfg.scopes, contains('offline_access'));
+  });
+
+  test('applies default scopes when caller omits them', () {
+    final cfg = resolveConfig(const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://i',
+      apiBaseUrl: 'https://a',
+      redirectScheme: 'x',
+    ));
+    expect(cfg.scopes, ['openid', 'profile', 'email', 'offline_access']);
+  });
+
+  test('honors timeout overrides partially', () {
+    final cfg = resolveConfig(const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://i',
+      apiBaseUrl: 'https://a',
+      redirectScheme: 'x',
+      apiTimeout: Duration(seconds: 5),
+    ));
+    expect(cfg.apiTimeout, const Duration(seconds: 5));
+    expect(cfg.tokenTimeout, const Duration(seconds: 10));
+    expect(cfg.discoveryTimeout, const Duration(seconds: 10));
+    expect(cfg.uploadTimeout, const Duration(seconds: 60));
+  });
+
+  test('keeps caller-provided scopes', () {
+    final cfg = resolveConfig(const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://i',
+      apiBaseUrl: 'https://a',
+      redirectScheme: 'x',
+      scopes: ['openid', 'profile'],
+    ));
+    expect(cfg.scopes, ['openid', 'profile']);
+  });
+
+  test('AuthConfig has value equality', () {
+    const a = AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://i',
+      apiBaseUrl: 'https://a',
+      redirectScheme: 'x',
+    );
+    const b = AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://i',
+      apiBaseUrl: 'https://a',
+      redirectScheme: 'x',
+    );
+    expect(a, equals(b));
+    expect(a.hashCode, b.hashCode);
+  });
+}

--- a/ui/runtime/test/crypto/key_manager_test.dart
+++ b/ui/runtime/test/crypto/key_manager_test.dart
@@ -1,0 +1,135 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late KeyManager km;
+
+  setUp(() {
+    km = DefaultKeyManager();
+  });
+
+  group('DPoP key', () {
+    test('generateDpopKey produces a usable P-256 pair', () async {
+      final kp = await km.generateDpopKey();
+      expect(kp.privateKey.d, isNotNull);
+      expect(kp.publicKey.Q, isNotNull);
+    });
+
+    test('exportDpopPublicJwk has kty/crv/x/y with 32-byte components',
+        () async {
+      final kp = await km.generateDpopKey();
+      final jwk = await km.exportDpopPublicJwk(kp);
+      expect(jwk['kty'], 'EC');
+      expect(jwk['crv'], 'P-256');
+      expect(jwk['x'], isA<String>());
+      expect(jwk['y'], isA<String>());
+      // base64url-no-pad of 32 bytes is 43 chars.
+      expect((jwk['x'] as String).length, 43);
+      expect((jwk['y'] as String).length, 43);
+    });
+
+    test('signDpopJws produces a 64-byte raw r||s signature that verifies',
+        () async {
+      final kp = await km.generateDpopKey();
+      const input = 'header.payload';
+      final sig = await km.signDpopJws(kp, input);
+      expect(sig.length, 64);
+      // Verify via PointyCastle path exposed by dpop.dart.
+      final ok = verifyEcdsaRaw(
+        kp.publicKey,
+        Uint8List.fromList(utf8.encode(input)),
+        sig,
+      );
+      expect(ok, isTrue);
+    });
+
+    test(
+        'DpopContext wired with keyManager signs via the injected backend '
+        'and still verifies against the embedded public key', () async {
+      final kp = await km.generateDpopKey();
+      final ctx = await makeDpopContextAsync(kp, keyManager: km);
+      final proof = await buildProof(
+        ctx,
+        htm: 'POST',
+        htu: 'https://idp.example.com/token',
+      );
+      final parts = proof.split('.');
+      expect(parts.length, 3);
+      final signingInput = '${parts[0]}.${parts[1]}';
+      final padded = parts[2]
+          .padRight(parts[2].length + (4 - parts[2].length % 4) % 4, '=');
+      final sig = base64Url.decode(padded);
+      final ok = verifyEcdsaRaw(
+        kp.publicKey,
+        Uint8List.fromList(utf8.encode(signingInput)),
+        sig,
+      );
+      expect(ok, isTrue);
+    });
+  });
+
+  group('wrap/unwrap', () {
+    test('generateWrapKey produces a 256-bit secret', () async {
+      final wk = await km.generateWrapKey();
+      final bytes = await wk.secretKey.extractBytes();
+      expect(bytes.length, 32);
+    });
+
+    test('wrap/unwrap round-trips', () async {
+      final wk = await km.generateWrapKey();
+      final plaintext = utf8.encode('the-refresh-token-value');
+      final blob = await km.wrap(wk, plaintext);
+      expect(blob.iv.length, greaterThanOrEqualTo(12));
+      expect(blob.ciphertext.length,
+          greaterThan(plaintext.length)); // includes MAC
+      final back = await km.unwrap(wk, blob);
+      expect(utf8.decode(back), 'the-refresh-token-value');
+    });
+
+    test('two wrap calls produce different ciphertexts (fresh IV)', () async {
+      final wk = await km.generateWrapKey();
+      final plaintext = utf8.encode('same-input');
+      final a = await km.wrap(wk, plaintext);
+      final b = await km.wrap(wk, plaintext);
+      expect(a.iv, isNot(equals(b.iv)));
+      expect(a.ciphertext, isNot(equals(b.ciphertext)));
+    });
+
+    test('unwrap with a different key throws storageCorruption', () async {
+      final wk1 = await km.generateWrapKey();
+      final wk2 = await km.generateWrapKey();
+      final blob = await km.wrap(wk1, utf8.encode('hello'));
+      expect(
+        () => km.unwrap(wk2, blob),
+        throwsA(isA<AuthError>().having(
+          (e) => e.code,
+          'code',
+          AuthErrorCode.storageCorruption,
+        )),
+      );
+    });
+
+    test('tampered ciphertext fails auth and throws storageCorruption',
+        () async {
+      final wk = await km.generateWrapKey();
+      final blob = await km.wrap(wk, utf8.encode('hello'));
+      final tampered = Uint8List.fromList(blob.ciphertext);
+      tampered[0] ^= 0x01;
+      final corrupt = WrappedBlob(iv: blob.iv, ciphertext: tampered);
+      expect(
+        () => km.unwrap(wk, corrupt),
+        throwsA(isA<AuthError>().having(
+          (e) => e.code,
+          'code',
+          AuthErrorCode.storageCorruption,
+        )),
+      );
+    });
+  });
+}

--- a/ui/runtime/test/integration/_helpers.dart
+++ b/ui/runtime/test/integration/_helpers.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/auth_runtime_impl.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
+import 'package:antinvestor_auth_runtime/src/oauth/oauth_flow.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/api_proxy.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
+import 'package:antinvestor_auth_runtime/src/runtime/refresh_lock.dart';
+import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
+import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
+import 'package:antinvestor_auth_runtime/src/worker/token_worker.dart';
+
+import 'mock_idp.dart';
+
+/// Deterministic controllable clock.
+///
+/// The integration tests inject this into [TokenWorker] so they can
+/// fast-forward across access-token expiry without sleeping for real time.
+class TestClock {
+  TestClock(this._now);
+
+  DateTime _now;
+
+  DateTime now() => _now;
+
+  void advance(Duration d) {
+    _now = _now.add(d);
+  }
+
+  void setTo(DateTime t) {
+    _now = t;
+  }
+}
+
+/// Short-circuits the browser leg of OAuth: returns a pre-built
+/// code/verifier/state triple without ever opening a browser. The
+/// MockIdp's `/token` handler accepts any code, so we don't even need to
+/// hit a real `/authorize` endpoint.
+///
+/// The fake preserves the [OAuthFlow] public shape by extending it and
+/// overriding `authorize`.
+class FakeOAuthFlow implements OAuthFlow {
+  FakeOAuthFlow({this.code = 'fake-code', this.verifier = 'fake-verifier'});
+
+  final String code;
+  final String verifier;
+  int calls = 0;
+
+  String? lastState;
+  String? lastNonce;
+
+  /// Driven from outside: if set, [authorize] throws this instead of
+  /// returning a result. Lets tests exercise the cancellation path.
+  Object? pendingError;
+
+  @override
+  Future<OAuthResult> authorize(ResolvedConfig cfg) async {
+    calls++;
+    final err = pendingError;
+    if (err != null) {
+      pendingError = null;
+      throw err;
+    }
+    return OAuthResult(
+      code: code,
+      verifier: verifier,
+      state: lastState,
+      nonce: lastNonce,
+    );
+  }
+}
+
+/// Bundle returned by [buildHarness] — exposes everything a test needs
+/// to assert against without reaching into the factory.
+class IntegrationHarness {
+  IntegrationHarness({
+    required this.runtime,
+    required this.worker,
+    required this.mock,
+    required this.fakeOAuth,
+    required this.clock,
+    required this.tokenStore,
+    required this.sessionKv,
+    required this.rootKv,
+    required this.config,
+  });
+
+  final AuthRuntime runtime;
+  final TokenWorker worker;
+  final MockIdp mock;
+  final FakeOAuthFlow fakeOAuth;
+  final TestClock clock;
+  final TokenStore tokenStore;
+  final KeyValueStore sessionKv;
+  final KeyValueStore rootKv;
+  final ResolvedConfig config;
+
+  Future<void> dispose() async {
+    await runtime.dispose();
+    clearDiscoveryCache();
+    await mock.stop();
+  }
+}
+
+/// Builds an end-to-end wired runtime pointed at a running MockIdp.
+///
+/// The runtime uses the real in-thread [TokenWorker] + real
+/// [TokenExchange] + real [ApiProxy] so the HTTP round-trips, DPoP proofs
+/// and discovery cache are all exercised exactly as they would be in
+/// production. The only seam is the browser leg: a [FakeOAuthFlow] that
+/// returns a pre-built [OAuthResult].
+///
+/// The caller should invoke `await harness.dispose()` in `tearDown`.
+Future<IntegrationHarness> buildHarness({
+  MockIdp? mock,
+  TestClock? clock,
+  FakeOAuthFlow? fakeOAuth,
+  KeyValueStore? sessionKv,
+  KeyValueStore? rootKv,
+}) async {
+  final m = mock ?? MockIdp();
+  // Idempotent start: if the mock hasn't listened yet, start it. Tests
+  // that pre-start the mock (to configure toggles before runtime build)
+  // hit the `try` path.
+  String base;
+  final existing = _tryGetBaseUrl(m);
+  if (existing != null) {
+    base = existing;
+  } else {
+    base = await m.start();
+  }
+
+  final testClock = clock ?? TestClock(DateTime.now());
+  final fake = fakeOAuth ?? FakeOAuthFlow();
+  final sKv = sessionKv ?? InMemoryKeyValueStore();
+  final rKv = rootKv ?? InMemoryKeyValueStore();
+
+  final cfg = resolveConfig(AuthConfig(
+    clientId: 'antinvestor-mobile',
+    idpBaseUrl: base,
+    apiBaseUrl: base, // Authenticated API calls land on the mock too.
+    redirectScheme: 'com.antinvestor.test',
+    scopes: const <String>['openid', 'profile', 'email', 'offline_access'],
+  ));
+
+  // Clear the module-level discovery cache so each test starts fresh.
+  clearDiscoveryCache();
+
+  final tokenStore = SecureTokenStore(kv: sKv);
+  final worker = TokenWorker(
+    config: cfg,
+    keyManager: DefaultKeyManager(),
+    rootKeyStore: DefaultRootKeyStore(kv: rKv),
+    tokenStore: tokenStore,
+    discoveryClient: DefaultDiscoveryClient(),
+    tokenExchange: TokenExchange(timeout: cfg.tokenTimeout),
+    apiProxy: ApiProxy(),
+    refreshLock: RefreshLock(),
+    clock: testClock.now,
+  );
+
+  final runtime = AuthRuntimeImpl(
+    config: cfg,
+    worker: worker,
+    oauthFlow: fake,
+  );
+  await runtime.init();
+
+  return IntegrationHarness(
+    runtime: runtime,
+    worker: worker,
+    mock: m,
+    fakeOAuth: fake,
+    clock: testClock,
+    tokenStore: tokenStore,
+    sessionKv: sKv,
+    rootKv: rKv,
+    config: cfg,
+  );
+}
+
+String? _tryGetBaseUrl(MockIdp m) {
+  try {
+    return m.baseUrl;
+  } catch (_) {
+    return null;
+  }
+}

--- a/ui/runtime/test/integration/clock_skew_test.dart
+++ b/ui/runtime/test/integration/clock_skew_test.dart
@@ -1,0 +1,38 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '_helpers.dart';
+import 'mock_idp.dart';
+
+void main() {
+  late IntegrationHarness h;
+
+  tearDown(() async {
+    await h.dispose();
+  });
+
+  test(
+      'invalid_dpop_proof with future Date header triggers client-side '
+      'offset and retry', () async {
+    final mock = MockIdp()..enableClockSkewChallenge();
+    h = await buildHarness(mock: mock);
+
+    await h.runtime.ensureAuthenticated();
+    expect(h.runtime.state, AuthState.authenticated);
+
+    final hits = h.mock.tokenRequests
+        .where((r) => r.grantType == 'authorization_code')
+        .toList();
+    // Exactly two hits: first rejected for skew, second retried after the
+    // runtime applied the Date-header offset.
+    expect(hits, hasLength(2));
+
+    final firstIat = hits[0].dpopClaims!.iat;
+    final retryIat = hits[1].dpopClaims!.iat;
+    // Retry iat should be ~5 minutes (the Date-header offset) ahead of
+    // the first proof. Allow a generous tolerance for scheduler latency.
+    final delta = retryIat - firstIat;
+    expect(delta, greaterThan(240)); // > 4 minutes
+    expect(delta, lessThan(360)); // < 6 minutes
+  });
+}

--- a/ui/runtime/test/integration/dpop_nonce_test.dart
+++ b/ui/runtime/test/integration/dpop_nonce_test.dart
@@ -1,0 +1,36 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '_helpers.dart';
+import 'mock_idp.dart';
+
+void main() {
+  late IntegrationHarness h;
+
+  tearDown(() async {
+    await h.dispose();
+  });
+
+  test(
+      'nonce-challenge first 401 triggers retry with DPoP-Nonce claim embedded',
+      () async {
+    final mock = MockIdp()..enableNonceChallenge(nonce: 'srv-nonce-42');
+    h = await buildHarness(mock: mock);
+
+    await h.runtime.ensureAuthenticated();
+    expect(h.runtime.state, AuthState.authenticated);
+
+    // Exactly two /token hits: first one challenged, second carried the
+    // server-issued nonce.
+    final hits = h.mock.tokenRequests
+        .where((r) => r.grantType == 'authorization_code')
+        .toList();
+    expect(hits, hasLength(2));
+
+    expect(hits[0].dpopClaims, isNotNull);
+    expect(hits[0].dpopClaims!.nonce, isNull);
+
+    expect(hits[1].dpopClaims, isNotNull);
+    expect(hits[1].dpopClaims!.nonce, 'srv-nonce-42');
+  });
+}

--- a/ui/runtime/test/integration/logout_flow_test.dart
+++ b/ui/runtime/test/integration/logout_flow_test.dart
@@ -1,0 +1,54 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '_helpers.dart';
+
+void main() {
+  late IntegrationHarness h;
+
+  tearDown(() async {
+    await h.dispose();
+  });
+
+  test('logout revokes RT, calls end_session, wipes storage', () async {
+    h = await buildHarness();
+    await h.runtime.ensureAuthenticated();
+    expect(h.runtime.state, AuthState.authenticated);
+    expect(await h.tokenStore.load(h.config.namespace), isNotNull);
+
+    await h.runtime.logout();
+
+    expect(h.runtime.state, AuthState.unauthenticated);
+    expect(await h.tokenStore.load(h.config.namespace), isNull);
+
+    // Exactly one revocation POST; exactly one end_session GET.
+    expect(h.mock.revocationRequests, hasLength(1));
+    expect(h.mock.endSessionRequests, hasLength(1));
+
+    // Revocation body includes the refresh_token + token_type_hint.
+    final form = Uri.splitQueryString(h.mock.revocationRequests.single.body);
+    expect(form['token'], 'rt-1');
+    expect(form['token_type_hint'], 'refresh_token');
+  });
+
+  test('post-logout ensureAuthenticated drives a new OAuth flow', () async {
+    h = await buildHarness();
+    await h.runtime.ensureAuthenticated();
+    expect(h.fakeOAuth.calls, 1);
+
+    await h.runtime.logout();
+    await Future<void>.delayed(Duration.zero);
+    expect(h.runtime.state, AuthState.unauthenticated);
+
+    await h.runtime.ensureAuthenticated();
+    expect(h.fakeOAuth.calls, 2);
+    expect(h.runtime.state, AuthState.authenticated);
+    // Two authorization_code grants ran in total.
+    expect(
+      h.mock.tokenRequests
+          .where((r) => r.grantType == 'authorization_code')
+          .length,
+      2,
+    );
+  });
+}

--- a/ui/runtime/test/integration/mock_idp.dart
+++ b/ui/runtime/test/integration/mock_idp.dart
@@ -1,0 +1,381 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:shelf/shelf.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:shelf_router/shelf_router.dart';
+
+/// Minimal IdP surface the runtime exercises end-to-end.
+///
+/// Listens on `127.0.0.1:<kernel-picked>` so multiple tests can run in
+/// parallel without port collisions. Every handler is deterministic and
+/// synchronous so assertion counts are stable.
+///
+/// Toggles live on the instance so a single test can, for example, enable
+/// the nonce challenge for one call and then turn it off again to verify
+/// the happy-path retry.
+class MockIdp {
+  MockIdp({this.tokenLifetime = const Duration(seconds: 300)});
+
+  /// How long `expires_in` claims for minted access tokens.
+  final Duration tokenLifetime;
+
+  HttpServer? _server;
+  String? _baseUrl;
+
+  /// List of every `/token` request observed, in order. Useful for
+  /// assertions about DPoP proof content and retries.
+  final List<RecordedTokenRequest> tokenRequests = <RecordedTokenRequest>[];
+
+  /// List of every `/revocation` POST observed.
+  final List<RecordedRequest> revocationRequests = <RecordedRequest>[];
+
+  /// List of every `/end_session` hit observed.
+  final List<RecordedRequest> endSessionRequests = <RecordedRequest>[];
+
+  /// When true, the first `/token` hit without a `nonce` claim in the DPoP
+  /// proof returns 401 + a `DPoP-Nonce` header; subsequent hits accept any
+  /// `nonce` claim at all (we don't verify signatures).
+  bool nonceChallengeArmed = false;
+
+  /// When true, the first `/token` hit whose DPoP `iat` is further from
+  /// server time than [_clockSkewTolerance] returns 400
+  /// `invalid_dpop_proof` + a `Date` header 5 minutes in the future.
+  bool clockSkewChallengeArmed = false;
+
+  /// The `DPoP-Nonce` value handed back during a nonce challenge.
+  String currentNonce = 'nonce-from-idp';
+
+  /// Used RTs and their issuing JTI — re-submitting a consumed RT triggers
+  /// reuse detection. Map value is the RT family id.
+  final Map<String, String> _consumedRefreshTokens = <String, String>{};
+  final Set<String> _liveRefreshTokens = <String>{};
+
+  /// Monotonic counter feeding access / refresh token ids so tests can
+  /// reason about which tokens came from which rotation.
+  int _rotationCounter = 0;
+
+  /// The issuer URL advertised in discovery + ID tokens. Populated at
+  /// `start` time.
+  String get baseUrl => _baseUrl!;
+
+  /// Convenience: the token endpoint a DPoP proof's `htu` claim must match.
+  String get tokenEndpoint => '$baseUrl/token';
+
+  /// Starts listening on an ephemeral loopback port.
+  Future<String> start() async {
+    final router = Router();
+
+    router.get('/.well-known/openid-configuration', _discovery);
+    router.post('/token', _token);
+    router.post('/revocation', _revocation);
+    // The runtime issues a GET for end_session per RFC 7662 (client-driven
+    // redirect), so we respond to both verbs.
+    router.get('/end_session', _endSession);
+    router.post('/end_session', _endSession);
+
+    _server = await shelf_io.serve(router.call, '127.0.0.1', 0);
+    _baseUrl = 'http://127.0.0.1:${_server!.port}';
+    return _baseUrl!;
+  }
+
+  /// Shuts the server down. Safe to call even if not running.
+  Future<void> stop() async {
+    final s = _server;
+    _server = null;
+    _baseUrl = null;
+    await s?.close(force: true);
+  }
+
+  // Public toggles ----------------------------------------------------------
+
+  void enableNonceChallenge({String nonce = 'nonce-from-idp'}) {
+    nonceChallengeArmed = true;
+    currentNonce = nonce;
+  }
+
+  void enableClockSkewChallenge() {
+    clockSkewChallengeArmed = true;
+  }
+
+  /// Resets the counters / recorded requests so a single MockIdp can be
+  /// reused across scenarios.
+  void reset() {
+    tokenRequests.clear();
+    revocationRequests.clear();
+    endSessionRequests.clear();
+    nonceChallengeArmed = false;
+    clockSkewChallengeArmed = false;
+    _consumedRefreshTokens.clear();
+    _liveRefreshTokens.clear();
+    _rotationCounter = 0;
+  }
+
+  // Handlers ----------------------------------------------------------------
+
+  Response _discovery(Request _) {
+    final body = <String, dynamic>{
+      'issuer': baseUrl,
+      'authorization_endpoint': '$baseUrl/authorize',
+      'token_endpoint': tokenEndpoint,
+      'end_session_endpoint': '$baseUrl/end_session',
+      'revocation_endpoint': '$baseUrl/revocation',
+      'userinfo_endpoint': '$baseUrl/userinfo',
+      'jwks_uri': '$baseUrl/jwks',
+      'dpop_signing_alg_values_supported': <String>['ES256'],
+    };
+    return Response.ok(
+      json.encode(body),
+      headers: <String, String>{'Content-Type': 'application/json'},
+    );
+  }
+
+  Future<Response> _token(Request req) async {
+    final bodyStr = await req.readAsString();
+    final form = Uri.splitQueryString(bodyStr);
+    final dpopHeader = _headerIgnoreCase(req.headers, 'DPoP');
+
+    DpopProofClaims? dpop;
+    if (dpopHeader != null) {
+      dpop = _parseDpopProof(dpopHeader);
+    }
+
+    tokenRequests.add(RecordedTokenRequest(
+      grantType: form['grant_type'] ?? '',
+      form: form,
+      dpopHeader: dpopHeader,
+      dpopClaims: dpop,
+    ));
+
+    // Nonce challenge: first call without nonce claim in proof → 401 +
+    // DPoP-Nonce header. Arm-once semantics: once consumed, the challenge
+    // stands down so the retry succeeds.
+    if (nonceChallengeArmed) {
+      if (dpop == null || dpop.nonce == null) {
+        nonceChallengeArmed = false;
+        return Response(
+          401,
+          headers: <String, String>{
+            'DPoP-Nonce': currentNonce,
+            'Content-Type': 'application/json',
+          },
+          body: json.encode(<String, String>{'error': 'use_dpop_nonce'}),
+        );
+      }
+    }
+
+    // Clock-skew challenge: first hit unconditionally returns 400
+    // invalid_dpop_proof + a Date header 5 minutes in the future. The
+    // runtime is expected to read the Date header, compensate its
+    // clockOffsetMs, and retry. Arm-once.
+    if (clockSkewChallengeArmed && dpop != null) {
+      clockSkewChallengeArmed = false;
+      final future = DateTime.now().add(const Duration(minutes: 5));
+      return Response(
+        400,
+        headers: <String, String>{
+          'Date': HttpDate.format(future),
+          'Content-Type': 'application/json',
+        },
+        body: json.encode(<String, String>{'error': 'invalid_dpop_proof'}),
+      );
+    }
+
+    final grant = form['grant_type'];
+    switch (grant) {
+      case 'authorization_code':
+        return _issueTokens(newFamily: true);
+      case 'refresh_token':
+        final rt = form['refresh_token'];
+        if (rt == null || rt.isEmpty) {
+          return Response(
+            400,
+            headers: <String, String>{'Content-Type': 'application/json'},
+            body: json.encode(<String, String>{'error': 'invalid_grant'}),
+          );
+        }
+        if (_consumedRefreshTokens.containsKey(rt)) {
+          // Reuse detection: the RT has already been rotated away.
+          return Response(
+            400,
+            headers: <String, String>{'Content-Type': 'application/json'},
+            body: json.encode(<String, String>{
+              'error': 'invalid_grant',
+              'error_description': 'refresh token reuse detected',
+            }),
+          );
+        }
+        if (!_liveRefreshTokens.contains(rt)) {
+          // Unknown RT — never issued.
+          return Response(
+            400,
+            headers: <String, String>{'Content-Type': 'application/json'},
+            body: json.encode(<String, String>{'error': 'invalid_grant'}),
+          );
+        }
+        // Rotation: consume the presented RT, mint a new pair.
+        _liveRefreshTokens.remove(rt);
+        _consumedRefreshTokens[rt] = 'family';
+        return _issueTokens(newFamily: false);
+      default:
+        return Response(
+          400,
+          headers: <String, String>{'Content-Type': 'application/json'},
+          body: json.encode(<String, String>{'error': 'unsupported_grant_type'}),
+        );
+    }
+  }
+
+  Response _issueTokens({required bool newFamily}) {
+    _rotationCounter += 1;
+    final n = _rotationCounter;
+    final accessToken = _makeUnsignedJwt(<String, dynamic>{
+      'iss': baseUrl,
+      'sub': 'user-1',
+      'aud': 'antinvestor-mobile',
+      'iat': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      'exp': DateTime.now()
+              .add(tokenLifetime)
+              .millisecondsSinceEpoch ~/
+          1000,
+      'roles': <String>['user', 'admin'],
+      'jti': 'at-$n',
+    });
+    final idToken = _makeUnsignedJwt(<String, dynamic>{
+      'iss': baseUrl,
+      'sub': 'user-1',
+      'aud': 'antinvestor-mobile',
+      'iat': DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      'exp': DateTime.now()
+              .add(tokenLifetime)
+              .millisecondsSinceEpoch ~/
+          1000,
+      'email': 'user@example.com',
+      'name': 'Test User',
+      'picture': 'https://example.com/avatar.png',
+    });
+    final refreshToken = 'rt-$n';
+    _liveRefreshTokens.add(refreshToken);
+
+    final body = <String, dynamic>{
+      'access_token': accessToken,
+      'refresh_token': refreshToken,
+      'id_token': idToken,
+      'token_type': 'DPoP',
+      'expires_in': tokenLifetime.inSeconds,
+    };
+    return Response.ok(
+      json.encode(body),
+      headers: <String, String>{'Content-Type': 'application/json'},
+    );
+  }
+
+  Future<Response> _revocation(Request req) async {
+    final body = await req.readAsString();
+    revocationRequests.add(RecordedRequest(body: body, headers: req.headers));
+    return Response(204);
+  }
+
+  Future<Response> _endSession(Request req) async {
+    final body =
+        req.method == 'POST' ? await req.readAsString() : '';
+    endSessionRequests.add(RecordedRequest(body: body, headers: req.headers));
+    return Response(204);
+  }
+}
+
+/// Captured state of a `/token` hit.
+class RecordedTokenRequest {
+  RecordedTokenRequest({
+    required this.grantType,
+    required this.form,
+    required this.dpopHeader,
+    required this.dpopClaims,
+  });
+
+  final String grantType;
+  final Map<String, String> form;
+  final String? dpopHeader;
+  final DpopProofClaims? dpopClaims;
+}
+
+/// Minimal capture of a non-token request (revocation / end-session).
+class RecordedRequest {
+  RecordedRequest({required this.body, required this.headers});
+
+  final String body;
+  final Map<String, String> headers;
+}
+
+/// Parsed-but-not-verified DPoP proof payload.
+class DpopProofClaims {
+  DpopProofClaims({
+    required this.htm,
+    required this.htu,
+    required this.iat,
+    required this.jti,
+    this.nonce,
+    this.ath,
+  });
+
+  final String htm;
+  final String htu;
+  final int iat;
+  final String jti;
+  final String? nonce;
+  final String? ath;
+}
+
+/// Best-effort parser: splits the JWS, base64url-decodes the payload, and
+/// pulls the claims the runtime ships. Returns null on any structural
+/// failure so the caller can decide how strict to be.
+DpopProofClaims? _parseDpopProof(String proof) {
+  final parts = proof.split('.');
+  if (parts.length != 3) return null;
+  try {
+    final payload = json.decode(utf8.decode(_b64urlDecode(parts[1])));
+    if (payload is! Map) return null;
+    final htm = payload['htm'];
+    final htu = payload['htu'];
+    final iat = payload['iat'];
+    final jti = payload['jti'];
+    if (htm is! String || htu is! String || iat is! int || jti is! String) {
+      return null;
+    }
+    return DpopProofClaims(
+      htm: htm,
+      htu: htu,
+      iat: iat,
+      jti: jti,
+      nonce: payload['nonce'] is String ? payload['nonce'] as String : null,
+      ath: payload['ath'] is String ? payload['ath'] as String : null,
+    );
+  } catch (_) {
+    return null;
+  }
+}
+
+List<int> _b64urlDecode(String s) {
+  final padded = s.padRight((s.length + 3) & ~3, '=');
+  return base64Url.decode(padded);
+}
+
+String? _headerIgnoreCase(Map<String, String> headers, String name) {
+  final lower = name.toLowerCase();
+  for (final e in headers.entries) {
+    if (e.key.toLowerCase() == lower) return e.value;
+  }
+  return null;
+}
+
+String _makeUnsignedJwt(Map<String, dynamic> payload) {
+  final header = base64Url
+      .encode(utf8.encode(json.encode(<String, String>{'alg': 'none'})))
+      .replaceAll('=', '');
+  final body = base64Url
+      .encode(utf8.encode(json.encode(payload)))
+      .replaceAll('=', '');
+  // Deliberately empty signature so this stays visibly a test fixture.
+  return '$header.$body.';
+}

--- a/ui/runtime/test/integration/refresh_flow_test.dart
+++ b/ui/runtime/test/integration/refresh_flow_test.dart
@@ -1,0 +1,66 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '_helpers.dart';
+import 'mock_idp.dart';
+
+void main() {
+  late IntegrationHarness h;
+
+  tearDown(() async {
+    await h.dispose();
+  });
+
+  test('near-expiry fetch triggers refresh and rotates RT', () async {
+    // Short access-token lifetime so the worker's refresh buffer (60s)
+    // already engulfs the token from the moment it's issued — the next
+    // fetch therefore has to refresh before doing anything else.
+    final mock = MockIdp(tokenLifetime: const Duration(seconds: 30));
+    h = await buildHarness(mock: mock);
+
+    await h.runtime.ensureAuthenticated();
+    expect(h.runtime.state, AuthState.authenticated);
+
+    // Only the authorization_code grant has run so far.
+    expect(
+      h.mock.tokenRequests.where((r) => r.grantType == 'refresh_token'),
+      isEmpty,
+    );
+
+    // A fetch forces ensureFresh, which refreshes because the AT is already
+    // inside the refresh buffer.
+    try {
+      await h.runtime.fetch('/ping');
+    } catch (_) {
+      // 404 from the mock is fine; the refresh ran *before* the API call.
+    }
+
+    final refreshCalls =
+        h.mock.tokenRequests.where((r) => r.grantType == 'refresh_token');
+    expect(refreshCalls, hasLength(1));
+    // The presented RT is the original rt-1; the mock has consumed it and
+    // issued rt-2.
+    expect(refreshCalls.single.form['refresh_token'], 'rt-1');
+  });
+
+  test('second near-expiry fetch uses the rotated RT', () async {
+    final mock = MockIdp(tokenLifetime: const Duration(seconds: 30));
+    h = await buildHarness(mock: mock);
+
+    await h.runtime.ensureAuthenticated();
+
+    for (var i = 0; i < 2; i++) {
+      try {
+        await h.runtime.fetch('/ping');
+      } catch (_) {/* 404 ok */}
+    }
+
+    final refreshCalls = h.mock.tokenRequests
+        .where((r) => r.grantType == 'refresh_token')
+        .toList();
+    expect(refreshCalls.length, greaterThanOrEqualTo(2));
+    // The second refresh used rt-2 (issued by the first rotation), not rt-1.
+    expect(refreshCalls[0].form['refresh_token'], 'rt-1');
+    expect(refreshCalls[1].form['refresh_token'], 'rt-2');
+  });
+}

--- a/ui/runtime/test/integration/reuse_detection_test.dart
+++ b/ui/runtime/test/integration/reuse_detection_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
+import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
+import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '_helpers.dart';
+import 'mock_idp.dart';
+
+void main() {
+  late IntegrationHarness h;
+
+  tearDown(() async {
+    await h.dispose();
+  });
+
+  test(
+      'submitting a consumed RT triggers reuse detection, wipes session, '
+      'emits RefreshReuseDetected', () async {
+    final mock = MockIdp(tokenLifetime: const Duration(seconds: 30));
+    h = await buildHarness(mock: mock);
+
+    await h.runtime.ensureAuthenticated();
+
+    final events = <SecurityEvent>[];
+    h.runtime.securityEventStream.listen(events.add);
+
+    // Drive one rotation so the mock has consumed rt-1 and issued rt-2.
+    try {
+      await h.runtime.fetch('/ping');
+    } catch (_) {/* 404 ok */}
+    expect(
+      h.mock.tokenRequests
+          .where((r) => r.grantType == 'refresh_token')
+          .length,
+      1,
+    );
+
+    // Persist rt-1 back into storage under the covers to model an attacker
+    // replaying a stolen token (or a cloned-device scenario).
+    await _rewriteStoredRefreshToken(
+      sessionKv: h.sessionKv,
+      rootKv: h.rootKv,
+      namespace: h.config.namespace,
+      replacement: 'rt-1',
+    );
+
+    // Force the worker to reload its session from storage so it picks up
+    // the rewritten RT.
+    final reloadedMock = mock;
+    final sessionKv = h.sessionKv;
+    final rootKv = h.rootKv;
+    await h.runtime.dispose();
+    h = await buildHarness(
+      mock: reloadedMock,
+      sessionKv: sessionKv,
+      rootKv: rootKv,
+    );
+    final events2 = <SecurityEvent>[];
+    h.runtime.securityEventStream.listen(events2.add);
+
+    // Next fetch drives a refresh; mock rejects rt-1 with invalid_grant +
+    // reuse_detected description.
+    try {
+      await h.runtime.fetch('/ping');
+      fail('expected AuthError(refreshReuseDetected)');
+    } on AuthError catch (e) {
+      expect(e.code, AuthErrorCode.refreshReuseDetected);
+    }
+
+    await Future<void>.delayed(Duration.zero);
+    expect(events2.whereType<RefreshReuseDetected>(), isNotEmpty);
+    expect(h.runtime.state, AuthState.unauthenticated);
+    expect(await h.tokenStore.load(h.config.namespace), isNull);
+  });
+}
+
+/// Rewrites the stored refresh token ciphertext so that decrypting it
+/// yields [replacement].
+///
+/// Round-trip: read the session, decrypt the wrap key, re-wrap the new
+/// plaintext under the same wrap key, put it back.
+Future<void> _rewriteStoredRefreshToken({
+  required KeyValueStore sessionKv,
+  required KeyValueStore rootKv,
+  required String namespace,
+  required String replacement,
+}) async {
+  final km = DefaultKeyManager();
+  final rootKeyStore = DefaultRootKeyStore(kv: rootKv);
+  final tokenStore = SecureTokenStore(kv: sessionKv);
+
+  final stored = await tokenStore.load(namespace);
+  if (stored == null) {
+    throw StateError('no stored session to rewrite');
+  }
+
+  // Decrypt wrap key under root key.
+  final rootKeyBytes = await rootKeyStore.getOrCreate(namespace);
+  final rootKey = await km.importWrapKey(rootKeyBytes);
+  final wrapKeyBytes = await km.unwrap(rootKey, stored.wrapKeyCiphertext);
+  final wrapKey = await km.importWrapKey(wrapKeyBytes);
+
+  // Re-wrap the replacement refresh token under the same wrap key.
+  final newBlob = await km.wrap(wrapKey, utf8.encode(replacement));
+
+  await tokenStore.save(
+    namespace,
+    StoredSession(
+      wrapKeyCiphertext: stored.wrapKeyCiphertext,
+      dpopPrivateKeyCiphertext: stored.dpopPrivateKeyCiphertext,
+      refreshTokenCiphertext: newBlob,
+      accessToken: stored.accessToken,
+      accessTokenExpiresAt: stored.accessTokenExpiresAt,
+      tokenType: stored.tokenType,
+      idToken: stored.idToken,
+      updatedAt: stored.updatedAt,
+    ),
+  );
+}

--- a/ui/runtime/test/integration/sign_in_flow_test.dart
+++ b/ui/runtime/test/integration/sign_in_flow_test.dart
@@ -1,0 +1,95 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '_helpers.dart';
+
+void main() {
+  late IntegrationHarness h;
+
+  tearDown(() async {
+    await h.dispose();
+  });
+
+  test('ensureAuthenticated drives full OAuth + token exchange against mock IdP',
+      () async {
+    h = await buildHarness();
+    final states = <AuthState>[];
+    h.runtime.authStateStream.listen(states.add);
+
+    expect(h.runtime.state, AuthState.unauthenticated);
+
+    await h.runtime.ensureAuthenticated();
+    // Give the broadcast stream time to flush.
+    await Future<void>.delayed(Duration.zero);
+
+    expect(h.runtime.state, AuthState.authenticated);
+    // We go unauthenticated → initializing → authenticated during sign-in.
+    expect(states, contains(AuthState.authenticated));
+    expect(h.fakeOAuth.calls, 1);
+
+    // Exactly one authorization_code grant hit the mock.
+    expect(
+      h.mock.tokenRequests.where((r) => r.grantType == 'authorization_code'),
+      hasLength(1),
+    );
+    // The request carried a well-formed DPoP proof with the right htm/htu.
+    final authzCall = h.mock.tokenRequests.firstWhere(
+      (r) => r.grantType == 'authorization_code',
+    );
+    expect(authzCall.dpopClaims, isNotNull);
+    expect(authzCall.dpopClaims!.htm, 'POST');
+    expect(authzCall.dpopClaims!.htu, h.mock.tokenEndpoint);
+  });
+
+  test('getClaims returns decoded ID token payload', () async {
+    h = await buildHarness();
+    await h.runtime.ensureAuthenticated();
+    final claims = await h.runtime.getClaims();
+    expect(claims['sub'], 'user-1');
+    expect(claims['email'], 'user@example.com');
+    expect(claims['name'], 'Test User');
+  });
+
+  test('getRoles extracts roles from access token', () async {
+    h = await buildHarness();
+    await h.runtime.ensureAuthenticated();
+    final roles = await h.runtime.getRoles();
+    expect(roles, unorderedEquals(<String>['user', 'admin']));
+  });
+
+  test('session persists across a runtime dispose + re-init', () async {
+    h = await buildHarness();
+    await h.runtime.ensureAuthenticated();
+    final firstClaims = await h.runtime.getClaims();
+    expect(firstClaims['sub'], 'user-1');
+
+    // Capture the storage so the second runtime sees the same on-disk state.
+    final sessionKv = h.sessionKv;
+    final rootKv = h.rootKv;
+    final mock = h.mock;
+    final firstHarness = h;
+
+    // Dispose the first runtime but keep the mock alive.
+    await firstHarness.runtime.dispose();
+    // Clear the singleton discovery cache so the fresh runtime actually
+    // re-reads the well-known document from the mock.
+    // (The helper does this, but we want to assert the cold-boot path.)
+
+    final fresh = await buildHarness(
+      mock: mock,
+      sessionKv: sessionKv,
+      rootKv: rootKv,
+    );
+    h = fresh;
+
+    await Future<void>.delayed(Duration.zero);
+    expect(fresh.runtime.state, AuthState.authenticated);
+    // No new authorization_code call: we restored from storage.
+    expect(
+      fresh.mock.tokenRequests
+          .where((r) => r.grantType == 'authorization_code')
+          .length,
+      1,
+    );
+  });
+}

--- a/ui/runtime/test/models/api_response_test.dart
+++ b/ui/runtime/test/models/api_response_test.dart
@@ -1,0 +1,27 @@
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ApiResponse exposes status, headers, body', () {
+    final body = Uint8List.fromList(const [1, 2, 3]);
+    final r = ApiResponse(
+      status: 200,
+      headers: const {'content-type': 'application/json'},
+      body: body,
+    );
+    expect(r.status, 200);
+    expect(r.headers['content-type'], 'application/json');
+    expect(r.body, body);
+  });
+
+  test('ApiResponse headers are unmodifiable', () {
+    final r = ApiResponse(
+      status: 200,
+      headers: const {'x-trace-id': 't'},
+      body: Uint8List(0),
+    );
+    expect(() => r.headers['x'] = 'y', throwsUnsupportedError);
+  });
+}

--- a/ui/runtime/test/models/auth_error_test.dart
+++ b/ui/runtime/test/models/auth_error_test.dart
@@ -1,0 +1,43 @@
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AuthError preserves code/message/cause and computes retryable', () {
+    final e = AuthError(
+      AuthErrorCode.networkTimeout,
+      'boom',
+      cause: StateError('x'),
+    );
+    expect(e.code, AuthErrorCode.networkTimeout);
+    expect(e.message, 'boom');
+    expect(e.cause, isA<StateError>());
+    expect(e.retryable, isTrue);
+  });
+
+  test('non-retryable codes flagged', () {
+    for (final c in const [
+      AuthErrorCode.invalidConfig,
+      AuthErrorCode.refreshReuseDetected,
+      AuthErrorCode.cryptoUnsupported,
+      AuthErrorCode.deepLinkMismatch,
+      AuthErrorCode.securityWipe,
+    ]) {
+      expect(AuthError(c, 'm').retryable, isFalse, reason: c.name);
+    }
+  });
+
+  test('toString includes code and message', () {
+    final e = AuthError(AuthErrorCode.discoveryFailed, 'well-known 404');
+    expect(e.toString(), contains('discoveryFailed'));
+    expect(e.toString(), contains('well-known 404'));
+  });
+
+  test('traceId round-trips', () {
+    final e = AuthError(
+      AuthErrorCode.apiServerError,
+      '500',
+      traceId: 'abc-123',
+    );
+    expect(e.traceId, 'abc-123');
+  });
+}

--- a/ui/runtime/test/models/auth_state_test.dart
+++ b/ui/runtime/test/models/auth_state_test.dart
@@ -1,0 +1,15 @@
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('AuthState enum exposes all expected variants', () {
+    expect(AuthState.values, containsAll(const [
+      AuthState.initializing,
+      AuthState.authenticated,
+      AuthState.unauthenticated,
+      AuthState.refreshing,
+      AuthState.error,
+    ]));
+    expect(AuthState.values.length, 5);
+  });
+}

--- a/ui/runtime/test/models/security_event_test.dart
+++ b/ui/runtime/test/models/security_event_test.dart
@@ -1,0 +1,46 @@
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final at = DateTime.utc(2026, 1, 1);
+
+  test('SecurityEvent has four variants with the at timestamp', () {
+    final events = <SecurityEvent>[
+      SecurityEvent.refreshReuseDetected(at),
+      SecurityEvent.storageCorruption(at),
+      SecurityEvent.bindingInvalidated(at),
+      SecurityEvent.loggedOutElsewhere(at),
+    ];
+    for (final e in events) {
+      expect(e.at, at);
+    }
+    expect(events[0], isA<RefreshReuseDetected>());
+    expect(events[1], isA<StorageCorruption>());
+    expect(events[2], isA<BindingInvalidated>());
+    expect(events[3], isA<LoggedOutElsewhere>());
+  });
+
+  test('SecurityEvent pattern-matches exhaustively', () {
+    String label(SecurityEvent e) => switch (e) {
+          RefreshReuseDetected() => 'reuse',
+          StorageCorruption() => 'storage',
+          BindingInvalidated() => 'binding',
+          LoggedOutElsewhere() => 'logout-elsewhere',
+        };
+    expect(label(SecurityEvent.refreshReuseDetected(at)), 'reuse');
+    expect(label(SecurityEvent.storageCorruption(at)), 'storage');
+    expect(label(SecurityEvent.bindingInvalidated(at)), 'binding');
+    expect(label(SecurityEvent.loggedOutElsewhere(at)), 'logout-elsewhere');
+  });
+
+  test('SecurityEvent equality compares variant and timestamp', () {
+    expect(
+      SecurityEvent.refreshReuseDetected(at),
+      equals(SecurityEvent.refreshReuseDetected(at)),
+    );
+    expect(
+      SecurityEvent.refreshReuseDetected(at),
+      isNot(equals(SecurityEvent.storageCorruption(at))),
+    );
+  });
+}

--- a/ui/runtime/test/models/token_set_test.dart
+++ b/ui/runtime/test/models/token_set_test.dart
@@ -1,0 +1,67 @@
+import 'package:antinvestor_auth_runtime/src/models/token_set.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('TokenSet constructs with bearer + DPoP variants', () {
+    final now = DateTime.utc(2026, 1, 1);
+    final bearer = TokenSet(
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: now,
+      tokenType: TokenType.bearer,
+    );
+    expect(bearer.accessToken, 'a');
+    expect(bearer.tokenType, TokenType.bearer);
+    expect(bearer.idToken, isNull);
+
+    final dpop = TokenSet(
+      accessToken: 'a2',
+      refreshToken: 'r2',
+      expiresAt: now,
+      tokenType: TokenType.dpop,
+      idToken: 'id',
+    );
+    expect(dpop.tokenType, TokenType.dpop);
+    expect(dpop.idToken, 'id');
+  });
+
+  test('isExpiredAt uses expiresAt comparison', () {
+    final expiry = DateTime.utc(2026, 1, 1, 12, 0, 0);
+    final t = TokenSet(
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: expiry,
+      tokenType: TokenType.bearer,
+    );
+    expect(t.isExpiredAt(DateTime.utc(2026, 1, 1, 11, 59, 0)), isFalse);
+    expect(t.isExpiredAt(DateTime.utc(2026, 1, 1, 12, 0, 0)), isTrue);
+    expect(t.isExpiredAt(DateTime.utc(2026, 1, 1, 12, 0, 1)), isTrue);
+  });
+
+  test('TokenSet equality and hashCode are value-based', () {
+    final now = DateTime.utc(2026, 1, 1);
+    final a = TokenSet(
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: now,
+      tokenType: TokenType.bearer,
+    );
+    final b = TokenSet(
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: now,
+      tokenType: TokenType.bearer,
+    );
+    expect(a, equals(b));
+    expect(a.hashCode, b.hashCode);
+  });
+
+  test('TokenType.fromString normalizes DPoP/Bearer case-insensitively', () {
+    expect(TokenType.fromString('Bearer'), TokenType.bearer);
+    expect(TokenType.fromString('bearer'), TokenType.bearer);
+    expect(TokenType.fromString('DPoP'), TokenType.dpop);
+    expect(TokenType.fromString('dpop'), TokenType.dpop);
+    expect(TokenType.fromString(null), TokenType.bearer);
+    expect(TokenType.fromString('unknown'), TokenType.bearer);
+  });
+}

--- a/ui/runtime/test/models/user_claims_test.dart
+++ b/ui/runtime/test/models/user_claims_test.dart
@@ -1,0 +1,43 @@
+import 'package:antinvestor_auth_runtime/src/models/user_claims.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('UserClaims exposes canonical OIDC fields', () {
+    const c = UserClaims({
+      'sub': 's1',
+      'name': 'Alice',
+      'email': 'a@example.com',
+      'picture': 'https://cdn/x.png',
+      'roles': <dynamic>['admin', 'editor'],
+    });
+    expect(c.sub, 's1');
+    expect(c.name, 'Alice');
+    expect(c.email, 'a@example.com');
+    expect(c.picture, 'https://cdn/x.png');
+    expect(c.roles, ['admin', 'editor']);
+  });
+
+  test('UserClaims pulls roles from realm_access fallback', () {
+    const c = UserClaims({
+      'sub': 's',
+      'realm_access': {'roles': <dynamic>['ops']},
+    });
+    expect(c.roles, ['ops']);
+  });
+
+  test('UserClaims missing fields return null and empty list', () {
+    const c = UserClaims({});
+    expect(c.sub, isNull);
+    expect(c.name, isNull);
+    expect(c.email, isNull);
+    expect(c.picture, isNull);
+    expect(c.roles, isEmpty);
+  });
+
+  test('UserClaims roles filter out non-string entries', () {
+    const c = UserClaims({
+      'roles': <dynamic>['ok', 1, null, 'good'],
+    });
+    expect(c.roles, ['ok', 'good']);
+  });
+}

--- a/ui/runtime/test/oauth/oauth_flow_test.dart
+++ b/ui/runtime/test/oauth/oauth_flow_test.dart
@@ -1,0 +1,129 @@
+import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/oauth/oauth_flow.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:flutter_appauth/flutter_appauth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAppAuth extends Mock implements FlutterAppAuth {}
+
+class _FakeAuthorizationRequest extends Fake implements AuthorizationRequest {}
+
+ResolvedConfig _cfg() => resolveConfig(const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://idp.example.com',
+      apiBaseUrl: 'https://api.example.com',
+      redirectScheme: 'com.example.app',
+    ));
+
+Future<OidcDiscovery> _fakeDiscovery(ResolvedConfig cfg) async =>
+    const OidcDiscovery(
+      issuer: 'https://idp.example.com',
+      authorizationEndpoint: 'https://idp.example.com/oauth2/auth',
+      tokenEndpoint: 'https://idp.example.com/oauth2/token',
+      endSessionEndpoint: 'https://idp.example.com/oauth2/sessions/logout',
+    );
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(_FakeAuthorizationRequest());
+  });
+
+  test('successful authorize returns code + verifier', () async {
+    final appAuth = _MockAppAuth();
+    when(() => appAuth.authorize(any())).thenAnswer((_) async =>
+        const AuthorizationResponse(
+          authorizationCode: 'CODE-1',
+          codeVerifier: 'VERIF-1',
+          nonce: 'N-1',
+        ));
+    final flow = OAuthFlow(appAuth: appAuth, discoveryFn: _fakeDiscovery);
+
+    final result = await flow.authorize(_cfg());
+    expect(result.code, 'CODE-1');
+    expect(result.verifier, 'VERIF-1');
+    expect(result.nonce, 'N-1');
+  });
+
+  test('AuthorizationRequest is built from ResolvedConfig + discovery',
+      () async {
+    final appAuth = _MockAppAuth();
+    AuthorizationRequest? seen;
+    when(() => appAuth.authorize(any())).thenAnswer((inv) async {
+      seen = inv.positionalArguments.first as AuthorizationRequest;
+      return const AuthorizationResponse(
+        authorizationCode: 'c',
+        codeVerifier: 'v',
+      );
+    });
+
+    final flow = OAuthFlow(appAuth: appAuth, discoveryFn: _fakeDiscovery);
+    await flow.authorize(_cfg());
+
+    expect(seen, isNotNull);
+    expect(seen!.clientId, 'c');
+    expect(seen!.redirectUrl, 'com.example.app://callback');
+    expect(seen!.scopes, contains('openid'));
+    expect(seen!.serviceConfiguration?.authorizationEndpoint,
+        'https://idp.example.com/oauth2/auth');
+    expect(seen!.serviceConfiguration?.tokenEndpoint,
+        'https://idp.example.com/oauth2/token');
+  });
+
+  test('FlutterAppAuthUserCancelledException maps to oauthUserCanceled',
+      () async {
+    final appAuth = _MockAppAuth();
+    when(() => appAuth.authorize(any())).thenThrow(
+      FlutterAppAuthUserCancelledException(
+        code: 'cancelled',
+        platformErrorDetails:
+            FlutterAppAuthPlatformErrorDetails(error: 'user_cancelled'),
+      ),
+    );
+
+    final flow = OAuthFlow(appAuth: appAuth, discoveryFn: _fakeDiscovery);
+    await expectLater(
+      flow.authorize(_cfg()),
+      throwsA(isA<AuthError>().having(
+        (e) => e.code,
+        'code',
+        AuthErrorCode.oauthUserCanceled,
+      )),
+    );
+  });
+
+  test('other exceptions map to oauthFailed', () async {
+    final appAuth = _MockAppAuth();
+    when(() => appAuth.authorize(any())).thenThrow(
+      Exception('boom'),
+    );
+
+    final flow = OAuthFlow(appAuth: appAuth, discoveryFn: _fakeDiscovery);
+    await expectLater(
+      flow.authorize(_cfg()),
+      throwsA(isA<AuthError>().having(
+        (e) => e.code,
+        'code',
+        AuthErrorCode.oauthFailed,
+      )),
+    );
+  });
+
+  test('missing code/verifier raises oauthFailed', () async {
+    final appAuth = _MockAppAuth();
+    when(() => appAuth.authorize(any())).thenAnswer((_) async =>
+        const AuthorizationResponse(authorizationCode: null, codeVerifier: 'v'));
+
+    final flow = OAuthFlow(appAuth: appAuth, discoveryFn: _fakeDiscovery);
+    await expectLater(
+      flow.authorize(_cfg()),
+      throwsA(isA<AuthError>().having(
+        (e) => e.code,
+        'code',
+        AuthErrorCode.oauthFailed,
+      )),
+    );
+  });
+}

--- a/ui/runtime/test/protocol/api_proxy_test.dart
+++ b/ui/runtime/test/protocol/api_proxy_test.dart
@@ -1,0 +1,287 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/token_set.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/api_proxy.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+ResolvedConfig _cfg() => resolveConfig(const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://idp.example.com',
+      apiBaseUrl: 'https://api.example.com',
+      redirectScheme: 'com.example.app',
+    ));
+
+class _TestTokenProvider implements TokenProvider {
+  _TestTokenProvider({
+    String initialAccess = 'at-1',
+    TokenType type = TokenType.bearer,
+    String refreshedAccess = 'at-2',
+  })  : _access = initialAccess,
+        _type = type,
+        _refreshed = refreshedAccess;
+
+  String _access;
+  final TokenType _type;
+  final String _refreshed;
+  int refreshCount = 0;
+  int forcedRefreshCount = 0;
+  int onRefreshNotifications = 0;
+
+  @override
+  Future<TokenSnapshot> ensureFresh({bool force = false}) async {
+    if (force) {
+      forcedRefreshCount++;
+      _access = _refreshed;
+    }
+    refreshCount++;
+    return TokenSnapshot(accessToken: _access, tokenType: _type);
+  }
+
+  @override
+  void onRefresh() {
+    onRefreshNotifications++;
+  }
+}
+
+void main() {
+  group('fetch', () {
+    test('attaches Bearer Authorization in bearer mode', () async {
+      final cfg = _cfg();
+      late http.Request captured;
+      final client = MockClient((req) async {
+        captured = req;
+        return http.Response('{"ok":true}', 200,
+            headers: {'content-type': 'application/json'});
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      final response = await proxy.fetch(
+        cfg,
+        ctx,
+        _TestTokenProvider(),
+        path: '/v1/ping',
+        method: 'GET',
+      );
+      expect(response.status, 200);
+      expect(captured.url.toString(), 'https://api.example.com/v1/ping');
+      expect(captured.headers['authorization'], 'Bearer at-1');
+      expect(captured.headers.containsKey('dpop'), isFalse);
+      expect(utf8.decode(response.body), '{"ok":true}');
+    });
+
+    test('attaches DPoP + proof in DPoP mode', () async {
+      final cfg = _cfg();
+      late http.Request captured;
+      final client = MockClient((req) async {
+        captured = req;
+        return http.Response('{}', 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await proxy.fetch(
+        cfg,
+        ctx,
+        _TestTokenProvider(type: TokenType.dpop),
+        path: '/v1/ping',
+        method: 'POST',
+        body: '{"x":1}',
+      );
+      expect(captured.headers['authorization'], 'DPoP at-1');
+      expect(captured.headers.containsKey('dpop'), isTrue);
+      expect(captured.headers['content-type'], contains('application/json'));
+    });
+
+    test('401 triggers a single forced refresh + retry', () async {
+      final cfg = _cfg();
+      var calls = 0;
+      final client = MockClient((req) async {
+        calls++;
+        final auth = req.headers['authorization'];
+        if (calls == 1) {
+          expect(auth, 'Bearer at-1');
+          return http.Response('{}', 401);
+        }
+        expect(auth, 'Bearer at-2');
+        return http.Response('{"ok":true}', 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      final tp = _TestTokenProvider();
+      final res = await proxy.fetch(
+        cfg,
+        ctx,
+        tp,
+        path: '/v1/x',
+        method: 'GET',
+      );
+      expect(res.status, 200);
+      expect(calls, 2);
+      expect(tp.forcedRefreshCount, 1);
+      expect(tp.onRefreshNotifications, 1);
+    });
+
+    test('dpop-nonce challenge is retried before forcing refresh', () async {
+      final cfg = _cfg();
+      var calls = 0;
+      final client = MockClient((req) async {
+        calls++;
+        if (calls == 1) {
+          return http.Response('{}', 401,
+              headers: {'dpop-nonce': 'n-new'});
+        }
+        return http.Response('{"ok":true}', 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      final tp = _TestTokenProvider(type: TokenType.dpop);
+      final res = await proxy.fetch(
+        cfg,
+        ctx,
+        tp,
+        path: '/v1/x',
+        method: 'GET',
+      );
+      expect(res.status, 200);
+      expect(tp.forcedRefreshCount, 0);
+      expect(ctx.nonceByOrigin['https://api.example.com'], 'n-new');
+    });
+
+    test('204 returns empty body', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async => http.Response('', 204));
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      final res = await proxy.fetch(
+        cfg,
+        ctx,
+        _TestTokenProvider(),
+        path: '/v1/x',
+        method: 'DELETE',
+      );
+      expect(res.status, 204);
+      expect(res.body, isEmpty);
+    });
+
+    test('403 maps to apiForbidden', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async => http.Response('nope', 403));
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await expectLater(
+        proxy.fetch(cfg, ctx, _TestTokenProvider(),
+            path: '/v1/x', method: 'GET'),
+        throwsA(isA<AuthError>()
+            .having((e) => e.code, 'code', AuthErrorCode.apiForbidden)),
+      );
+    });
+
+    test('404 maps to apiNotFound', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async => http.Response('nf', 404));
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await expectLater(
+        proxy.fetch(cfg, ctx, _TestTokenProvider(),
+            path: '/v1/x', method: 'GET'),
+        throwsA(isA<AuthError>()
+            .having((e) => e.code, 'code', AuthErrorCode.apiNotFound)),
+      );
+    });
+
+    test('500 maps to apiServerError with trace id', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async => http.Response('boom', 500,
+          headers: {'x-trace-id': 'trace-xyz'}));
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      try {
+        await proxy.fetch(cfg, ctx, _TestTokenProvider(),
+            path: '/v1/x', method: 'GET');
+        fail('expected throw');
+      } on AuthError catch (e) {
+        expect(e.code, AuthErrorCode.apiServerError);
+        expect(e.traceId, 'trace-xyz');
+      }
+    });
+
+    test('persistent 401 after retry maps to apiUnauthorized', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async => http.Response('nope', 401));
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await expectLater(
+        proxy.fetch(cfg, ctx, _TestTokenProvider(),
+            path: '/v1/x', method: 'GET'),
+        throwsA(isA<AuthError>()
+            .having((e) => e.code, 'code', AuthErrorCode.apiUnauthorized)),
+      );
+    });
+
+    test('timeout maps to networkTimeout', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async {
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+        return http.Response('', 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await expectLater(
+        proxy.fetch(cfg, ctx, _TestTokenProvider(),
+            path: '/v1/x',
+            method: 'GET',
+            timeout: const Duration(milliseconds: 20)),
+        throwsA(isA<AuthError>()
+            .having((e) => e.code, 'code', AuthErrorCode.networkTimeout)),
+      );
+    });
+  });
+
+  group('upload', () {
+    test('multipart request attaches auth and propagates response', () async {
+      final cfg = _cfg();
+      late http.BaseRequest captured;
+      final client = MockClient.streaming((req, body) async {
+        captured = req;
+        return http.StreamedResponse(
+          Stream.value(utf8.encode('{"stored":true}')),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      final res = await proxy.upload(
+        cfg,
+        ctx,
+        _TestTokenProvider(),
+        path: '/v1/file',
+        fieldName: 'file',
+        filename: 'a.bin',
+        contentType: 'application/octet-stream',
+        bytes: Stream.value(const [0x01, 0x02, 0x03]),
+        length: 3,
+      );
+      expect(res.status, 200);
+      expect(captured.headers['authorization'], 'Bearer at-1');
+      expect(captured is http.MultipartRequest, isTrue);
+    });
+  });
+}

--- a/ui/runtime/test/protocol/discovery_test.dart
+++ b/ui/runtime/test/protocol/discovery_test.dart
@@ -1,0 +1,146 @@
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+const _timeout = Duration(seconds: 5);
+
+Map<String, dynamic> _doc({
+  String issuer = 'https://i',
+  String tokenEndpoint = 'https://i/token',
+  String authorizationEndpoint = 'https://i/oauth2/auth',
+  List<String>? dpopAlgs,
+}) {
+  return <String, dynamic>{
+    'issuer': issuer,
+    'authorization_endpoint': authorizationEndpoint,
+    'token_endpoint': tokenEndpoint,
+    'dpop_signing_alg_values_supported': ?dpopAlgs,
+  };
+}
+
+void main() {
+  setUp(clearDiscoveryCache);
+
+  test('200 JSON is parsed and cached', () async {
+    var calls = 0;
+    final client = MockClient((req) async {
+      calls++;
+      expect(req.method, 'GET');
+      expect(req.url.toString(),
+          'https://idp.example.com/.well-known/openid-configuration');
+      return http.Response(jsonEncode(_doc(issuer: 'https://idp.example.com')),
+          200,
+          headers: {'content-type': 'application/json'});
+    });
+
+    final d1 = await getDiscovery(
+      'https://idp.example.com',
+      _timeout,
+      client: client,
+    );
+    expect(d1.issuer, 'https://idp.example.com');
+    expect(d1.tokenEndpoint, 'https://i/token');
+
+    // Second call should hit the cache and skip HTTP.
+    final d2 = await getDiscovery(
+      'https://idp.example.com',
+      _timeout,
+      client: client,
+    );
+    expect(identical(d1, d2), isTrue);
+    expect(calls, 1);
+  });
+
+  test('trailing slash is stripped before cache key', () async {
+    var calls = 0;
+    final client = MockClient((req) async {
+      calls++;
+      return http.Response(jsonEncode(_doc()), 200,
+          headers: {'content-type': 'application/json'});
+    });
+    await getDiscovery('https://i', _timeout, client: client);
+    await getDiscovery('https://i/', _timeout, client: client);
+    expect(calls, 1);
+  });
+
+  test('404 raises AuthError(discoveryFailed) and does not cache', () async {
+    var calls = 0;
+    final client = MockClient((req) async {
+      calls++;
+      return http.Response('not found', 404);
+    });
+    await expectLater(
+      getDiscovery('https://i', _timeout, client: client),
+      throwsA(isA<AuthError>()
+          .having((e) => e.code, 'code', AuthErrorCode.discoveryFailed)),
+    );
+    // Second call should retry (failure not cached).
+    await expectLater(
+      getDiscovery('https://i', _timeout, client: client),
+      throwsA(isA<AuthError>()),
+    );
+    expect(calls, 2);
+  });
+
+  test('non-JSON body raises AuthError(discoveryFailed)', () async {
+    final client = MockClient((req) async => http.Response('<html/>', 200,
+        headers: {'content-type': 'text/html'}));
+    await expectLater(
+      getDiscovery('https://i', _timeout, client: client),
+      throwsA(isA<AuthError>()
+          .having((e) => e.code, 'code', AuthErrorCode.discoveryFailed)),
+    );
+  });
+
+  test('missing required fields raises AuthError(discoveryFailed)', () async {
+    final client = MockClient((req) async =>
+        http.Response(jsonEncode({'issuer': 'https://i'}), 200));
+    await expectLater(
+      getDiscovery('https://i', _timeout, client: client),
+      throwsA(isA<AuthError>()
+          .having((e) => e.code, 'code', AuthErrorCode.discoveryFailed)),
+    );
+  });
+
+  test('network timeout maps to AuthError(networkTimeout)', () async {
+    final client = MockClient((req) async {
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+      return http.Response(jsonEncode(_doc()), 200);
+    });
+    await expectLater(
+      getDiscovery('https://i', const Duration(milliseconds: 50),
+          client: client),
+      throwsA(isA<AuthError>()
+          .having((e) => e.code, 'code', AuthErrorCode.networkTimeout)),
+    );
+  });
+
+  test('supportsDpop detects ES256 advertisement', () {
+    final withDpop = OidcDiscovery.fromJson(
+        _doc(dpopAlgs: ['ES256', 'RS256']));
+    final withoutDpop = OidcDiscovery.fromJson(_doc());
+    expect(supportsDpop(withDpop), isTrue);
+    expect(supportsDpop(withoutDpop), isFalse);
+  });
+
+  test('concurrent callers share a single in-flight request', () async {
+    var calls = 0;
+    final client = MockClient((req) async {
+      calls++;
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      return http.Response(jsonEncode(_doc()), 200);
+    });
+    final results = await Future.wait([
+      getDiscovery('https://i', _timeout, client: client),
+      getDiscovery('https://i', _timeout, client: client),
+      getDiscovery('https://i', _timeout, client: client),
+    ]);
+    expect(calls, 1);
+    expect(identical(results[0], results[1]), isTrue);
+    expect(identical(results[1], results[2]), isTrue);
+  });
+}

--- a/ui/runtime/test/protocol/dpop_test.dart
+++ b/ui/runtime/test/protocol/dpop_test.dart
@@ -1,0 +1,167 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:crypto/crypto.dart' as crypto;
+import 'package:flutter_test/flutter_test.dart';
+
+Map<String, dynamic> _decodeJson(String b64) {
+  final padded = b64.padRight(b64.length + (4 - b64.length % 4) % 4, '=');
+  return json.decode(utf8.decode(base64Url.decode(padded)))
+      as Map<String, dynamic>;
+}
+
+Uint8List _decodeBytes(String b64) {
+  final padded = b64.padRight(b64.length + (4 - b64.length % 4) % 4, '=');
+  return base64Url.decode(padded);
+}
+
+String _b64urlNoPad(List<int> bytes) =>
+    base64Url.encode(bytes).replaceAll('=', '');
+
+void main() {
+  late DpopKeyPair kp;
+
+  setUp(() {
+    kp = generateDpopKeyPair();
+  });
+
+  test('buildProof emits a 3-part compact JWT with DPoP header', () async {
+    final ctx = makeDpopContext(kp);
+    final token = await buildProof(
+      ctx,
+      htm: 'POST',
+      htu: 'https://idp.example.com/token',
+    );
+    final parts = token.split('.');
+    expect(parts.length, 3);
+
+    final header = _decodeJson(parts[0]);
+    expect(header['typ'], 'dpop+jwt');
+    expect(header['alg'], 'ES256');
+    final jwk = header['jwk'] as Map<String, dynamic>;
+    expect(jwk['kty'], 'EC');
+    expect(jwk['crv'], 'P-256');
+    expect(jwk['x'], isA<String>());
+    expect(jwk['y'], isA<String>());
+    // x/y are 32-byte values — base64url-no-pad length is 43.
+    expect((jwk['x'] as String).length, 43);
+    expect((jwk['y'] as String).length, 43);
+
+    final payload = _decodeJson(parts[1]);
+    expect(payload['htm'], 'POST');
+    expect(payload['htu'], 'https://idp.example.com/token');
+    expect(payload['iat'], isA<int>());
+    expect(payload['jti'], isA<String>());
+    // Optional fields absent by default.
+    expect(payload.containsKey('ath'), isFalse);
+    expect(payload.containsKey('nonce'), isFalse);
+
+    final sigBytes = _decodeBytes(parts[2]);
+    expect(sigBytes.length, 64);
+  });
+
+  test('htm is uppercased in payload', () async {
+    final ctx = makeDpopContext(kp);
+    final token = await buildProof(
+      ctx,
+      htm: 'post',
+      htu: 'https://i/token',
+    );
+    final payload = _decodeJson(token.split('.')[1]);
+    expect(payload['htm'], 'POST');
+  });
+
+  test('ath is sha256 of access token when provided', () async {
+    final ctx = makeDpopContext(kp);
+    const accessToken = 'some-access-token';
+    final expectedAth = _b64urlNoPad(
+        crypto.sha256.convert(utf8.encode(accessToken)).bytes);
+    final token = await buildProof(
+      ctx,
+      htm: 'GET',
+      htu: 'https://api.example.com/thing',
+      accessToken: accessToken,
+    );
+    final payload = _decodeJson(token.split('.')[1]);
+    expect(payload['ath'], expectedAth);
+  });
+
+  test('rememberNonce round-trips into proof payload', () async {
+    final ctx = makeDpopContext(kp);
+    rememberNonce(ctx, 'https://i/token', {'DPoP-Nonce': 'n-1234'});
+    final token = await buildProof(
+      ctx,
+      htm: 'POST',
+      htu: 'https://i/token',
+    );
+    final payload = _decodeJson(token.split('.')[1]);
+    expect(payload['nonce'], 'n-1234');
+
+    // Case-insensitive lookup.
+    final ctx2 = makeDpopContext(kp);
+    rememberNonce(ctx2, 'https://i/token', {'dpop-nonce': 'n-lower'});
+    final token2 = await buildProof(
+      ctx2,
+      htm: 'POST',
+      htu: 'https://i/token',
+    );
+    expect(_decodeJson(token2.split('.')[1])['nonce'], 'n-lower');
+  });
+
+  test('nonce is scoped per origin', () async {
+    final ctx = makeDpopContext(kp);
+    rememberNonce(ctx, 'https://a.example.com/token', {'DPoP-Nonce': 'a'});
+    rememberNonce(ctx, 'https://b.example.com/token', {'DPoP-Nonce': 'b'});
+    final proofA = await buildProof(ctx,
+        htm: 'POST', htu: 'https://a.example.com/token');
+    final proofB = await buildProof(ctx,
+        htm: 'POST', htu: 'https://b.example.com/token');
+    expect(_decodeJson(proofA.split('.')[1])['nonce'], 'a');
+    expect(_decodeJson(proofB.split('.')[1])['nonce'], 'b');
+  });
+
+  test('rememberClockOffset adjusts iat using Date header', () async {
+    final ctx = makeDpopContext(kp);
+    // Pick a far-future server date so the delta is unmistakable.
+    final serverTime = DateTime.utc(2099, 1, 1, 0, 0, 0);
+    rememberClockOffset(ctx, {
+      'Date': 'Thu, 01 Jan 2099 00:00:00 GMT',
+    });
+    expect(ctx.clockOffsetMs, greaterThan(0));
+
+    final token = await buildProof(ctx, htm: 'POST', htu: 'https://i/token');
+    final payload = _decodeJson(token.split('.')[1]);
+    final iat = payload['iat'] as int;
+    // Tolerate a few seconds for test execution.
+    expect(iat, closeTo(serverTime.millisecondsSinceEpoch ~/ 1000, 5));
+  });
+
+  test('rememberClockOffset ignores missing or malformed Date header',
+      () async {
+    final ctx = makeDpopContext(kp);
+    rememberClockOffset(ctx, const {});
+    expect(ctx.clockOffsetMs, 0);
+    rememberClockOffset(ctx, {'Date': 'not-a-date'});
+    expect(ctx.clockOffsetMs, 0);
+  });
+
+  test('buildProof signature verifies against the embedded public key',
+      () async {
+    final ctx = makeDpopContext(kp);
+    final token = await buildProof(
+      ctx,
+      htm: 'POST',
+      htu: 'https://i/token',
+    );
+    final parts = token.split('.');
+    final signingInput = '${parts[0]}.${parts[1]}';
+    final sigBytes = _decodeBytes(parts[2]);
+    final ok = verifyEcdsaRaw(
+      kp.publicKey,
+      Uint8List.fromList(utf8.encode(signingInput)),
+      sigBytes,
+    );
+    expect(ok, isTrue);
+  });
+}

--- a/ui/runtime/test/protocol/jwt_test.dart
+++ b/ui/runtime/test/protocol/jwt_test.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/src/protocol/jwt.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+String _fakeJwt(Map<String, dynamic> payload) {
+  String seg(Map<String, dynamic> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  final header = seg({'alg': 'none', 'typ': 'JWT'});
+  final body = seg(payload);
+  // Signature segment is arbitrary for payload-only decoding.
+  return '$header.$body.sig';
+}
+
+void main() {
+  group('decodeJwtPayload', () {
+    test('round-trips payloads of varied length', () {
+      // 1-char, 20-char strings plus nested map
+      for (var len = 1; len <= 20; len++) {
+        final sub = 'a' * len;
+        final token = _fakeJwt({'sub': sub, 'len': len});
+        final decoded = decodeJwtPayload(token);
+        expect(decoded['sub'], sub);
+        expect(decoded['len'], len);
+      }
+    });
+
+    test('handles missing base64 padding correctly', () {
+      // Payload chosen so base64 length mod 4 == 2 (needs two `=` pad chars).
+      final token = _fakeJwt({'x': 'a'});
+      final decoded = decodeJwtPayload(token);
+      expect(decoded['x'], 'a');
+    });
+
+    test('throws on malformed JWT', () {
+      expect(() => decodeJwtPayload('not.a.jwt.with.extra.parts'),
+          throwsFormatException);
+      expect(() => decodeJwtPayload('only-one-part'), throwsFormatException);
+    });
+  });
+
+  group('extractRolesFromToken', () {
+    test('returns direct roles array', () {
+      final token = _fakeJwt({
+        'sub': 's',
+        'roles': ['admin', 'editor'],
+      });
+      expect(extractRolesFromToken(token), ['admin', 'editor']);
+    });
+
+    test('falls back to realm_access.roles', () {
+      final token = _fakeJwt({
+        'sub': 's',
+        'realm_access': {
+          'roles': ['ops', 'support'],
+        },
+      });
+      expect(extractRolesFromToken(token), ['ops', 'support']);
+    });
+
+    test('returns empty list when no roles claim is present', () {
+      final token = _fakeJwt({'sub': 's'});
+      expect(extractRolesFromToken(token), isEmpty);
+    });
+
+    test('returns empty list on malformed token', () {
+      expect(extractRolesFromToken('garbage'), isEmpty);
+    });
+
+    test('ignores non-string role entries', () {
+      final token = _fakeJwt({
+        'roles': <dynamic>['ok', 42, null, 'good'],
+      });
+      expect(extractRolesFromToken(token), ['ok', 'good']);
+    });
+  });
+}

--- a/ui/runtime/test/protocol/pkce_test.dart
+++ b/ui/runtime/test/protocol/pkce_test.dart
@@ -1,0 +1,41 @@
+import 'package:antinvestor_auth_runtime/src/protocol/pkce.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('verifier is 43-128 url-safe chars', () async {
+    final pair = await generatePkcePair();
+    expect(RegExp(r'^[A-Za-z0-9_-]{43,128}$').hasMatch(pair.verifier), true);
+    expect(RegExp(r'^[A-Za-z0-9_-]+$').hasMatch(pair.challenge), true);
+  });
+
+  test('challenge is deterministic from verifier', () async {
+    final a = await generatePkcePair();
+    expect(await computeChallenge(a.verifier), a.challenge);
+  });
+
+  test('generateVerifier produces distinct values (entropy)', () {
+    final seen = <String>{
+      for (var i = 0; i < 32; i++) generateVerifier(),
+    };
+    // Collisions with 64 random bytes are astronomically unlikely; if
+    // we ever collide it likely means we're not using Random.secure().
+    expect(seen.length, 32);
+  });
+
+  test('SHA-256 challenge is 43 base64url chars (no padding)', () async {
+    final challenge = await computeChallenge('a-known-verifier-string');
+    expect(challenge.length, 43);
+    expect(challenge.contains('='), isFalse);
+    expect(challenge.contains('+'), isFalse);
+    expect(challenge.contains('/'), isFalse);
+  });
+
+  test('computeChallenge matches RFC 7636 known-answer vector', () async {
+    // Appendix B example:
+    // verifier = dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk
+    // challenge = E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+    final challenge =
+        await computeChallenge('dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk');
+    expect(challenge, 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM');
+  });
+}

--- a/ui/runtime/test/protocol/token_exchange_test.dart
+++ b/ui/runtime/test/protocol/token_exchange_test.dart
@@ -1,0 +1,259 @@
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/token_set.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+const _timeout = Duration(seconds: 5);
+
+ResolvedConfig _cfg() => resolveConfig(const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://idp.example.com',
+      apiBaseUrl: 'https://api.example.com',
+      redirectScheme: 'com.example.app',
+    ));
+
+Map<String, dynamic> _discoveryDoc({bool dpop = false}) => <String, dynamic>{
+      'issuer': 'https://idp.example.com',
+      'authorization_endpoint': 'https://idp.example.com/oauth2/auth',
+      'token_endpoint': 'https://idp.example.com/oauth2/token',
+      if (dpop) 'dpop_signing_alg_values_supported': ['ES256'],
+    };
+
+Map<String, dynamic> _tokenResp({
+  String accessToken = 'at-1',
+  String refreshToken = 'rt-1',
+  int expiresIn = 300,
+  String tokenType = 'Bearer',
+  String? idToken,
+}) =>
+    <String, dynamic>{
+      'access_token': accessToken,
+      'refresh_token': refreshToken,
+      'expires_in': expiresIn,
+      'token_type': tokenType,
+      'id_token': ?idToken,
+    };
+
+void main() {
+  setUp(clearDiscoveryCache);
+
+  group('exchangeCode', () {
+    test('bearer-mode exchange posts authorization_code grant', () async {
+      final cfg = _cfg();
+      final calls = <http.Request>[];
+      final client = MockClient((req) async {
+        calls.add(req);
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        expect(req.url.toString(), 'https://idp.example.com/oauth2/token');
+        expect(req.headers['content-type'],
+            startsWith('application/x-www-form-urlencoded'));
+        expect(req.headers.containsKey('dpop'), isFalse);
+        final form = Uri.splitQueryString(req.body);
+        expect(form['grant_type'], 'authorization_code');
+        expect(form['client_id'], 'c');
+        expect(form['code'], 'code-xyz');
+        expect(form['code_verifier'], 'verifier-xyz');
+        expect(form['redirect_uri'], 'com.example.app://callback');
+        return http.Response(jsonEncode(_tokenResp()), 200,
+            headers: {'content-type': 'application/json'});
+      });
+
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      final tokens = await exchange.exchangeCode(
+        cfg,
+        ctx,
+        code: 'code-xyz',
+        verifier: 'verifier-xyz',
+      );
+      expect(tokens.accessToken, 'at-1');
+      expect(tokens.refreshToken, 'rt-1');
+      expect(tokens.tokenType, TokenType.bearer);
+    });
+
+    test('DPoP-mode adds DPoP header and retries on nonce challenge',
+        () async {
+      final cfg = _cfg();
+      var tokenCalls = 0;
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc(dpop: true)), 200);
+        }
+        tokenCalls++;
+        expect(req.headers.containsKey('dpop'), isTrue);
+        if (tokenCalls == 1) {
+          return http.Response(
+            jsonEncode({'error': 'use_dpop_nonce'}),
+            401,
+            headers: {'dpop-nonce': 'n-fresh'},
+          );
+        }
+        // On retry the nonce should be present in the proof payload.
+        final proof = req.headers['dpop']!;
+        final payloadB64 = proof.split('.')[1];
+        final padded = payloadB64.padRight(
+            payloadB64.length + (4 - payloadB64.length % 4) % 4, '=');
+        final payload =
+            jsonDecode(utf8.decode(base64Url.decode(padded))) as Map;
+        expect(payload['nonce'], 'n-fresh');
+        return http.Response(jsonEncode(_tokenResp(tokenType: 'DPoP')), 200);
+      });
+
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      final tokens = await exchange.exchangeCode(
+        cfg,
+        ctx,
+        code: 'c',
+        verifier: 'v',
+      );
+      expect(tokens.tokenType, TokenType.dpop);
+      expect(tokenCalls, 2);
+    });
+
+    test('clock-skew retry on invalid_dpop_proof', () async {
+      final cfg = _cfg();
+      var tokenCalls = 0;
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc(dpop: true)), 200);
+        }
+        tokenCalls++;
+        if (tokenCalls == 1) {
+          return http.Response(
+            jsonEncode({'error': 'invalid_dpop_proof'}),
+            400,
+            headers: {'date': 'Thu, 01 Jan 2099 00:00:00 GMT'},
+          );
+        }
+        return http.Response(jsonEncode(_tokenResp(tokenType: 'DPoP')), 200);
+      });
+
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      final tokens = await exchange.exchangeCode(
+        cfg,
+        ctx,
+        code: 'c',
+        verifier: 'v',
+      );
+      expect(tokens.accessToken, 'at-1');
+      expect(tokenCalls, 2);
+      expect(ctx.clockOffsetMs, greaterThan(0));
+    });
+
+    test('non-2xx final response raises tokenExchangeFailed', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        return http.Response('{"error":"invalid_request"}', 400);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      await expectLater(
+        exchange.exchangeCode(cfg, ctx, code: 'c', verifier: 'v'),
+        throwsA(isA<AuthError>()
+            .having((e) => e.code, 'code', AuthErrorCode.tokenExchangeFailed)),
+      );
+    });
+  });
+
+  group('refresh', () {
+    test('rotating refresh returns RefreshOutcome.rotated', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        final form = Uri.splitQueryString(req.body);
+        expect(form['grant_type'], 'refresh_token');
+        expect(form['refresh_token'], 'rt-1');
+        return http.Response(
+            jsonEncode(_tokenResp(accessToken: 'at-2', refreshToken: 'rt-2')),
+            200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      final outcome = await exchange.refresh(cfg, ctx, 'rt-1');
+      expect(outcome, isA<RefreshRotated>());
+      final rotated = outcome as RefreshRotated;
+      expect(rotated.tokens.accessToken, 'at-2');
+      expect(rotated.tokens.refreshToken, 'rt-2');
+    });
+
+    test('invalid_grant with reuse mention returns reuseDetected', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        return http.Response(
+          jsonEncode({
+            'error': 'invalid_grant',
+            'error_description': 'refresh token reuse detected',
+          }),
+          400,
+        );
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      final outcome = await exchange.refresh(cfg, ctx, 'rt-stale');
+      expect(outcome, isA<RefreshReuseDetectedOutcome>());
+    });
+
+    test('other server failure wraps as networkError', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        return http.Response('boom', 500);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      final outcome = await exchange.refresh(cfg, ctx, 'rt');
+      expect(outcome, isA<RefreshNetworkError>());
+      final err = outcome as RefreshNetworkError;
+      expect(err.error.code, AuthErrorCode.tokenRefreshFailed);
+    });
+
+    test('refresh supports sealed-class pattern matching', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        return http.Response(jsonEncode(_tokenResp()), 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      final outcome = await exchange.refresh(cfg, ctx, 'rt');
+      final label = switch (outcome) {
+        RefreshRotated() => 'rotated',
+        RefreshReuseDetectedOutcome() => 'reuse',
+        RefreshNetworkError() => 'err',
+      };
+      expect(label, 'rotated');
+    });
+  });
+}

--- a/ui/runtime/test/providers/auth_providers_test.dart
+++ b/ui/runtime/test/providers/auth_providers_test.dart
@@ -1,0 +1,171 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_auth_runtime.dart';
+
+void main() {
+  late FakeAuthRuntime fake;
+  late ProviderContainer container;
+
+  setUp(() {
+    fake = FakeAuthRuntime(initialState: AuthState.unauthenticated);
+    container = ProviderContainer(
+      overrides: [authRuntimeProvider.overrideWithValue(fake)],
+    );
+    addTearDown(container.dispose);
+    addTearDown(fake.dispose);
+  });
+
+  test('default authRuntimeProvider throws without an override', () {
+    final bare = ProviderContainer();
+    addTearDown(bare.dispose);
+    // Riverpod 3 wraps provider-thrown errors in a ProviderException; we
+    // match on the underlying message rather than the type so this stays
+    // robust against future Riverpod re-wraps.
+    expect(
+      () => bare.read(authRuntimeProvider),
+      throwsA(predicate<Object>(
+        (e) => e.toString().contains('Override authRuntimeProvider'),
+      )),
+    );
+  });
+
+  test('authStateProvider mirrors the runtime stream', () async {
+    // Attach a subscription so Riverpod starts the stream.
+    final received = <AuthState>[];
+    container.listen<AsyncValue<AuthState>>(
+      authStateProvider,
+      (_, next) {
+        next.whenData(received.add);
+      },
+      fireImmediately: true,
+    );
+
+    fake.emitState(AuthState.initializing);
+    fake.emitState(AuthState.authenticated);
+    await Future<void>.microtask(() {});
+    await Future<void>.delayed(Duration.zero);
+
+    expect(received, containsAllInOrder(<AuthState>[
+      AuthState.initializing,
+      AuthState.authenticated,
+    ]));
+  });
+
+  test('isAuthenticatedProvider reflects current AuthState', () async {
+    // Subscribe so the StreamProvider starts emitting.
+    container.listen(authStateProvider, (_, _) {});
+    expect(container.read(isAuthenticatedProvider), isFalse);
+
+    fake.emitState(AuthState.authenticated);
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(isAuthenticatedProvider), isTrue);
+
+    fake.emitState(AuthState.unauthenticated);
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(isAuthenticatedProvider), isFalse);
+  });
+
+  test('userClaimsProvider returns {} while unauthenticated', () async {
+    container.listen(authStateProvider, (_, _) {});
+    final claims = await container.read(userClaimsProvider.future);
+    expect(claims, isEmpty);
+  });
+
+  test('userClaimsProvider returns runtime claims once authenticated',
+      () async {
+    fake.claims = {'sub': 'u-1', 'email': 'a@b.c'};
+    container.listen(authStateProvider, (_, _) {});
+    fake.emitState(AuthState.authenticated);
+    // Invalidate so it re-reads now that the state has flipped.
+    await Future<void>.delayed(Duration.zero);
+    container.invalidate(userClaimsProvider);
+    final claims = await container.read(userClaimsProvider.future);
+    expect(claims['sub'], 'u-1');
+    expect(claims['email'], 'a@b.c');
+  });
+
+  test('rolesProvider returns [] while unauthenticated', () async {
+    container.listen(authStateProvider, (_, _) {});
+    final roles = await container.read(rolesProvider.future);
+    expect(roles, isEmpty);
+  });
+
+  test('rolesProvider returns runtime roles once authenticated', () async {
+    fake.roles = ['admin', 'user'];
+    container.listen(authStateProvider, (_, _) {});
+    fake.emitState(AuthState.authenticated);
+    await Future<void>.delayed(Duration.zero);
+    container.invalidate(rolesProvider);
+    final roles = await container.read(rolesProvider.future);
+    expect(roles, ['admin', 'user']);
+  });
+
+  test('securityEventsProvider streams runtime events', () async {
+    final events = <SecurityEvent>[];
+    container.listen<AsyncValue<SecurityEvent>>(
+      securityEventsProvider,
+      (_, next) {
+        next.whenData(events.add);
+      },
+    );
+    final at = DateTime.utc(2026, 4, 19, 12, 0, 0);
+    fake.emitSecurityEvent(SecurityEvent.refreshReuseDetected(at));
+    fake.emitSecurityEvent(SecurityEvent.storageCorruption(at));
+    await Future<void>.delayed(Duration.zero);
+    expect(events, hasLength(2));
+    expect(events[0], isA<RefreshReuseDetected>());
+    expect(events[1], isA<StorageCorruption>());
+  });
+
+  testWidgets('AuthRuntimeScope.of returns the runtime from context',
+      (tester) async {
+    AuthRuntime? seen;
+    await tester.pumpWidget(
+      AuthRuntimeScope(
+        runtime: fake,
+        child: Builder(
+          builder: (ctx) {
+            seen = AuthRuntimeScope.of(ctx);
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+    expect(identical(seen, fake), isTrue);
+  });
+
+  testWidgets('AuthRuntimeScope.of throws when no ancestor is present',
+      (tester) async {
+    FlutterError? caught;
+    await tester.pumpWidget(
+      Builder(
+        builder: (ctx) {
+          try {
+            AuthRuntimeScope.of(ctx);
+          } on FlutterError catch (err) {
+            caught = err;
+          }
+          return const SizedBox();
+        },
+      ),
+    );
+    expect(caught, isNotNull);
+  });
+
+  testWidgets('AuthRuntimeScope.maybeOf returns null without ancestor',
+      (tester) async {
+    AuthRuntime? seen = fake;
+    await tester.pumpWidget(
+      Builder(
+        builder: (ctx) {
+          seen = AuthRuntimeScope.maybeOf(ctx);
+          return const SizedBox();
+        },
+      ),
+    );
+    expect(seen, isNull);
+  });
+}

--- a/ui/runtime/test/runtime/refresh_lock_test.dart
+++ b/ui/runtime/test/runtime/refresh_lock_test.dart
@@ -1,0 +1,94 @@
+import 'dart:async';
+
+import 'package:antinvestor_auth_runtime/src/runtime/refresh_lock.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('two concurrent calls on the same key serialize', () async {
+    final lock = RefreshLock();
+    final order = <String>[];
+    final c1 = Completer<void>();
+    final c2 = Completer<void>();
+
+    final f1 = lock.withLock<int>('ns', () async {
+      order.add('start-1');
+      await c1.future;
+      order.add('end-1');
+      return 1;
+    });
+    final f2 = lock.withLock<int>('ns', () async {
+      order.add('start-2');
+      await c2.future;
+      order.add('end-2');
+      return 2;
+    });
+
+    // Give the scheduler a chance to run task 1.
+    await Future<void>.delayed(Duration.zero);
+    expect(order, ['start-1']);
+
+    c1.complete();
+    await Future<void>.delayed(Duration.zero);
+    // Only after task 1 completes may task 2 enter.
+    expect(order.contains('start-2'), isTrue);
+
+    c2.complete();
+    expect(await f1, 1);
+    expect(await f2, 2);
+    expect(order, ['start-1', 'end-1', 'start-2', 'end-2']);
+  });
+
+  test('different keys proceed in parallel', () async {
+    final lock = RefreshLock();
+    final started = <String>[];
+
+    final barrier = Completer<void>();
+    final a = lock.withLock<void>('a', () async {
+      started.add('a');
+      await barrier.future;
+    });
+    final b = lock.withLock<void>('b', () async {
+      started.add('b');
+    });
+
+    // Task b must be able to finish even though task a is blocked.
+    await b;
+    expect(started, containsAll(<String>['a', 'b']));
+
+    barrier.complete();
+    await a;
+  });
+
+  test('a thrown error releases the lock for the next caller', () async {
+    final lock = RefreshLock();
+
+    await expectLater(
+      lock.withLock<void>('ns', () async {
+        throw StateError('boom');
+      }),
+      throwsA(isA<StateError>()),
+    );
+
+    // Second caller must still be able to acquire.
+    final result = await lock.withLock<int>('ns', () async => 42);
+    expect(result, 42);
+  });
+
+  test('sequential calls on the same key execute one at a time', () async {
+    final lock = RefreshLock();
+    var active = 0;
+    var peakActive = 0;
+
+    Future<void> run() async {
+      await lock.withLock<void>('ns', () async {
+        active++;
+        peakActive = active > peakActive ? active : peakActive;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        active--;
+      });
+    }
+
+    await Future.wait(<Future<void>>[run(), run(), run(), run()]);
+    expect(peakActive, 1);
+  });
+}

--- a/ui/runtime/test/runtime/state_machine_test.dart
+++ b/ui/runtime/test/runtime/state_machine_test.dart
@@ -1,0 +1,148 @@
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/runtime/state_machine.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final _dummyError =
+    AuthError(AuthErrorCode.tokenRefreshFailed, 'test');
+
+void main() {
+  group('initializing', () {
+    test('init_done hasTokens=true -> authenticated', () {
+      expect(
+        reduce(AuthState.initializing, const StateInput.initDone(hasTokens: true)),
+        AuthState.authenticated,
+      );
+    });
+
+    test('init_done hasTokens=false -> unauthenticated', () {
+      expect(
+        reduce(AuthState.initializing,
+            const StateInput.initDone(hasTokens: false)),
+        AuthState.unauthenticated,
+      );
+    });
+
+    test('sign_in_done -> authenticated', () {
+      expect(reduce(AuthState.initializing, const StateInput.signInDone()),
+          AuthState.authenticated);
+    });
+
+    test('sign_in_fail -> unauthenticated', () {
+      expect(reduce(AuthState.initializing, StateInput.signInFail(_dummyError)),
+          AuthState.unauthenticated);
+    });
+
+    test('unrelated input is a no-op', () {
+      expect(reduce(AuthState.initializing, const StateInput.refreshDone()),
+          AuthState.initializing);
+    });
+  });
+
+  group('unauthenticated', () {
+    test('sign_in_start -> initializing', () {
+      expect(reduce(AuthState.unauthenticated, const StateInput.signInStart()),
+          AuthState.initializing);
+    });
+
+    test('logout is a no-op', () {
+      expect(reduce(AuthState.unauthenticated, const StateInput.logout()),
+          AuthState.unauthenticated);
+    });
+
+    test('refresh_start is a no-op (guards against races)', () {
+      expect(reduce(AuthState.unauthenticated, const StateInput.refreshStart()),
+          AuthState.unauthenticated);
+    });
+  });
+
+  group('authenticated', () {
+    test('refresh_start -> refreshing', () {
+      expect(reduce(AuthState.authenticated, const StateInput.refreshStart()),
+          AuthState.refreshing);
+    });
+
+    test('logout -> unauthenticated', () {
+      expect(reduce(AuthState.authenticated, const StateInput.logout()),
+          AuthState.unauthenticated);
+    });
+
+    test('sign_in_done is a no-op', () {
+      expect(reduce(AuthState.authenticated, const StateInput.signInDone()),
+          AuthState.authenticated);
+    });
+  });
+
+  group('refreshing', () {
+    test('refresh_done -> authenticated', () {
+      expect(reduce(AuthState.refreshing, const StateInput.refreshDone()),
+          AuthState.authenticated);
+    });
+
+    test('refresh_fail without wipe -> unauthenticated', () {
+      expect(
+        reduce(
+          AuthState.refreshing,
+          StateInput.refreshFail(error: _dummyError, wipe: false),
+        ),
+        AuthState.unauthenticated,
+      );
+    });
+
+    test('refresh_fail with wipe -> unauthenticated', () {
+      expect(
+        reduce(
+          AuthState.refreshing,
+          StateInput.refreshFail(error: _dummyError, wipe: true),
+        ),
+        AuthState.unauthenticated,
+      );
+    });
+
+    test('logout mid-refresh -> unauthenticated', () {
+      expect(reduce(AuthState.refreshing, const StateInput.logout()),
+          AuthState.unauthenticated);
+    });
+  });
+
+  group('security_wipe', () {
+    test('from initializing -> unauthenticated', () {
+      expect(
+          reduce(AuthState.initializing, const StateInput.securityWipe('r')),
+          AuthState.unauthenticated);
+    });
+
+    test('from authenticated -> unauthenticated', () {
+      expect(reduce(AuthState.authenticated, const StateInput.securityWipe('r')),
+          AuthState.unauthenticated);
+    });
+
+    test('from refreshing -> unauthenticated', () {
+      expect(reduce(AuthState.refreshing, const StateInput.securityWipe('r')),
+          AuthState.unauthenticated);
+    });
+
+    test('from unauthenticated -> unauthenticated', () {
+      expect(
+          reduce(AuthState.unauthenticated, const StateInput.securityWipe('r')),
+          AuthState.unauthenticated);
+    });
+
+    test('from error -> unauthenticated', () {
+      expect(reduce(AuthState.error, const StateInput.securityWipe('r')),
+          AuthState.unauthenticated);
+    });
+  });
+
+  group('error', () {
+    test('sign_in_start -> initializing', () {
+      expect(reduce(AuthState.error, const StateInput.signInStart()),
+          AuthState.initializing);
+    });
+
+    test('refresh_done is a no-op', () {
+      expect(reduce(AuthState.error, const StateInput.refreshDone()),
+          AuthState.error);
+    });
+  });
+}

--- a/ui/runtime/test/storage/secure_token_store_test.dart
+++ b/ui/runtime/test/storage/secure_token_store_test.dart
@@ -1,0 +1,87 @@
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
+import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+StoredSession _session({String? idToken, DateTime? at}) => StoredSession(
+      wrappedRefreshToken: WrappedBlob(
+        iv: Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+        ciphertext: Uint8List.fromList(List<int>.generate(48, (i) => i)),
+      ),
+      dpopKeyEncrypted: Uint8List.fromList([0x10, 0x20, 0x30]),
+      wrapKeyEncrypted: Uint8List.fromList([0x40, 0x50, 0x60]),
+      lastIdToken: idToken,
+      updatedAt: at ?? DateTime.utc(2026, 4, 19, 22, 35, 0),
+    );
+
+void main() {
+  late InMemoryKeyValueStore kv;
+  late SecureTokenStore store;
+
+  setUp(() {
+    kv = InMemoryKeyValueStore();
+    store = SecureTokenStore(kv: kv);
+  });
+
+  test('save then load round-trips', () async {
+    final s = _session(idToken: 'id-abc');
+    await store.save('ns1', s);
+    final loaded = await store.load('ns1');
+    expect(loaded, isNotNull);
+    expect(loaded!.wrappedRefreshToken.iv, s.wrappedRefreshToken.iv);
+    expect(loaded.wrappedRefreshToken.ciphertext,
+        s.wrappedRefreshToken.ciphertext);
+    expect(loaded.dpopKeyEncrypted, s.dpopKeyEncrypted);
+    expect(loaded.wrapKeyEncrypted, s.wrapKeyEncrypted);
+    expect(loaded.lastIdToken, 'id-abc');
+    expect(loaded.updatedAt, s.updatedAt);
+  });
+
+  test('load of unknown namespace returns null', () async {
+    expect(await store.load('never-saved'), isNull);
+  });
+
+  test('namespaces are isolated', () async {
+    final a = _session(idToken: 'A');
+    final b = _session(idToken: 'B');
+    await store.save('nsA', a);
+    await store.save('nsB', b);
+    expect((await store.load('nsA'))!.lastIdToken, 'A');
+    expect((await store.load('nsB'))!.lastIdToken, 'B');
+  });
+
+  test('clear removes the stored session', () async {
+    await store.save('nsX', _session());
+    expect(await store.load('nsX'), isNotNull);
+    await store.clear('nsX');
+    expect(await store.load('nsX'), isNull);
+  });
+
+  test('clear on unknown namespace does not throw', () async {
+    await store.clear('does-not-exist');
+  });
+
+  test('corrupt JSON on load returns null (no throw)', () async {
+    await kv.write('auth:corrupt', 'not-json-at-all');
+    expect(await store.load('corrupt'), isNull);
+  });
+
+  test('valid JSON with bad shape returns null', () async {
+    await kv.write('auth:badshape', '{"v":1,"wrappedRt":"wrong-type"}');
+    expect(await store.load('badshape'), isNull);
+  });
+
+  test('wrong version returns null', () async {
+    await kv.write('auth:oldver',
+        '{"v":99,"wrappedRt":{"iv":"","ct":""},"dpopKeyEnc":"","wrapKeyEnc":"","updatedAt":"2026-04-19T00:00:00Z"}');
+    expect(await store.load('oldver'), isNull);
+  });
+
+  test('missing id_token is preserved as null', () async {
+    await store.save('ns-no-id', _session());
+    final loaded = await store.load('ns-no-id');
+    expect(loaded!.lastIdToken, isNull);
+  });
+}

--- a/ui/runtime/test/storage/secure_token_store_test.dart
+++ b/ui/runtime/test/storage/secure_token_store_test.dart
@@ -5,14 +5,21 @@ import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
 import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-StoredSession _session({String? idToken, DateTime? at}) => StoredSession(
-      wrappedRefreshToken: WrappedBlob(
-        iv: Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
-        ciphertext: Uint8List.fromList(List<int>.generate(48, (i) => i)),
+WrappedBlob _blob(int seed) => WrappedBlob(
+      iv: Uint8List.fromList(List<int>.generate(12, (i) => (seed + i) & 0xff)),
+      ciphertext: Uint8List.fromList(
+        List<int>.generate(48, (i) => (seed * 7 + i) & 0xff),
       ),
-      dpopKeyEncrypted: Uint8List.fromList([0x10, 0x20, 0x30]),
-      wrapKeyEncrypted: Uint8List.fromList([0x40, 0x50, 0x60]),
-      lastIdToken: idToken,
+    );
+
+StoredSession _session({String? idToken, DateTime? at}) => StoredSession(
+      wrapKeyCiphertext: _blob(1),
+      dpopPrivateKeyCiphertext: _blob(2),
+      refreshTokenCiphertext: _blob(3),
+      accessToken: 'at-abc',
+      accessTokenExpiresAt: DateTime.utc(2026, 4, 19, 23, 0, 0),
+      tokenType: 'Bearer',
+      idToken: idToken,
       updatedAt: at ?? DateTime.utc(2026, 4, 19, 22, 35, 0),
     );
 
@@ -30,12 +37,18 @@ void main() {
     await store.save('ns1', s);
     final loaded = await store.load('ns1');
     expect(loaded, isNotNull);
-    expect(loaded!.wrappedRefreshToken.iv, s.wrappedRefreshToken.iv);
-    expect(loaded.wrappedRefreshToken.ciphertext,
-        s.wrappedRefreshToken.ciphertext);
-    expect(loaded.dpopKeyEncrypted, s.dpopKeyEncrypted);
-    expect(loaded.wrapKeyEncrypted, s.wrapKeyEncrypted);
-    expect(loaded.lastIdToken, 'id-abc');
+    expect(loaded!.wrapKeyCiphertext.iv, s.wrapKeyCiphertext.iv);
+    expect(loaded.wrapKeyCiphertext.ciphertext, s.wrapKeyCiphertext.ciphertext);
+    expect(loaded.dpopPrivateKeyCiphertext.iv, s.dpopPrivateKeyCiphertext.iv);
+    expect(loaded.dpopPrivateKeyCiphertext.ciphertext,
+        s.dpopPrivateKeyCiphertext.ciphertext);
+    expect(loaded.refreshTokenCiphertext.iv, s.refreshTokenCiphertext.iv);
+    expect(loaded.refreshTokenCiphertext.ciphertext,
+        s.refreshTokenCiphertext.ciphertext);
+    expect(loaded.accessToken, 'at-abc');
+    expect(loaded.accessTokenExpiresAt, s.accessTokenExpiresAt);
+    expect(loaded.tokenType, 'Bearer');
+    expect(loaded.idToken, 'id-abc');
     expect(loaded.updatedAt, s.updatedAt);
   });
 
@@ -48,8 +61,8 @@ void main() {
     final b = _session(idToken: 'B');
     await store.save('nsA', a);
     await store.save('nsB', b);
-    expect((await store.load('nsA'))!.lastIdToken, 'A');
-    expect((await store.load('nsB'))!.lastIdToken, 'B');
+    expect((await store.load('nsA'))!.idToken, 'A');
+    expect((await store.load('nsB'))!.idToken, 'B');
   });
 
   test('clear removes the stored session', () async {
@@ -69,19 +82,37 @@ void main() {
   });
 
   test('valid JSON with bad shape returns null', () async {
-    await kv.write('auth:badshape', '{"v":1,"wrappedRt":"wrong-type"}');
+    await kv.write('auth:badshape', '{"v":2,"wrapKey":"wrong-type"}');
     expect(await store.load('badshape'), isNull);
   });
 
   test('wrong version returns null', () async {
-    await kv.write('auth:oldver',
-        '{"v":99,"wrappedRt":{"iv":"","ct":""},"dpopKeyEnc":"","wrapKeyEnc":"","updatedAt":"2026-04-19T00:00:00Z"}');
+    await kv.write(
+      'auth:oldver',
+      '{"v":99,"wrapKey":{"iv":"","ct":""},'
+          '"dpopKey":{"iv":"","ct":""},'
+          '"refreshToken":{"iv":"","ct":""},'
+          '"accessToken":"x","accessExpiresAt":"2026-04-19T00:00:00Z",'
+          '"tokenType":"Bearer","updatedAt":"2026-04-19T00:00:00Z"}',
+    );
     expect(await store.load('oldver'), isNull);
+  });
+
+  test('legacy v1 schema is rejected (returns null)', () async {
+    // v1 had: wrappedRt/dpopKeyEnc/wrapKeyEnc/idToken/updatedAt.
+    // We explicitly don't support forward-migration; callers fall back
+    // to a fresh sign-in.
+    await kv.write(
+      'auth:v1',
+      '{"v":1,"wrappedRt":{"iv":"","ct":""},"dpopKeyEnc":"","wrapKeyEnc":"",'
+          '"updatedAt":"2026-04-19T00:00:00Z"}',
+    );
+    expect(await store.load('v1'), isNull);
   });
 
   test('missing id_token is preserved as null', () async {
     await store.save('ns-no-id', _session());
     final loaded = await store.load('ns-no-id');
-    expect(loaded!.lastIdToken, isNull);
+    expect(loaded!.idToken, isNull);
   });
 }

--- a/ui/runtime/test/support/fake_auth_runtime.dart
+++ b/ui/runtime/test/support/fake_auth_runtime.dart
@@ -1,0 +1,128 @@
+import 'dart:async';
+
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+
+/// Controllable [AuthRuntime] for widget + provider tests.
+///
+/// Streams and return values are driven via plain fields / controllers so
+/// tests can push arbitrary sequences of [AuthState] transitions and
+/// [SecurityEvent]s without spinning up OAuth or HTTP. Method call
+/// counters make it easy to assert that the widget layer plumbed user
+/// interactions through to the runtime.
+class FakeAuthRuntime implements AuthRuntime {
+  FakeAuthRuntime({
+    AuthState initialState = AuthState.unauthenticated,
+    Map<String, dynamic>? claims,
+    List<String>? roles,
+  })  : _state = initialState,
+        _claims = claims ?? const <String, dynamic>{},
+        _roles = roles ?? const <String>[];
+
+  final StreamController<AuthState> _stateCtl =
+      StreamController<AuthState>.broadcast();
+  final StreamController<SecurityEvent> _secCtl =
+      StreamController<SecurityEvent>.broadcast();
+
+  AuthState _state;
+  Map<String, dynamic> _claims;
+  List<String> _roles;
+  bool _disposed = false;
+
+  int ensureAuthenticatedCalls = 0;
+  int logoutCalls = 0;
+  int fetchCalls = 0;
+  int uploadCalls = 0;
+  int prefetchCalls = 0;
+
+  /// When set, [ensureAuthenticated] throws it instead of transitioning.
+  Object? ensureAuthenticatedError;
+
+  @override
+  AuthState get state => _state;
+
+  @override
+  Stream<AuthState> get authStateStream => _stateCtl.stream;
+
+  @override
+  Stream<SecurityEvent> get securityEventStream => _secCtl.stream;
+
+  @override
+  String get version => authRuntimeVersion;
+
+  /// Drive an [AuthState] transition into the stream and update [state].
+  void emitState(AuthState s) {
+    _state = s;
+    _stateCtl.add(s);
+  }
+
+  /// Emit a [SecurityEvent] to subscribers.
+  void emitSecurityEvent(SecurityEvent event) {
+    _secCtl.add(event);
+  }
+
+  /// Swap the claims returned by [getClaims].
+  set claims(Map<String, dynamic> next) => _claims = next;
+
+  /// Swap the roles returned by [getRoles].
+  set roles(List<String> next) => _roles = next;
+
+  @override
+  Future<void> ensureAuthenticated() async {
+    ensureAuthenticatedCalls++;
+    final err = ensureAuthenticatedError;
+    if (err != null) throw err;
+    emitState(AuthState.authenticated);
+  }
+
+  @override
+  Future<ApiResponse> fetch(
+    String path, {
+    String method = 'GET',
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    fetchCalls++;
+    throw UnimplementedError('fetch not stubbed in FakeAuthRuntime');
+  }
+
+  @override
+  Future<ApiResponse> upload(
+    String path, {
+    required String fieldName,
+    required String filename,
+    required String contentType,
+    required Stream<List<int>> bytes,
+    required int length,
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    uploadCalls++;
+    throw UnimplementedError('upload not stubbed in FakeAuthRuntime');
+  }
+
+  @override
+  Future<Map<String, dynamic>> getClaims() async => _claims;
+
+  @override
+  Future<List<String>> getRoles() async => _roles;
+
+  @override
+  Future<void> logout() async {
+    logoutCalls++;
+    emitState(AuthState.unauthenticated);
+  }
+
+  @override
+  Future<void> prefetchDiscovery() async {
+    prefetchCalls++;
+  }
+
+  @override
+  Future<void> dispose() async {
+    if (_disposed) return;
+    _disposed = true;
+    await _stateCtl.close();
+    await _secCtl.close();
+  }
+}

--- a/ui/runtime/test/widgets/auth_event_listener_test.dart
+++ b/ui/runtime/test/widgets/auth_event_listener_test.dart
@@ -1,0 +1,97 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_auth_runtime.dart';
+
+Widget _wrap(FakeAuthRuntime fake, {required Widget child}) {
+  return ProviderScope(
+    overrides: [authRuntimeProvider.overrideWithValue(fake)],
+    child: MaterialApp(
+      home: Scaffold(body: child),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('renders child as-is', (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const AuthEventListener(child: Text('home')),
+    ));
+    expect(find.text('home'), findsOneWidget);
+  });
+
+  testWidgets('shows default SnackBar on refreshReuseDetected',
+      (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const AuthEventListener(child: Text('home')),
+    ));
+    fake.emitSecurityEvent(
+      SecurityEvent.refreshReuseDetected(DateTime.utc(2026, 4, 19)),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.textContaining('suspicious session activity'),
+        findsOneWidget);
+  });
+
+  testWidgets('shows default SnackBar on storageCorruption', (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const AuthEventListener(child: Text('home')),
+    ));
+    fake.emitSecurityEvent(
+      SecurityEvent.storageCorruption(DateTime.utc(2026, 4, 19)),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.textContaining('could not be read'), findsOneWidget);
+  });
+
+  testWidgets('custom builder replaces the default message', (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: AuthEventListener(
+        builder: (context, ev, _) => const Text('custom-snack'),
+        child: const Text('home'),
+      ),
+    ));
+    fake.emitSecurityEvent(
+      SecurityEvent.loggedOutElsewhere(DateTime.utc(2026, 4, 19)),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('custom-snack'), findsOneWidget);
+  });
+
+  testWidgets('builder returning null suppresses the default SnackBar',
+      (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: AuthEventListener(
+        builder: (_, _, _) => null,
+        child: const Text('home'),
+      ),
+    ));
+    fake.emitSecurityEvent(
+      SecurityEvent.bindingInvalidated(DateTime.utc(2026, 4, 19)),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(find.byType(SnackBar), findsNothing);
+  });
+}

--- a/ui/runtime/test/widgets/auth_gate_test.dart
+++ b/ui/runtime/test/widgets/auth_gate_test.dart
@@ -1,0 +1,141 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_auth_runtime.dart';
+
+Widget _wrap(FakeAuthRuntime fake, {required Widget child}) {
+  return ProviderScope(
+    overrides: [authRuntimeProvider.overrideWithValue(fake)],
+    child: MaterialApp(home: Scaffold(body: child)),
+  );
+}
+
+void main() {
+  testWidgets('shows loading while the stream is resolving', (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.initializing);
+    addTearDown(fake.dispose);
+
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const AuthGate(
+        child: Text('protected'),
+      ),
+    ));
+    // Pre-first-event: stream is loading → default spinner shows.
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('protected'), findsNothing);
+  });
+
+  testWidgets('shows child when authenticated', (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.unauthenticated);
+    addTearDown(fake.dispose);
+
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const AuthGate(child: Text('protected')),
+    ));
+    fake.emitState(AuthState.authenticated);
+    await tester.pump();
+    expect(find.text('protected'), findsOneWidget);
+  });
+
+  testWidgets(
+      'default unauthenticatedBuilder renders an ElevatedButton with '
+      '"Sign in"', (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.unauthenticated);
+    addTearDown(fake.dispose);
+
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const AuthGate(child: Text('protected')),
+    ));
+    fake.emitState(AuthState.unauthenticated);
+    await tester.pump();
+    expect(find.text('Sign in'), findsOneWidget);
+    expect(find.byType(ElevatedButton), findsOneWidget);
+  });
+
+  testWidgets(
+      'tapping the default Sign in button invokes ensureAuthenticated',
+      (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.unauthenticated);
+    addTearDown(fake.dispose);
+
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const AuthGate(child: Text('protected')),
+    ));
+    fake.emitState(AuthState.unauthenticated);
+    await tester.pump();
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(fake.ensureAuthenticatedCalls, 1);
+    // ensureAuthenticated drives the state to authenticated.
+    expect(find.text('protected'), findsOneWidget);
+  });
+
+  testWidgets('custom unauthenticatedBuilder is honoured', (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.unauthenticated);
+    addTearDown(fake.dispose);
+
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: AuthGate(
+        unauthenticatedBuilder: (_) => const Text('custom-login'),
+        child: const Text('protected'),
+      ),
+    ));
+    fake.emitState(AuthState.unauthenticated);
+    await tester.pump();
+    expect(find.text('custom-login'), findsOneWidget);
+    expect(find.text('Sign in'), findsNothing);
+  });
+
+  testWidgets('custom loadingBuilder is honoured', (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.initializing);
+    addTearDown(fake.dispose);
+
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: AuthGate(
+        loadingBuilder: (_) => const Text('booting…'),
+        child: const Text('protected'),
+      ),
+    ));
+    expect(find.text('booting…'), findsOneWidget);
+  });
+
+  testWidgets('refreshing state uses the loading builder', (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.authenticated);
+    addTearDown(fake.dispose);
+
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const AuthGate(child: Text('protected')),
+    ));
+    fake.emitState(AuthState.authenticated);
+    await tester.pump();
+    expect(find.text('protected'), findsOneWidget);
+
+    fake.emitState(AuthState.refreshing);
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('protected'), findsNothing);
+  });
+
+  testWidgets('error state renders the default error UI with retry',
+      (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.error);
+    addTearDown(fake.dispose);
+
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const AuthGate(child: Text('protected')),
+    ));
+    fake.emitState(AuthState.error);
+    await tester.pump();
+    expect(find.text('Retry'), findsOneWidget);
+  });
+}

--- a/ui/runtime/test/widgets/auth_state_builder_test.dart
+++ b/ui/runtime/test/widgets/auth_state_builder_test.dart
@@ -1,0 +1,68 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_auth_runtime.dart';
+
+Widget _wrap(FakeAuthRuntime fake, {required Widget child}) {
+  return ProviderScope(
+    overrides: [authRuntimeProvider.overrideWithValue(fake)],
+    child: MaterialApp(home: child),
+  );
+}
+
+void main() {
+  testWidgets('builder receives initializing while stream is loading',
+      (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.unauthenticated);
+    addTearDown(fake.dispose);
+
+    AuthState? observed;
+    await tester.pumpWidget(
+      _wrap(
+        fake,
+        child: AuthStateBuilder(
+          builder: (_, s) {
+            observed = s;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    // The first frame has no stream event yet — we treat "loading" as
+    // initializing so widgets can render a spinner without branching on
+    // AsyncValue.
+    expect(observed, AuthState.initializing);
+  });
+
+  testWidgets('builder rebuilds when the runtime emits a transition',
+      (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.unauthenticated);
+    addTearDown(fake.dispose);
+
+    final observed = <AuthState>[];
+    await tester.pumpWidget(
+      _wrap(
+        fake,
+        child: AuthStateBuilder(
+          builder: (_, s) {
+            observed.add(s);
+            return Text('state=${s.name}');
+          },
+        ),
+      ),
+    );
+    expect(observed.last, AuthState.initializing);
+
+    fake.emitState(AuthState.unauthenticated);
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('state=unauthenticated'), findsOneWidget);
+
+    fake.emitState(AuthState.authenticated);
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('state=authenticated'), findsOneWidget);
+  });
+}

--- a/ui/runtime/test/widgets/profile_avatar_test.dart
+++ b/ui/runtime/test/widgets/profile_avatar_test.dart
@@ -1,0 +1,91 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/widgets/profile_avatar.dart'
+    show initialsFromClaims;
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_auth_runtime.dart';
+
+Widget _wrap(FakeAuthRuntime fake, {required Widget child}) {
+  return ProviderScope(
+    overrides: [authRuntimeProvider.overrideWithValue(fake)],
+    child: MaterialApp(home: Scaffold(body: Center(child: child))),
+  );
+}
+
+void main() {
+  group('initialsFromClaims', () {
+    test('derives two initials from a multi-word name', () {
+      expect(initialsFromClaims({'name': 'Alice Example'}), 'AE');
+    });
+
+    test('single-word name yields a single initial', () {
+      expect(initialsFromClaims({'name': 'Alice'}), 'A');
+    });
+
+    test('falls back to email local-part when name is missing', () {
+      expect(initialsFromClaims({'email': 'alice@example.com'}), 'A');
+    });
+
+    test('returns empty string when no usable claim present', () {
+      expect(initialsFromClaims({}), '');
+    });
+
+    test('collapses extra whitespace in name', () {
+      expect(initialsFromClaims({'name': '  Alice   Example  Smith'}), 'AE');
+    });
+  });
+
+  testWidgets(
+      'renders initials when claims include a name and no picture URL',
+      (tester) async {
+    final fake = FakeAuthRuntime(
+      initialState: AuthState.authenticated,
+      claims: {'name': 'Alice Example'},
+    );
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(fake, child: const ProfileAvatar()));
+    fake.emitState(AuthState.authenticated);
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('AE'), findsOneWidget);
+  });
+
+  testWidgets('renders initials from email when no name is set',
+      (tester) async {
+    final fake = FakeAuthRuntime(
+      initialState: AuthState.authenticated,
+      claims: {'email': 'bob@example.com'},
+    );
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(fake, child: const ProfileAvatar()));
+    fake.emitState(AuthState.authenticated);
+    await tester.pump();
+    await tester.pump();
+    expect(find.text('B'), findsOneWidget);
+  });
+
+  testWidgets('falls back to a placeholder icon with no usable claims',
+      (tester) async {
+    final fake = FakeAuthRuntime(
+      initialState: AuthState.authenticated,
+      claims: {},
+    );
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(fake, child: const ProfileAvatar()));
+    fake.emitState(AuthState.authenticated);
+    await tester.pump();
+    await tester.pump();
+    expect(find.byIcon(Icons.person_outline), findsOneWidget);
+  });
+
+  testWidgets('while claims resolve, shows an empty placeholder circle',
+      (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.unauthenticated);
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(fake, child: const ProfileAvatar()));
+    // First frame has no resolved claims yet → loading branch.
+    expect(find.byType(CircleAvatar), findsOneWidget);
+  });
+}

--- a/ui/runtime/test/widgets/sign_in_button_test.dart
+++ b/ui/runtime/test/widgets/sign_in_button_test.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_auth_runtime.dart';
+
+Widget _wrap(FakeAuthRuntime fake, {required Widget child}) {
+  return ProviderScope(
+    overrides: [authRuntimeProvider.overrideWithValue(fake)],
+    child: MaterialApp(home: Scaffold(body: Center(child: child))),
+  );
+}
+
+void main() {
+  testWidgets('renders default label and is enabled', (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(fake, child: const SignInButton()));
+    expect(find.text('Sign in'), findsOneWidget);
+    final button = tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+    expect(button.onPressed, isNotNull);
+  });
+
+  testWidgets('custom label is honoured', (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(
+      _wrap(fake, child: const SignInButton(label: 'Log in')),
+    );
+    expect(find.text('Log in'), findsOneWidget);
+  });
+
+  testWidgets('tap triggers ensureAuthenticated and onAuthenticated callback',
+      (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    var done = 0;
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: SignInButton(onAuthenticated: () => done++),
+    ));
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(fake.ensureAuthenticatedCalls, 1);
+    expect(done, 1);
+  });
+
+  testWidgets('button disables itself while ensureAuthenticated is pending',
+      (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    final completer = FakeSlowFuture();
+    fake.ensureAuthenticatedError = null;
+    // Wrap in a thin shim: override ensureAuthenticated to stall on a
+    // Completer so we can catch the "pending" frame.
+    final slowFake = _SlowSignInFake(completer);
+    addTearDown(slowFake.dispose);
+    await tester.pumpWidget(_wrap(slowFake, child: const SignInButton()));
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pump();
+    // Now pending: button should be disabled and show a progress spinner.
+    final pressed =
+        tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+    expect(pressed.onPressed, isNull);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    completer.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('onError fires and suppresses the exception', (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    fake.ensureAuthenticatedError = AuthError(
+      AuthErrorCode.oauthFailed,
+      'nope',
+    );
+    AuthError? caught;
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: SignInButton(onError: (err) => caught = err),
+    ));
+    await tester.tap(find.byType(ElevatedButton));
+    await tester.pumpAndSettle();
+    expect(caught, isNotNull);
+    expect(caught!.code, AuthErrorCode.oauthFailed);
+    expect(tester.takeException(), isNull);
+  });
+}
+
+class FakeSlowFuture {
+  final _completer = Completer<void>();
+  Future<void> get future => _completer.future;
+  void complete() => _completer.complete();
+}
+
+class _SlowSignInFake extends FakeAuthRuntime {
+  _SlowSignInFake(this.signal);
+  final FakeSlowFuture signal;
+  @override
+  Future<void> ensureAuthenticated() async {
+    ensureAuthenticatedCalls++;
+    await signal.future;
+    emitState(AuthState.authenticated);
+  }
+}

--- a/ui/runtime/test/widgets/sign_out_button_test.dart
+++ b/ui/runtime/test/widgets/sign_out_button_test.dart
@@ -1,0 +1,46 @@
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/fake_auth_runtime.dart';
+
+Widget _wrap(FakeAuthRuntime fake, {required Widget child}) {
+  return ProviderScope(
+    overrides: [authRuntimeProvider.overrideWithValue(fake)],
+    child: MaterialApp(home: Scaffold(body: Center(child: child))),
+  );
+}
+
+void main() {
+  testWidgets('renders default "Sign out" label', (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(fake, child: const SignOutButton()));
+    expect(find.text('Sign out'), findsOneWidget);
+  });
+
+  testWidgets('tap triggers logout and onSignedOut callback', (tester) async {
+    final fake = FakeAuthRuntime(initialState: AuthState.authenticated);
+    addTearDown(fake.dispose);
+    var done = 0;
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: SignOutButton(onSignedOut: () => done++),
+    ));
+    await tester.tap(find.byType(TextButton));
+    await tester.pumpAndSettle();
+    expect(fake.logoutCalls, 1);
+    expect(done, 1);
+  });
+
+  testWidgets('custom label is honoured', (tester) async {
+    final fake = FakeAuthRuntime();
+    addTearDown(fake.dispose);
+    await tester.pumpWidget(_wrap(
+      fake,
+      child: const SignOutButton(label: 'Log out'),
+    ));
+    expect(find.text('Log out'), findsOneWidget);
+  });
+}

--- a/ui/runtime/test/worker/messages_test.dart
+++ b/ui/runtime/test/worker/messages_test.dart
@@ -1,0 +1,199 @@
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/worker/messages.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+T _roundTripRequest<T extends WorkerRequest>(T req) {
+  final map = req.toMap();
+  return WorkerRequest.fromMap(map) as T;
+}
+
+T _roundTripEvent<T extends WorkerEvent>(T ev) {
+  final map = ev.toMap();
+  return WorkerEvent.fromMap(map) as T;
+}
+
+void main() {
+  group('WorkerRequest', () {
+    test('init round-trips', () {
+      final r = _roundTripRequest(const InitRequest(correlationId: 'c-1'));
+      expect(r.correlationId, 'c-1');
+    });
+
+    test('prepareAuth round-trips', () {
+      final r = _roundTripRequest(
+          const PrepareAuthRequest(correlationId: 'c-2'));
+      expect(r.correlationId, 'c-2');
+    });
+
+    test('completeAuth round-trips all fields', () {
+      final orig = const CompleteAuthRequest(
+        correlationId: 'c-3',
+        code: 'CODE',
+        verifier: 'VERIF',
+        state: 'STATE',
+        nonce: 'NONCE',
+      );
+      final r = _roundTripRequest(orig);
+      expect(r.code, 'CODE');
+      expect(r.verifier, 'VERIF');
+      expect(r.state, 'STATE');
+      expect(r.nonce, 'NONCE');
+    });
+
+    test('fetch round-trips headers and body', () {
+      final orig = const FetchRequest(
+        correlationId: 'c-4',
+        path: '/users',
+        method: 'GET',
+        headers: {'X-Trace': 't1'},
+        timeoutMs: 15000,
+      );
+      final r = _roundTripRequest(orig);
+      expect(r.path, '/users');
+      expect(r.method, 'GET');
+      expect(r.headers, {'X-Trace': 't1'});
+      expect(r.timeoutMs, 15000);
+    });
+
+    test('upload round-trips binary payload', () {
+      final bytes = Uint8List.fromList(List<int>.generate(128, (i) => i));
+      final orig = UploadRequest(
+        correlationId: 'c-5',
+        path: '/media',
+        fieldName: 'file',
+        filename: 'a.bin',
+        contentType: 'application/octet-stream',
+        bytes: bytes,
+      );
+      final r = _roundTripRequest(orig);
+      expect(r.bytes, bytes);
+      expect(r.filename, 'a.bin');
+      expect(r.contentType, 'application/octet-stream');
+    });
+
+    test('getRoles, getClaims, logout, destroy round-trip', () {
+      expect(_roundTripRequest(
+          const GetRolesRequest(correlationId: 'a')).correlationId, 'a');
+      expect(_roundTripRequest(
+          const GetClaimsRequest(correlationId: 'b')).correlationId, 'b');
+      expect(_roundTripRequest(
+          const LogoutRequest(correlationId: 'c')).correlationId, 'c');
+      expect(_roundTripRequest(
+          const DestroyRequest(correlationId: 'd')).correlationId, 'd');
+    });
+
+    test('unknown kind throws FormatException', () {
+      expect(
+        () => WorkerRequest.fromMap({'kind': 'nope', 'correlationId': 'x'}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+
+  group('WorkerEvent', () {
+    test('ready + ok round-trip', () {
+      final r = _roundTripEvent(const ReadyEvent(correlationId: 'c-1'));
+      expect(r.correlationId, 'c-1');
+      final o = _roundTripEvent(const OkEvent(correlationId: 'c-2'));
+      expect(o.correlationId, 'c-2');
+    });
+
+    test('state round-trips AuthState by name', () {
+      for (final s in AuthState.values) {
+        final r = _roundTripEvent(StateEvent(state: s));
+        expect(r.state, s);
+      }
+    });
+
+    test('authUrl round-trips', () {
+      final r = _roundTripEvent(const AuthUrlEvent(
+        correlationId: 'c-3',
+        url: 'https://idp/auth?...',
+        verifier: 'v',
+        state: 's',
+        nonce: 'n',
+      ));
+      expect(r.url, 'https://idp/auth?...');
+      expect(r.verifier, 'v');
+      expect(r.state, 's');
+      expect(r.nonce, 'n');
+    });
+
+    test('response round-trips body + headers', () {
+      final bytes = Uint8List.fromList([1, 2, 3, 4, 5]);
+      final r = _roundTripEvent(ResponseEvent(
+        correlationId: 'c-4',
+        response: ApiResponse(
+          status: 200,
+          headers: const {'content-type': 'application/json'},
+          body: bytes,
+        ),
+      ));
+      expect(r.response.status, 200);
+      expect(r.response.headers['content-type'], 'application/json');
+      expect(r.response.body, bytes);
+    });
+
+    test('error round-trips code, message, traceId', () {
+      final r = _roundTripEvent(const ErrorEvent(
+        correlationId: 'c-5',
+        code: AuthErrorCode.apiUnauthorized,
+        message: 'boom',
+        traceId: 'trace-xyz',
+      ));
+      expect(r.code, AuthErrorCode.apiUnauthorized);
+      expect(r.message, 'boom');
+      expect(r.traceId, 'trace-xyz');
+
+      final err = r.toAuthError();
+      expect(err.code, AuthErrorCode.apiUnauthorized);
+      expect(err.traceId, 'trace-xyz');
+    });
+
+    test('roles + claims round-trip', () {
+      final roles = _roundTripEvent(const RolesEvent(
+        correlationId: 'c-6',
+        roles: ['admin', 'user'],
+      ));
+      expect(roles.roles, ['admin', 'user']);
+
+      final claims = _roundTripEvent(const ClaimsEvent(
+        correlationId: 'c-7',
+        claims: {
+          'sub': 'u-1',
+          'email': 'a@b.c',
+          'roles': ['admin'],
+        },
+      ));
+      expect(claims.claims['sub'], 'u-1');
+      expect(claims.claims['roles'], ['admin']);
+    });
+
+    test('securityEvent round-trips every variant', () {
+      final at = DateTime.utc(2026, 4, 19, 12, 0, 0);
+      for (final ev in [
+        SecurityEvent.refreshReuseDetected(at),
+        SecurityEvent.storageCorruption(at),
+        SecurityEvent.bindingInvalidated(at),
+        SecurityEvent.loggedOutElsewhere(at),
+      ]) {
+        final w = SecurityEventWire(event: ev);
+        final back = _roundTripEvent(w);
+        expect(back.event.runtimeType, ev.runtimeType);
+        expect(back.event.at, at);
+      }
+    });
+
+    test('unknown event kind throws FormatException', () {
+      expect(
+        () => WorkerEvent.fromMap({'kind': 'nope'}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}

--- a/ui/runtime/test/worker/token_isolate_test.dart
+++ b/ui/runtime/test/worker/token_isolate_test.dart
@@ -1,0 +1,72 @@
+import 'package:antinvestor_auth_runtime/src/worker/messages.dart';
+import 'package:antinvestor_auth_runtime/src/worker/token_isolate.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TokenIsolateHandle', () {
+    test('spawn + destroy round-trip completes cleanly', () async {
+      final handle = await TokenIsolateHandle.spawn();
+      final proxy = IsolatedTokenWorkerProxy(handle);
+
+      // init is answered with OkEvent by the scaffolding entry point.
+      await proxy.init();
+
+      // destroy both acks and kills the isolate. It should complete
+      // without throwing even though the isolate tears itself down.
+      await proxy.destroy();
+    });
+
+    test('ReadyEvent is emitted on spawn', () async {
+      final handle = await TokenIsolateHandle.spawn();
+      try {
+        final ev = await handle.events.firstWhere((e) => e is ReadyEvent);
+        expect(ev, isA<ReadyEvent>());
+      } finally {
+        await handle.dispose();
+      }
+    });
+
+    test('request/response correlation works', () async {
+      final handle = await TokenIsolateHandle.spawn();
+      try {
+        final ev = await handle.request(
+          const InitRequest(correlationId: 'corr-init-1'),
+          timeout: const Duration(seconds: 3),
+        );
+        expect(ev, isA<OkEvent>());
+        expect(ev.correlationId, 'corr-init-1');
+      } finally {
+        await handle.dispose();
+      }
+    });
+
+    test('unimplemented request yields an ErrorEvent', () async {
+      final handle = await TokenIsolateHandle.spawn();
+      try {
+        final ev = await handle.request(
+          const PrepareAuthRequest(correlationId: 'corr-prepare-1'),
+          timeout: const Duration(seconds: 3),
+        );
+        expect(ev, isA<ErrorEvent>());
+        expect(ev.correlationId, 'corr-prepare-1');
+      } finally {
+        await handle.dispose();
+      }
+    });
+
+    test('dispose is idempotent', () async {
+      final handle = await TokenIsolateHandle.spawn();
+      await handle.dispose();
+      await handle.dispose();
+    });
+
+    test('send after dispose throws StateError', () async {
+      final handle = await TokenIsolateHandle.spawn();
+      await handle.dispose();
+      expect(
+        () => handle.send(const InitRequest(correlationId: 'corr')),
+        throwsStateError,
+      );
+    });
+  });
+}

--- a/ui/runtime/test/worker/token_worker_test.dart
+++ b/ui/runtime/test/worker/token_worker_test.dart
@@ -1,0 +1,508 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
+import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
+import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/models/token_set.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/api_proxy.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
+import 'package:antinvestor_auth_runtime/src/runtime/refresh_lock.dart';
+import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
+import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
+import 'package:antinvestor_auth_runtime/src/worker/token_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+class _FakeDiscoveryClient implements DiscoveryClient {
+  _FakeDiscoveryClient();
+
+  String authz = 'https://idp.example.com/oauth2/auth';
+  String tokenEp = 'https://idp.example.com/oauth2/token';
+  String? endSession = 'https://idp.example.com/oauth2/sessions/logout';
+  String? revocation = 'https://idp.example.com/oauth2/revoke';
+  bool dpop = false;
+  int calls = 0;
+
+  @override
+  Future<OidcDiscovery> getDiscovery(
+    String idpBaseUrl,
+    Duration timeout,
+  ) async {
+    calls++;
+    return OidcDiscovery(
+      issuer: idpBaseUrl,
+      authorizationEndpoint: authz,
+      tokenEndpoint: tokenEp,
+      endSessionEndpoint: endSession,
+      revocationEndpoint: revocation,
+      dpopSigningAlgValuesSupported: dpop ? const ['ES256'] : null,
+    );
+  }
+}
+
+/// Stub [TokenExchange] that records calls and returns canned outcomes.
+class _FakeTokenExchange extends TokenExchange {
+  _FakeTokenExchange()
+      : super(timeout: const Duration(seconds: 5));
+
+  List<TokenSet> rotateQueue = [];
+  List<RefreshOutcome> refreshQueue = [];
+  int exchangeCalls = 0;
+  int refreshCalls = 0;
+
+  @override
+  Future<TokenSet> exchangeCode(
+    ResolvedConfig cfg,
+    DpopContext ctx, {
+    required String code,
+    required String verifier,
+  }) async {
+    exchangeCalls++;
+    if (rotateQueue.isEmpty) {
+      throw AuthError(
+        AuthErrorCode.tokenExchangeFailed,
+        'fake: no token queued',
+      );
+    }
+    return rotateQueue.removeAt(0);
+  }
+
+  @override
+  Future<RefreshOutcome> refresh(
+    ResolvedConfig cfg,
+    DpopContext ctx,
+    String refreshToken,
+  ) async {
+    refreshCalls++;
+    if (refreshQueue.isEmpty) {
+      throw AuthError(AuthErrorCode.tokenRefreshFailed, 'no refresh queued');
+    }
+    return refreshQueue.removeAt(0);
+  }
+}
+
+class _FakeApiProxy extends ApiProxy {
+  _FakeApiProxy();
+
+  ApiResponse? cannedResponse;
+  Object? cannedError;
+  int fetchCalls = 0;
+  int uploadCalls = 0;
+  String? seenAuthHeader;
+
+  @override
+  Future<ApiResponse> fetch(
+    ResolvedConfig cfg,
+    DpopContext ctx,
+    TokenProvider tp, {
+    required String path,
+    required String method,
+    Map<String, String>? headers,
+    Object? body,
+    Duration? timeout,
+  }) async {
+    fetchCalls++;
+    final snap = await tp.ensureFresh();
+    seenAuthHeader =
+        '${snap.tokenType.headerValue} ${snap.accessToken}';
+    if (cannedError != null) throw cannedError!;
+    return cannedResponse ??
+        ApiResponse(status: 200, headers: const {}, body: Uint8List(0));
+  }
+
+  @override
+  Future<ApiResponse> upload(
+    ResolvedConfig cfg,
+    DpopContext ctx,
+    TokenProvider tp, {
+    required String path,
+    required String fieldName,
+    required String filename,
+    required String contentType,
+    required Stream<List<int>> bytes,
+    required int length,
+    Map<String, String>? headers,
+    Duration? timeout,
+  }) async {
+    uploadCalls++;
+    final snap = await tp.ensureFresh();
+    seenAuthHeader =
+        '${snap.tokenType.headerValue} ${snap.accessToken}';
+    return cannedResponse ??
+        ApiResponse(status: 200, headers: const {}, body: Uint8List(0));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+ResolvedConfig _cfg() => resolveConfig(const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://idp.example.com',
+      apiBaseUrl: 'https://api.example.com',
+      redirectScheme: 'com.example.app',
+    ));
+
+TokenSet _tokens({
+  String access = 'at-1',
+  String refresh = 'rt-1',
+  DateTime? expiresAt,
+  String? idToken,
+  TokenType type = TokenType.bearer,
+}) =>
+    TokenSet(
+      accessToken: access,
+      refreshToken: refresh,
+      expiresAt: expiresAt ?? DateTime.utc(2030, 1, 1),
+      tokenType: type,
+      idToken: idToken,
+    );
+
+class _Deps {
+  _Deps({
+    KeyManager? km,
+    TokenStore? store,
+    _FakeDiscoveryClient? disco,
+    _FakeTokenExchange? exchange,
+    _FakeApiProxy? proxy,
+    Clock? clock,
+  })  : config = _cfg(),
+        keyManager = km ?? DefaultKeyManager(),
+        tokenStore = store ?? SecureTokenStore(kv: InMemoryKeyValueStore()),
+        discoveryClient = disco ?? _FakeDiscoveryClient(),
+        tokenExchange = exchange ?? _FakeTokenExchange(),
+        apiProxy = proxy ?? _FakeApiProxy(),
+        refreshLock = RefreshLock(),
+        clock = clock ?? _fixedNow;
+
+  final ResolvedConfig config;
+  final KeyManager keyManager;
+  final TokenStore tokenStore;
+  final _FakeDiscoveryClient discoveryClient;
+  final _FakeTokenExchange tokenExchange;
+  final _FakeApiProxy apiProxy;
+  final RefreshLock refreshLock;
+  final Clock clock;
+
+  TokenWorker build() => TokenWorker(
+        config: config,
+        keyManager: keyManager,
+        tokenStore: tokenStore,
+        discoveryClient: discoveryClient,
+        tokenExchange: tokenExchange,
+        apiProxy: apiProxy,
+        refreshLock: refreshLock,
+        clock: clock,
+      );
+}
+
+DateTime _fixedNow() => DateTime.utc(2026, 4, 19, 12, 0, 0);
+
+void main() {
+  tearDown(clearDiscoveryCache);
+
+  test('fresh worker with empty store ends in unauthenticated', () async {
+    final d = _Deps();
+    final w = d.build();
+    final states = <AuthState>[];
+    w.authStateStream.listen(states.add);
+    await w.init();
+    await Future<void>.delayed(Duration.zero);
+    expect(w.state, AuthState.unauthenticated);
+    expect(states, [AuthState.unauthenticated]);
+    await w.destroy();
+  });
+
+  test('completeAuth persists session and transitions to authenticated',
+      () async {
+    final d = _Deps();
+    final w = d.build();
+    d.tokenExchange.rotateQueue
+        .add(_tokens(access: 'access-1', refresh: 'refresh-1'));
+    final states = <AuthState>[];
+    w.authStateStream.listen(states.add);
+
+    await w.init();
+    await w.completeAuth(
+      code: 'code-1',
+      verifier: 'verif-1',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+    // Flush microtasks so the broadcast stream delivers.
+    await Future<void>.delayed(Duration.zero);
+    expect(d.tokenExchange.exchangeCalls, 1);
+    expect(w.state, AuthState.authenticated);
+    expect(states.last, AuthState.authenticated);
+    expect(await d.tokenStore.load(d.config.namespace), isNotNull);
+    await w.destroy();
+  });
+
+  test('completeAuth rejects state mismatch', () async {
+    final d = _Deps();
+    final w = d.build();
+    await w.init();
+    expect(
+      () => w.completeAuth(
+        code: 'code',
+        verifier: 'v',
+        state: 'A',
+        nonce: 'n',
+        expectedState: 'B',
+      ),
+      throwsA(isA<AuthError>().having(
+        (e) => e.code,
+        'code',
+        AuthErrorCode.oauthFailed,
+      )),
+    );
+    await w.destroy();
+  });
+
+  test('prepareAuth returns a URL containing PKCE + state + nonce', () async {
+    final d = _Deps();
+    final w = d.build();
+    await w.init();
+    final req = await w.prepareAuth();
+    final uri = Uri.parse(req.url);
+    expect(uri.queryParameters['code_challenge_method'], 'S256');
+    expect(uri.queryParameters['code_challenge'], isNotEmpty);
+    expect(uri.queryParameters['state'], req.state);
+    expect(uri.queryParameters['nonce'], req.nonce);
+    expect(uri.queryParameters['client_id'], 'c');
+    expect(uri.queryParameters['redirect_uri'], 'com.example.app://callback');
+    await w.destroy();
+  });
+
+  test('refresh rotates and persists the new refresh token', () async {
+    final d = _Deps();
+    final w = d.build();
+    d.tokenExchange.rotateQueue.add(_tokens(
+      access: 'at-1',
+      refresh: 'rt-1',
+      // Near-expiry so ensureFresh triggers a refresh.
+      expiresAt: _fixedNow().add(const Duration(seconds: 5)),
+    ));
+    d.tokenExchange.refreshQueue.add(RefreshOutcome.rotated(_tokens(
+      access: 'at-2',
+      refresh: 'rt-2',
+      expiresAt: _fixedNow().add(const Duration(minutes: 10)),
+    )));
+
+    await w.init();
+    await w.completeAuth(
+      code: 'c',
+      verifier: 'v',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+
+    final snap = await w.ensureFresh();
+    expect(snap.accessToken, 'at-2');
+    expect(d.tokenExchange.refreshCalls, 1);
+    // Persisted session reflects the new refresh token — verified indirectly
+    // by the presence of a save.
+    expect(await d.tokenStore.load(d.config.namespace), isNotNull);
+    await w.destroy();
+  });
+
+  test('reuse-detected refresh wipes and emits SecurityEvent', () async {
+    final d = _Deps();
+    final w = d.build();
+    d.tokenExchange.rotateQueue.add(_tokens(
+      expiresAt: _fixedNow().add(const Duration(seconds: 5)),
+    ));
+    d.tokenExchange.refreshQueue
+        .add(const RefreshOutcome.reuseDetected());
+
+    final events = <SecurityEvent>[];
+    w.securityEventStream.listen(events.add);
+    final states = <AuthState>[];
+    w.authStateStream.listen(states.add);
+
+    await w.init();
+    await w.completeAuth(
+      code: 'c',
+      verifier: 'v',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+
+    await expectLater(
+      w.ensureFresh(),
+      throwsA(isA<AuthError>().having(
+        (e) => e.code,
+        'code',
+        AuthErrorCode.refreshReuseDetected,
+      )),
+    );
+    // Allow microtask-scheduled stream events to flush.
+    await Future<void>.delayed(Duration.zero);
+    expect(events.length, 1);
+    expect(events.first, isA<RefreshReuseDetected>());
+    expect(w.state, AuthState.unauthenticated);
+    expect(await d.tokenStore.load(d.config.namespace), isNull);
+    await w.destroy();
+  });
+
+  test('ensureFresh returns cached token when not near expiry', () async {
+    final d = _Deps();
+    final w = d.build();
+    d.tokenExchange.rotateQueue.add(_tokens(
+      access: 'at-cached',
+      expiresAt: _fixedNow().add(const Duration(minutes: 10)),
+    ));
+
+    await w.init();
+    await w.completeAuth(
+      code: 'c',
+      verifier: 'v',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+
+    final snap = await w.ensureFresh();
+    expect(snap.accessToken, 'at-cached');
+    expect(d.tokenExchange.refreshCalls, 0);
+    await w.destroy();
+  });
+
+  test('fetch forwards Authorization through ApiProxy', () async {
+    final d = _Deps();
+    final w = d.build();
+    d.tokenExchange.rotateQueue.add(_tokens(access: 'at-xyz'));
+
+    await w.init();
+    await w.completeAuth(
+      code: 'c',
+      verifier: 'v',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+
+    final res = await w.fetch(path: '/users', method: 'GET');
+    expect(res.status, 200);
+    expect(d.apiProxy.seenAuthHeader, 'Bearer at-xyz');
+    expect(d.apiProxy.fetchCalls, 1);
+    await w.destroy();
+  });
+
+  test('upload forwards Authorization through ApiProxy', () async {
+    final d = _Deps();
+    final w = d.build();
+    d.tokenExchange.rotateQueue.add(_tokens(access: 'at-up'));
+
+    await w.init();
+    await w.completeAuth(
+      code: 'c',
+      verifier: 'v',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+
+    final res = await w.upload(
+      path: '/media',
+      fieldName: 'file',
+      filename: 'x.bin',
+      contentType: 'application/octet-stream',
+      bytes: Stream<List<int>>.fromIterable([
+        [1, 2, 3]
+      ]),
+      length: 3,
+    );
+    expect(res.status, 200);
+    expect(d.apiProxy.seenAuthHeader, 'Bearer at-up');
+    expect(d.apiProxy.uploadCalls, 1);
+    await w.destroy();
+  });
+
+  test('getClaims decodes ID token payload; getRoles decodes access token',
+      () async {
+    final d = _Deps();
+    final w = d.build();
+    final id = _makeJwt({'sub': 'u-1', 'email': 'a@b.c'});
+    final access = _makeJwt({
+      'sub': 'u-1',
+      'roles': ['admin', 'user'],
+    });
+    d.tokenExchange.rotateQueue.add(_tokens(
+      access: access,
+      idToken: id,
+    ));
+
+    await w.init();
+    await w.completeAuth(
+      code: 'c',
+      verifier: 'v',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+
+    final claims = await w.getClaims();
+    expect(claims['sub'], 'u-1');
+    expect(claims['email'], 'a@b.c');
+
+    final roles = await w.getRoles();
+    expect(roles, ['admin', 'user']);
+    await w.destroy();
+  });
+
+  test('logout clears session + transitions to unauthenticated', () async {
+    final d = _Deps();
+    final w = d.build();
+    d.tokenExchange.rotateQueue.add(_tokens());
+
+    await w.init();
+    await w.completeAuth(
+      code: 'c',
+      verifier: 'v',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+    expect(w.state, AuthState.authenticated);
+    expect(await d.tokenStore.load(d.config.namespace), isNotNull);
+
+    await w.logout();
+    expect(w.state, AuthState.unauthenticated);
+    expect(await d.tokenStore.load(d.config.namespace), isNull);
+    await w.destroy();
+  });
+
+  test('operations after destroy() throw StateError', () async {
+    final d = _Deps();
+    final w = d.build();
+    await w.init();
+    await w.destroy();
+    expect(() => w.init(), throwsStateError);
+    expect(() => w.prepareAuth(), throwsStateError);
+  });
+}
+
+String _makeJwt(Map<String, dynamic> payload) {
+  final header = base64Url.encode(utf8.encode(json.encode({'alg': 'RS256'})));
+  final body = base64Url.encode(utf8.encode(json.encode(payload)));
+  final sig = base64Url.encode([1, 2, 3]);
+  String strip(String s) => s.replaceAll('=', '');
+  return '${strip(header)}.${strip(body)}.${strip(sig)}';
+}

--- a/ui/runtime/test/worker/token_worker_test.dart
+++ b/ui/runtime/test/worker/token_worker_test.dart
@@ -6,6 +6,7 @@ import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
 import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
 import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
@@ -175,6 +176,8 @@ class _Deps {
   _Deps({
     KeyManager? km,
     TokenStore? store,
+    RootKeyStore? rootKeyStore,
+    KeyValueStore? rootKv,
     _FakeDiscoveryClient? disco,
     _FakeTokenExchange? exchange,
     _FakeApiProxy? proxy,
@@ -182,6 +185,8 @@ class _Deps {
   })  : config = _cfg(),
         keyManager = km ?? DefaultKeyManager(),
         tokenStore = store ?? SecureTokenStore(kv: InMemoryKeyValueStore()),
+        rootKeyStore = rootKeyStore ??
+            DefaultRootKeyStore(kv: rootKv ?? InMemoryKeyValueStore()),
         discoveryClient = disco ?? _FakeDiscoveryClient(),
         tokenExchange = exchange ?? _FakeTokenExchange(),
         apiProxy = proxy ?? _FakeApiProxy(),
@@ -191,6 +196,7 @@ class _Deps {
   final ResolvedConfig config;
   final KeyManager keyManager;
   final TokenStore tokenStore;
+  final RootKeyStore rootKeyStore;
   final _FakeDiscoveryClient discoveryClient;
   final _FakeTokenExchange tokenExchange;
   final _FakeApiProxy apiProxy;
@@ -200,6 +206,7 @@ class _Deps {
   TokenWorker build() => TokenWorker(
         config: config,
         keyManager: keyManager,
+        rootKeyStore: rootKeyStore,
         tokenStore: tokenStore,
         discoveryClient: discoveryClient,
         tokenExchange: tokenExchange,
@@ -487,6 +494,96 @@ void main() {
     expect(w.state, AuthState.unauthenticated);
     expect(await d.tokenStore.load(d.config.namespace), isNull);
     await w.destroy();
+  });
+
+  test(
+      'second worker instance decrypts stored session and starts authenticated',
+      () async {
+    // Share the storage backends between both worker instances to
+    // simulate a cold app restart: the KV blob survives, and the root
+    // key store (also backed by flutter_secure_storage in prod) survives.
+    final sessionKv = InMemoryKeyValueStore();
+    final rootKv = InMemoryKeyValueStore();
+
+    _Deps makeDeps(_FakeTokenExchange? exchange) => _Deps(
+          store: SecureTokenStore(kv: sessionKv),
+          rootKeyStore: DefaultRootKeyStore(kv: rootKv),
+          exchange: exchange,
+        );
+
+    final d1 = makeDeps(_FakeTokenExchange());
+    final w1 = d1.build();
+    d1.tokenExchange.rotateQueue
+        .add(_tokens(access: 'at-restored', refresh: 'rt-restored'));
+    await w1.init();
+    await w1.completeAuth(
+      code: 'c',
+      verifier: 'v',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+    expect(w1.state, AuthState.authenticated);
+    await w1.destroy();
+
+    // Second worker with its own instance of everything except the
+    // storage backends — models a fresh process coming up.
+    final d2 = makeDeps(_FakeTokenExchange());
+    final w2 = d2.build();
+    final states = <AuthState>[];
+    w2.authStateStream.listen(states.add);
+    await w2.init();
+    await Future<void>.delayed(Duration.zero);
+    expect(w2.state, AuthState.authenticated);
+    expect(states, [AuthState.authenticated]);
+    // Restored tokens match the persisted values without making an
+    // exchange call.
+    expect(d2.tokenExchange.exchangeCalls, 0);
+    // fetch uses the restored access token straight away.
+    await w2.fetch(path: '/ping', method: 'GET');
+    expect(d2.apiProxy.seenAuthHeader, 'Bearer at-restored');
+    await w2.destroy();
+  });
+
+  test(
+      'corrupt wrap-key ciphertext wipes session and emits storageCorruption',
+      () async {
+    final sessionKv = InMemoryKeyValueStore();
+    final rootKv = InMemoryKeyValueStore();
+    _Deps makeDeps() => _Deps(
+          store: SecureTokenStore(kv: sessionKv),
+          rootKeyStore: DefaultRootKeyStore(kv: rootKv),
+        );
+
+    final d1 = makeDeps();
+    final w1 = d1.build();
+    d1.tokenExchange.rotateQueue.add(_tokens());
+    await w1.init();
+    await w1.completeAuth(
+      code: 'c',
+      verifier: 'v',
+      state: 's',
+      nonce: 'n',
+      expectedState: 's',
+    );
+    await w1.destroy();
+
+    // Simulate the root key going missing / being rotated externally
+    // (e.g. user wiped the keychain): the second worker generates a
+    // fresh root key, wrap-key decryption fails, and the session is
+    // wiped with a storageCorruption signal.
+    rootKv.delete('${d1.config.namespace}::root-key');
+
+    final d2 = makeDeps();
+    final w2 = d2.build();
+    final events = <SecurityEvent>[];
+    w2.securityEventStream.listen(events.add);
+    await w2.init();
+    await Future<void>.delayed(Duration.zero);
+    expect(w2.state, AuthState.unauthenticated);
+    expect(events.any((e) => e is StorageCorruption), isTrue);
+    expect(await d2.tokenStore.load(d2.config.namespace), isNull);
+    await w2.destroy();
   });
 
   test('operations after destroy() throw StateError', () async {


### PR DESCRIPTION
New Flutter package at ui/runtime/ that standardises authentication across service-chat, service-fintech, service-thesa, and future Antinvestor apps. Mirrors the protocol of the shipped @stawi/auth-runtime (JS) so backend changes apply uniformly to both client families.

## What it does

- OAuth2 authorization_code + PKCE via flutter_appauth (ASWebAuthenticationSession on iOS/macOS, Chrome Custom Tabs on Android, system browser on Desktop).
- Adaptive DPoP (RFC 9449) — feature-detected from OIDC discovery's \`dpop_signing_alg_values_supported\`.
- Rotating refresh tokens with reuse-detection wipe.
- 401-refresh-retry, DPoP-nonce challenge handling, clock-skew recovery via \`Date\` header.
- Non-extractable ECDSA P-256 signing (PointyCastle) + AES-GCM wrap (cryptography) for refresh-token-at-rest.
- Per-install root key via flutter_secure_storage (Keychain / EncryptedSharedPreferences / libsecret / DPAPI).
- Optional Isolate-backed token holder (\`useIsolate: true\`) for defense-in-depth token isolation.
- Riverpod 3.3 providers + Material widget set (\`AuthGate\`, \`SignInButton\`, \`SignOutButton\`, \`ProfileAvatar\`, \`AuthStateBuilder\`, \`AuthEventListener\`).

## Specs

- \`docs/superpowers/specs/2026-04-19-auth-runtime-flutter-design.md\`
- \`docs/superpowers/plans/2026-04-19-auth-runtime-flutter.md\`

## Test plan

- [x] 227 tests passing (unit + widget + integration with shelf-based mock IdP).
- [x] \`flutter analyze\` — no issues.
- [x] \`flutter pub publish --dry-run\` — clean (0 warnings).
- [x] 86.4% line coverage.

## Consumer rollout (follow-up PRs)

- service-chat → standardise auth via \`createAuthRuntime\`.
- service-fintech → same.
- service-thesa → same.

Integration guide: \`docs/auth-runtime-integration.md\`.

## Follow-up

PR #2 (v0.2 native credentials — Apple + Google) is stacked on this branch and will rebase onto main after this merges.