### PR TITLE
feat(ui/runtime): antinvestor_auth_runtime v0.2.0 — Apple + Google native sign-in

### DIFF
--- a/docs/auth-runtime-native-credentials.md
+++ b/docs/auth-runtime-native-credentials.md
@@ -1,0 +1,199 @@
+# Native credentials (Apple + Google) — backend operator guide
+
+**Audience:** `service-authentication` backend operators and IdP admins
+who need to make the Flutter `antinvestor_auth_runtime` v0.2+ native
+sign-in path work end-to-end.
+
+**Scope:** what the Ory Hydra (or equivalent) IdP must accept for the
+Flutter runtime to exchange Apple / Google ID tokens into Antinvestor
+sessions via RFC 8693.
+
+**Status:** this is a **future enablement**. The Flutter runtime already
+ships the client side in v0.2. The Go service may need additional
+changes before it can honour the token-exchange grant end-to-end —
+track progress under `TODO track in Jira/issue` (replace with the
+actual issue ID once filed).
+
+---
+
+## 1. Prerequisites
+
+- Ory Hydra ≥ **v2.2** (first release with token-exchange grant
+  support), or an equivalent OAuth 2.0 authorization server.
+- OAuth clients are already provisioned for the mobile apps
+  (`antinvestor-mobile`, `antinvestor-chat-mobile`,
+  `antinvestor-fintech-mobile`, …) with the `authorization_code` and
+  `refresh_token` grants enabled.
+- Ability to update client registrations via Hydra's admin API or
+  equivalent tenancy config.
+- A trusted-issuer registry the auth service consults during
+  token-exchange: either a first-class Hydra feature or a thin shim in
+  front of `/oauth2/token`.
+
+## 2. Enable the token-exchange grant
+
+The mobile OAuth client's `grant_types` must include:
+
+```
+urn:ietf:params:oauth:grant-type:token-exchange
+```
+
+Example (Hydra admin API):
+
+```http
+PATCH /admin/clients/{client_id}
+Content-Type: application/json
+
+[
+  {
+    "op": "add",
+    "path": "/grant_types/-",
+    "value": "urn:ietf:params:oauth:grant-type:token-exchange"
+  }
+]
+```
+
+The client also needs `offline_access` in its allowed scopes so the
+exchanged session can be rotated via refresh tokens (already required
+for the v0.1 authorization-code path).
+
+## 3. Register Apple as a trusted subject issuer
+
+| Field            | Value                                                       |
+|------------------|-------------------------------------------------------------|
+| JWKS URI         | `https://appleid.apple.com/auth/keys`                       |
+| Issuer (`iss`)   | `https://appleid.apple.com`                                 |
+| Audience (`aud`) | The app's **Services ID** (per-app, documented on registration). |
+| Signing algs     | `RS256`, `ES256` (whatever Apple publishes in their JWKS).  |
+
+**Services ID per app:** each Antinvestor Flutter app registers its own
+Services ID at developer.apple.com. Maintain a mapping in your IdP
+configuration such as:
+
+```yaml
+trusted_issuers:
+  apple:
+    issuer: https://appleid.apple.com
+    jwks_uri: https://appleid.apple.com/auth/keys
+    audiences:
+      antinvestor-mobile: com.antinvestor.myapp.auth
+      antinvestor-chat-mobile: com.antinvestor.chat.auth
+      antinvestor-fintech-mobile: com.antinvestor.fintech.auth
+```
+
+At exchange time, validate `subject_token.aud` matches the expected
+Services ID for the requesting `client_id`.
+
+## 4. Register Google as a trusted subject issuer
+
+| Field            | Value                                                       |
+|------------------|-------------------------------------------------------------|
+| JWKS URI         | `https://www.googleapis.com/oauth2/v3/certs`                |
+| Issuer (`iss`)   | `https://accounts.google.com` (also accept `accounts.google.com` without scheme, per Google's own docs). |
+| Audience (`aud`) | The **server client ID** registered in Google Cloud Console (OAuth client of type "Web application"). |
+| Signing algs     | `RS256`.                                                    |
+
+Keep the Google server client ID in the same per-app mapping as Apple:
+
+```yaml
+trusted_issuers:
+  google:
+    issuer: https://accounts.google.com
+    jwks_uri: https://www.googleapis.com/oauth2/v3/certs
+    audiences:
+      antinvestor-mobile: 123.apps.googleusercontent.com
+      antinvestor-chat-mobile: 456.apps.googleusercontent.com
+```
+
+## 5. Claim-mapping rules
+
+When the exchange succeeds, the IdP mints a fresh Antinvestor session
+backed by the subject token's claims:
+
+| Source (subject token) | Target (Antinvestor user / ID token) |
+|------------------------|--------------------------------------|
+| `sub`                  | Primary user identity. Use a provider-scoped lookup (`apple:<sub>`, `google:<sub>`) to avoid collisions. If no user exists, create one; if one exists, attach the session. |
+| `email` + `email_verified` | User profile `email` — only set when `email_verified == true`. |
+| `name`, `given_name`, `family_name` | User profile display name. |
+| `picture`              | User profile avatar URL (Google only; Apple does not return it). |
+
+**Privacy note:** Apple's `email` claim may be a private-relay address
+(`@privaterelay.appleid.com`). Treat these as first-class — users can
+still receive email via the relay.
+
+**Apple's name quirk:** Apple only returns `given_name` / `family_name`
+on the very first sign-in, and only if the app requested the `name`
+scope. Subsequent sign-ins return `sub` and `email` only. Persist the
+name on first sight; do not overwrite with nulls on repeat exchanges.
+
+## 6. Security hardening
+
+- **Freshness:** reject `subject_token` whose `iat` is older than
+  **5 minutes** (plus a small clock-skew tolerance, e.g. ±30 s). Apple
+  and Google issue short-lived ID tokens by design.
+- **Signature verification:** fetch the provider's JWKS, honour the
+  `kid` header, cache JWKS responses for 15 minutes to bound the blast
+  radius of a rolled key. Do **not** delegate signature validation to
+  the Flutter runtime — the runtime trusts the OS platform APIs, not
+  the IdP.
+- **Audience pinning:** reject when `aud` does not match the expected
+  Services ID / server client ID for the requesting OAuth
+  `client_id`.
+- **Issuer pinning:** reject when `iss` does not match the
+  `subject_issuer` form parameter (defense in depth; the Flutter
+  runtime already sends `subject_issuer` explicitly).
+- **Nonce binding:** enforced by the **RP (Flutter runtime)** — the
+  runtime generates a random nonce, binds it into the provider's
+  authorize call, and rejects the ID token if the `nonce` claim does
+  not match. The IdP cannot verify this because Apple's `nonce` claim
+  is SHA-256 of the raw value and Google's is the raw value; the
+  runtime handles both shapes. The IdP should therefore **not**
+  re-verify the nonce — doing so would reject Apple tokens.
+- **Replay protection:** the auth service should record the
+  `subject_token` `jti` (or `iat+sub` when `jti` is absent, as with
+  Apple tokens) in a short-lived cache (≥ token freshness window) and
+  reject duplicates.
+
+## 7. Rate limiting
+
+Add a per-client, per-IP rate limit on the token-exchange endpoint.
+Suggested budget: **30 requests per minute per client** — more than
+enough for legitimate first-time sign-ins, tight enough to blunt
+credential-stuffing attempts that bypass `/oauth2/auth`.
+
+Log 429s and feed them into the existing auth-service dashboards
+alongside `/oauth2/token` errors.
+
+## 8. Testing checklist
+
+Before cutting over a production tenancy:
+
+- [ ] Client listed in `grant_types` includes
+      `urn:ietf:params:oauth:grant-type:token-exchange`.
+- [ ] Apple trusted issuer registered with correct Services ID per
+      consuming app.
+- [ ] Google trusted issuer registered with correct server client ID
+      per consuming app.
+- [ ] JWKS URIs reachable from the IdP and cached.
+- [ ] A token-exchange with a **freshly-minted Apple ID token** (via
+      the Flutter runtime's native path) completes with a 200 and
+      returns an Antinvestor access + refresh token.
+- [ ] Same for Google.
+- [ ] A token-exchange with a **stale** (> 5 min) subject token is
+      rejected with `400 invalid_grant`.
+- [ ] A token-exchange with a forged / unsigned subject token is
+      rejected.
+- [ ] A token-exchange with a mismatched `aud` is rejected.
+- [ ] The issued session is interchangeable with the existing
+      authorization-code path — it refreshes, it logs out, it
+      participates in reuse-detection.
+- [ ] Rate limit returns 429 at the configured budget.
+
+---
+
+## References
+
+- RFC 8693 — OAuth 2.0 Token Exchange: <https://www.rfc-editor.org/rfc/rfc8693>
+- Apple — Sign in with Apple REST API: <https://developer.apple.com/documentation/sign_in_with_apple>
+- Google — Authenticating with a backend server: <https://developers.google.com/identity/sign-in/android/backend-auth>
+- Ory Hydra — Token Exchange (when released): <https://www.ory.sh/docs/hydra>

--- a/docs/superpowers/plans/2026-04-20-auth-runtime-native-credentials.md
+++ b/docs/superpowers/plans/2026-04-20-auth-runtime-native-credentials.md
@@ -1,0 +1,248 @@
+# `antinvestor_auth_runtime` v0.2.0 — native credentials
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** add native silent-sign-in fast paths for Sign in with Apple (iOS/macOS) and Google (Android via Credential Manager + iOS via Google Sign-In SDK), mirroring the FedCM pattern from the JS runtime — as an additive layer on top of v0.1.0's OAuth2 popup flow. No breaking changes to the `AuthRuntime` public surface.
+
+**Branch:** `feat/auth-runtime-v0.2-native-credentials` — stacked on `feat/auth-runtime-flutter` (v0.1.0 branch). Rebases onto main after v0.1.0 merges.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-19-auth-runtime-flutter-design.md` §14 lists these as future work; this plan delivers them.
+
+## Architecture — additive
+
+Current v0.1.0 sign-in flow:
+```
+unauthenticated → OAuth popup → code+verifier → /token (DPoP) → authenticated
+```
+
+v0.2.0 with native credentials:
+```
+unauthenticated
+  ├─ proactive silent: try Apple (iOS/macOS) or Google CM (Android)
+  │    ↳ got id_token → /token (token-exchange grant + DPoP) → authenticated (fast path)
+  │    ↳ no session / user never signed in → fall through
+  └─ on user click:
+       ├─ interactive native attempt (button-mode)
+       │    ↳ success → token-exchange → authenticated
+       │    ↳ decline/cancel → fall through
+       └─ OAuth2 popup (existing path) → authenticated
+```
+
+## Backend dependency (must be coordinated with service-authentication Go service)
+
+The IdP (Ory Hydra) must accept:
+- `grant_type: urn:ietf:params:oauth:grant-type:token-exchange`
+- `subject_token_type: urn:ietf:params:oauth:token-type:id_token`
+- `subject_issuer`: Apple (`https://appleid.apple.com`) or Google (`https://accounts.google.com`)
+
+Issuer verification + JWKS validation + audience mapping happens server-side. Unsigned/wrong-issuer tokens MUST be rejected with 400 `invalid_grant`.
+
+Coordinate with service-authentication Go team before enabling in production; for this plan's tests the mock IdP accepts any well-formed ID token with the correct `iss`.
+
+## Library decisions
+
+- **Apple:** `sign_in_with_apple: ^6.1.x` — official Flutter wrapper over `AuthenticationServices.framework`. Supports iOS 13+, macOS 10.15+, Web (via JS redirect — we do not use).
+- **Google:** `google_sign_in: ^7.1.x` — v7 uses Android CredentialManager under the hood and will remain the official path. Works on Android 4.4+, iOS 12+. Do NOT use `credential_manager` package (3rd-party wrapper; unstable API).
+
+Both libraries issue provider-side ID tokens. We exchange them via OIDC token-exchange grant.
+
+## Forward-looking guard — Web support deferred
+
+Sign-in-with-Apple has a Web flavor. `google_sign_in` also supports Web. We do NOT wire Web in this PR (spec defers Web to v1.1). When Web lands, it must use `dart:js_interop` + `package:web` — not `dart:js` / `dart:js_util` / `package:js` / `dart:html`.
+
+## Task breakdown (10 commits)
+
+### Task N.1 — Pubspec + error codes + NativeCredentialProvider abstraction
+
+**Commit:** `feat(auth-runtime): NativeCredentialProvider abstraction + credential error codes`
+
+- Add dependencies to `pubspec.yaml`: `sign_in_with_apple: ^6.1.2`, `google_sign_in: ^7.1.1`.
+- Extend `AuthErrorCode` with: `nativeCredentialCancelled`, `nativeCredentialUnavailable`, `nativeCredentialIssuerMismatch`, `nativeCredentialExchangeFailed`.
+  - Non-retryable: `nativeCredentialIssuerMismatch`.
+- Create `lib/src/credentials/native_credential.dart`:
+  ```dart
+  enum NativeCredentialProviderKind { apple, google }
+
+  class NativeCredentialResult {
+    final NativeCredentialProviderKind provider;
+    final String idToken;
+    final String? authorizationCode;   // Apple gives this, Google doesn't
+    final String? nonce;                // what we passed in; mirrored for verification
+    final bool autoSelected;            // true if silent / hinted return
+  }
+
+  sealed class NativeCredentialOutcome {
+    const factory NativeCredentialOutcome.ok(NativeCredentialResult result) = _Ok;
+    const factory NativeCredentialOutcome.noSession() = _NoSession;
+    const factory NativeCredentialOutcome.cancelled() = _Cancelled;
+    const factory NativeCredentialOutcome.unavailable(String reason) = _Unavail;
+    const factory NativeCredentialOutcome.error(AuthError error) = _Err;
+  }
+
+  abstract class NativeCredentialProvider {
+    NativeCredentialProviderKind get kind;
+    Future<bool> isAvailable();
+    /// Attempts silent sign-in. Returns noSession() if no cached credential.
+    Future<NativeCredentialOutcome> attemptSilent({required String nonce});
+    /// Explicit user-gesture sign-in (button press).
+    Future<NativeCredentialOutcome> attemptInteractive({required String nonce});
+    /// Called during logout to remove the cached credential.
+    Future<void> signOut();
+  }
+  ```
+- `test/credentials/native_credential_test.dart` — type sanity + serialization if any.
+
+### Task N.2 — `AppleCredentialProvider`
+
+**Commit:** `feat(auth-runtime): AppleCredentialProvider via sign_in_with_apple`
+
+- `lib/src/credentials/apple_credential_provider.dart`.
+- `isAvailable()` via `SignInWithApple.isAvailable()` (guards non-iOS/macOS platforms).
+- `attemptSilent`: Apple does not expose a silent API that matches Google's. Return `noSession()` — we only invoke Apple on explicit user click. Document this.
+- `attemptInteractive({nonce})`:
+  - Generate a SHA-256 hash of the passed-in nonce (Apple requires the hash, not the raw nonce).
+  - Call `SignInWithApple.getAppleIDCredential(scopes: [email, fullName], nonce: sha256Hex(nonce), webAuthenticationOptions: null)`.
+  - On success → `NativeCredentialResult(provider: apple, idToken: credential.identityToken, authorizationCode: credential.authorizationCode, nonce: nonce, autoSelected: false)`.
+  - Map exceptions: user cancel → `cancelled()`; `SignInWithAppleAuthorizationException` non-cancel → `error(AuthError(nativeCredentialCancelled|unavailable))`.
+- `signOut()`: Apple doesn't require client-side sign-out (IdP handles sessions). No-op.
+- Test with `mocktail`-stubbed `SignInWithApple` surface via a thin `SignInWithAppleAdapter` seam.
+
+### Task N.3 — `GoogleCredentialProvider`
+
+**Commit:** `feat(auth-runtime): GoogleCredentialProvider via google_sign_in v7 (CredentialManager on Android)`
+
+- `lib/src/credentials/google_credential_provider.dart`.
+- Constructor takes `clientId` (the audience — Google client ID from Google Cloud Console).
+- `isAvailable()` — returns true on Android and iOS, false elsewhere.
+- `attemptSilent({nonce})`:
+  - `GoogleSignIn.signInSilently()` — returns cached credential if user previously signed in.
+  - If null: `noSession()`.
+  - Otherwise extract `authentication.idToken`; wrap in `NativeCredentialResult(autoSelected: true)`.
+- `attemptInteractive({nonce})`:
+  - `GoogleSignIn.authenticate()` (v7 API; replaces `signIn()`).
+  - Extract ID token; set `autoSelected: false`.
+- `signOut()`: `GoogleSignIn.signOut()` (clears cached credential; the IdP session at Google is independent and requires Google's Account page to revoke).
+- **Nonce quirk:** Google Sign-In for Flutter v7 accepts a `nonce` parameter on authentication calls; echo it into the returned ID token's `nonce` claim. If not supported in the concrete library version the subagent uses, document and move on — the server's token-exchange step still binds by `sub` + `iss`.
+- Test with `mocktail` against a `GoogleSignInAdapter` seam.
+
+### Task N.4 — Worker: `completeNativeCredential`
+
+**Commit:** `feat(auth-runtime): TokenWorker.completeNativeCredential via OIDC token-exchange grant`
+
+- Extend `TokenWorker` with:
+  ```dart
+  Future<void> completeNativeCredential({
+    required NativeCredentialResult credential,
+    required String expectedNonce,
+  }) async { ... }
+  ```
+- Flow:
+  1. Decode ID token locally (`decodeJwtPayload`).
+  2. Assert `iss` is one of: `https://appleid.apple.com`, `https://accounts.google.com` — match by `credential.provider`.
+  3. Assert `claims['nonce'] == expectedNonce` if the provider produced one; otherwise skip (Apple requires the nonce hash match, which the platform verifies; Google's nonce support varies).
+  4. Assert `aud == cfg.clientId` (for Google; Apple's `aud` is the app's services ID which may differ — document and accept).
+  5. POST to `/token` with:
+     ```
+     grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+     client_id=<cfg.clientId>
+     subject_token=<idToken>
+     subject_token_type=urn:ietf:params:oauth:token-type:id_token
+     subject_issuer=<matching iss>
+     ```
+     Plus `DPoP` header if DPoP mode.
+  6. Parse token response; persist; emit `signInDone`.
+  7. On any failure: emit `signInFail` with typed `AuthError`; do NOT silently swallow.
+
+- Add `WorkerRequest.completeNativeCredential` message variant + corresponding event.
+- Test using the existing `MockIdp` extended with a token-exchange handler that accepts any well-formed ID token with correct iss.
+
+### Task N.5 — MockIdp extension
+
+**Commit:** `test(auth-runtime): MockIdp accepts token-exchange grant`
+
+- Extend `test/integration/mock_idp.dart` `/token` handler to accept `grant_type=urn:ietf:params:oauth:grant-type:token-exchange` with `subject_token_type=urn:ietf:params:oauth:token-type:id_token`.
+- Parse the subject token, verify structure, echo `sub` back into the issued access token, issue a fresh refresh token, include DPoP support.
+- Reject if `subject_issuer` is missing or not in the allowed list (configurable per test).
+
+### Task N.6 — Runtime wiring
+
+**Commit:** `feat(auth-runtime): runtime orchestrates native → OAuth2 sign-in waterfall`
+
+- `AuthRuntimeImpl` accepts an optional list of `NativeCredentialProvider`s at construction:
+  ```dart
+  AuthRuntime createAuthRuntime(
+    AuthConfig config, {
+    bool useIsolate = false,
+    List<NativeCredentialProvider> nativeProviders = const [],
+  });
+  ```
+- On mount: if any provider `isAvailable()`, schedule a proactive silent attempt via `scheduleMicrotask` (not blocking) — roughly equivalent to JS `requestIdleCallback`.
+- In `ensureAuthenticated()`:
+  1. If state is already `authenticated`, return.
+  2. Generate a fresh nonce (crypto random).
+  3. Try each provider in declaration order via `attemptInteractive({nonce: nonce})`.
+  4. On any provider's `ok` outcome: call `worker.completeNativeCredential(credential: ..., expectedNonce: nonce)`; if success, return.
+  5. On all providers' `cancelled`/`noSession`/`error`: fall through to existing OAuth2 popup path.
+- On `logout()`: call `signOut()` on every provider before the existing revocation/end-session flow.
+
+- Add `onCredentialEvent(cb)` callback (analogous to JS `onFedcmEvent`) — fires `probe`, `silent-attempt`, `interactive-attempt`, `outcome`, `sign-out` events per provider.
+- Expose `AuthRuntime.nativeProvidersAvailable()` helper returning the set of kinds currently `isAvailable()`.
+
+### Task N.7 — Riverpod + factory integration
+
+**Commit:** `feat(auth-runtime): factory surfaces nativeProviders parameter`
+
+- Update `factory.dart` and `createAuthRuntime` signature + docs.
+- Expose a small Riverpod helper: `authNativeProvidersProvider = Provider<List<NativeCredentialProvider>>((ref) => [])` — consumers override at app root.
+- Update README with the new API.
+
+### Task N.8 — Integration tests
+
+**Commit:** `test(auth-runtime): native-credential waterfall end-to-end`
+
+- `test/integration/native_credential_flow_test.dart`:
+  - **silent-fast-path:** stubbed `FakeNativeCredentialProvider` returns `ok` on `attemptSilent`; MockIdp accepts token-exchange; runtime transitions `unauthenticated → authenticated` without any browser invocation.
+  - **interactive-success:** silent returns `noSession`, interactive returns `ok`; flow completes.
+  - **native-fall-through:** interactive returns `cancelled`; runtime falls through to OAuth2 popup (stubbed OAuthFlow).
+  - **issuer-mismatch:** provider returns ID token with wrong `iss`; worker rejects with `nativeCredentialIssuerMismatch`; state stays `unauthenticated`; no token-exchange request reaches the server.
+  - **logout-signs-out-providers:** authenticate via native, call `logout()`, assert `signOut()` was called on each provider.
+
+### Task N.9 — Docs
+
+**Commit:** `docs(auth-runtime): Apple and Google sign-in platform setup + backend requirements`
+
+- `README.md` — new section "Native sign-in (Apple / Google)":
+  - Platform setup: iOS entitlement (Sign In with Apple capability), Info.plist URL schemes for Google; Android SHA-256 fingerprint registration, `google-services.json` placement.
+  - Consumer code example: construct providers, pass to `createAuthRuntime(nativeProviders: [...])`.
+  - Failure-mode table: each `NativeCredentialProviderOutcome` → observable effect.
+- New `docs/auth-runtime-native-credentials.md` — backend operator guide:
+  - Ory Hydra configuration for token-exchange grant
+  - Registering Apple + Google as trusted issuers (JWKS URIs)
+  - Audience + claim mapping
+  - Security considerations: nonce binding, iss pinning, token TTL
+
+### Task N.10 — Version + changelog
+
+**Commit:** `chore(auth-runtime): bump to v0.2.0`
+
+- `pubspec.yaml`: `version: 0.2.0`.
+- `CHANGELOG.md` — v0.2.0 section listing: native credential fast paths; Apple provider; Google provider; token-exchange grant support; new error codes; no breaking changes.
+- Run `flutter test --coverage` and `flutter pub publish --dry-run`.
+- Push branch.
+
+## Test baseline
+
+- v0.1.0 ends at 227 tests passing, 86.4% line coverage.
+- v0.2.0 target: ≥ 240 tests; coverage ≥ 85%.
+
+## Self-review checklist
+
+1. No breaking change in `AuthRuntime` public surface (additive only).
+2. `NativeCredentialProvider` is pluggable — consumers can ship their own for enterprise IdPs.
+3. All four new `AuthErrorCode` values handled.
+4. Nonce binding on both providers where the platform supports it; documented otherwise.
+5. Issuer pinning enforced in the worker (trust boundary not delegated to the provider).
+6. Providers called on logout.
+7. No Web-specific code (deferred).
+8. `flutter analyze` clean.
+9. `flutter pub publish --dry-run` clean.

--- a/docs/superpowers/plans/2026-04-20-auth-runtime-native-credentials.md
+++ b/docs/superpowers/plans/2026-04-20-auth-runtime-native-credentials.md
@@ -139,7 +139,7 @@ Sign-in-with-Apple has a Web flavor. `google_sign_in` also supports Web. We do N
 - Flow:
   1. Decode ID token locally (`decodeJwtPayload`).
   2. Assert `iss` is one of: `https://appleid.apple.com`, `https://accounts.google.com` — match by `credential.provider`.
-  3. Assert `claims['nonce'] == expectedNonce` if the provider produced one; otherwise skip (Apple requires the nonce hash match, which the platform verifies; Google's nonce support varies).
+  3. Assert `claims['nonce'] == expectedNonce` (or `sha256(expectedNonce)` for Apple). The check is unconditional when `expectedNonce` is passed — the runtime always passes one.
   4. Assert `aud == cfg.clientId` (for Google; Apple's `aud` is the app's services ID which may differ — document and accept).
   5. POST to `/token` with:
      ```

--- a/docs/superpowers/plans/2026-04-20-service-chat-migration.md
+++ b/docs/superpowers/plans/2026-04-20-service-chat-migration.md
@@ -1,0 +1,197 @@
+# `service-chat/ui` — migration to `antinvestor_auth_runtime`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** retire `service-chat/ui`'s custom auth stack (`openid_client`-based `AuthService` + dual-cache `TokenManager` + `TokenRefreshCoordinator` + `SharedTokenService`) in favor of `antinvestor_auth_runtime`. ≥230 call sites migrate to the unified runtime API.
+
+**Prereq:** `antinvestor_auth_runtime` v0.3 merged (`audiences` + typed `UserClaims` getters + background-task docs).
+
+**Branch:** `feat/auth-runtime-migration` off `service-chat/main`.
+
+**Scope:** `service-chat/ui/` only. Non-goals: changing the backend auth contract (Hydra unchanged).
+
+## Pre-flight — confirmations
+
+1. Hydra continues to emit `contact_id` and `realm_access.roles` claims — verified.
+2. Runtime v0.3's `UserClaims.contactId` getter covers the `contact_id` use-case — verified by unit test before starting.
+3. WorkManager tasks construct a fresh runtime per task; no cross-Isolate sharing — documented in runtime README.
+4. Deep-link scheme `com.antinvestor.chat://sso/redirect` remains stable. Runtime's `redirectScheme: "com.antinvestor.chat"` with `redirectPath: "/sso/redirect"` (the latter is the path portion `flutter_appauth` uses).
+
+## Task breakdown
+
+### CHAT-1 — Add dependency + construct runtime at app root
+
+**Files:**
+- `service-chat/ui/pubspec.yaml` — add `antinvestor_auth_runtime: ^0.3.0` (path dep during feature branch).
+- `service-chat/ui/lib/core/auth/runtime_provider.dart` — new; holds a factory + provider override.
+- `service-chat/ui/lib/main.dart` — modify to construct runtime before `runApp`.
+
+```dart
+// core/auth/runtime_provider.dart
+const kChatAuthConfig = AuthConfig(
+  clientId: 'antinvestor-chat',
+  idpBaseUrl: 'https://oauth2.antinvestor.com',
+  apiBaseUrl: 'https://api.antinvestor.com',
+  redirectScheme: 'com.antinvestor.chat',
+  redirectPath: '/sso/redirect',
+  scopes: ['openid', 'profile', 'contact', 'offline_access'],
+);
+
+AuthRuntime buildChatRuntime() => createAuthRuntime(kChatAuthConfig);
+```
+
+```dart
+// main.dart (delta)
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await initializeApp(); // existing init
+  final runtime = buildChatRuntime();
+  runApp(
+    ProviderScope(
+      overrides: [authRuntimeProvider.overrideWithValue(runtime)],
+      child: StawiApp(),
+    ),
+  );
+}
+```
+
+Commit: `feat(auth): construct antinvestor_auth_runtime at app root`
+
+### CHAT-2 — Replace `AuthInterceptor` with runtime.fetch
+
+**Files:**
+- `service-chat/ui/lib/core/networking/interceptors.dart` — delete `AuthInterceptor`.
+- `service-chat/ui/lib/core/networking/client.dart` — rewire Connect RPC transport to use `runtime.fetch` under the hood.
+
+Connect RPC has a `Transport` abstraction; write a `RuntimeBackedTransport` that delegates all RPCs to `runtime.fetch(path, method: 'POST', body: jsonBody, headers: {...})`. For upload RPCs use `runtime.upload`.
+
+Commit: `refactor(chat/auth): route Connect RPC transport through runtime.fetch`
+
+### CHAT-3 — Delete legacy auth files
+
+**Files to delete:**
+- `service-chat/ui/lib/features/auth/data/auth_service.dart`
+- `service-chat/ui/lib/features/auth/data/auth_repository.dart`
+- `service-chat/ui/lib/core/auth/token_refresh_coordinator.dart`
+- `service-chat/ui/lib/core/auth/auth_context.dart` (if absorbed by runtime — confirm by running tests)
+
+**Files to update:**
+- `service-chat/ui/lib/features/auth/data/auth_state_provider.dart` — rewire to `authStateProvider` from runtime; remove `AuthStateNotifier` (runtime owns state).
+
+Commit: `refactor(chat/auth): delete legacy AuthService + TokenRefreshCoordinator`
+
+### CHAT-4 — Rewire background token refresh (WorkManager)
+
+**Files:**
+- `service-chat/ui/lib/core/auth/shared_token_service.dart` — replace with new `BackgroundAuthHelper`:
+
+```dart
+class BackgroundAuthHelper {
+  /// Call from WorkManager task entry. Constructs a runtime, performs
+  /// the work, disposes. Do NOT share runtime across tasks.
+  static Future<T> withRuntime<T>(Future<T> Function(AuthRuntime) fn) async {
+    final runtime = buildChatRuntime();
+    try {
+      if (!runtime.isAuthenticated) return Future.value() as T;
+      return await fn(runtime);
+    } finally {
+      await runtime.dispose();
+    }
+  }
+}
+```
+
+All ~50 WorkManager call sites switch to `BackgroundAuthHelper.withRuntime((rt) async { ... rt.fetch(...) ... })`.
+
+Commit: `refactor(chat/auth): BackgroundAuthHelper for WorkManager tasks`
+
+### CHAT-5 — Migrate route guards + login screen + profile UI
+
+**Files:**
+- `service-chat/ui/lib/app/router.dart` — replace `AuthChangeNotifier` with `ref.watch(authStateProvider)` directly in the `redirect` callback.
+- `service-chat/ui/lib/features/auth/ui/login_screen.dart` — replace custom OAuth trigger with `SignInButton` from runtime; keep existing branding.
+- `service-chat/ui/lib/features/settings/ui/settings_screen.dart` — replace sign-out button with `SignOutButton`.
+
+Commit: `refactor(chat/auth): route guards + login + settings use runtime widgets`
+
+### CHAT-6 — Access `contact_id` via typed UserClaims
+
+**Files:**
+- Grep for `contact_id` usage sites.
+- Replace `claims['contact_id']` casts with `userClaims.contactId` (typed).
+
+Commit: `refactor(chat/auth): use UserClaims.contactId typed getter`
+
+### CHAT-7 — One-time token storage migration
+
+**Files:**
+- `service-chat/ui/lib/core/auth/migration.dart` — new.
+
+```dart
+/// Clear v1 tokens so the runtime forces a fresh sign-in on first launch
+/// after the migration. Runs once per install via SharedPreferences flag.
+Future<void> migrateLegacyAuthIfNeeded() async {
+  final prefs = await SharedPreferences.getInstance();
+  if (prefs.getBool('auth_runtime_migrated') == true) return;
+  const storage = FlutterSecureStorage();
+  for (final key in ['access_token', 'refresh_token', 'id_token', 'token_expires_at']) {
+    await storage.delete(key: key);
+  }
+  await prefs.setBool('auth_runtime_migrated', true);
+}
+```
+
+Call from `main.dart` before `buildChatRuntime`.
+
+Commit: `refactor(chat/auth): one-time migration clears legacy secure-storage keys`
+
+### CHAT-8 — Update tests
+
+**Files:**
+- Replace `mockAuthService` fixtures with `MockAuthRuntime` (from `antinvestor_auth_runtime/test_support`).
+- Delete tests that cover the deleted legacy auth code.
+- Add integration smoke test: launch app → tap sign-in → (mocked) OAuth succeeds → home screen renders.
+
+Commit: `test(chat/auth): migrate test harness to MockAuthRuntime`
+
+### CHAT-9 — Platform manifest verification
+
+**Files:**
+- `service-chat/ui/android/app/src/main/AndroidManifest.xml` — verify the existing intent-filter matches the new `redirectScheme` / `redirectPath`. No change expected; document expected state in a comment.
+- `service-chat/ui/ios/Runner/Info.plist` — verify `CFBundleURLTypes` has the scheme. Add if missing.
+
+Commit: `chore(chat/auth): verify platform URL scheme manifests`
+
+### CHAT-10 — End-to-end smoke on device
+
+Manual QA checklist (not automatable):
+
+- [ ] Fresh install → sign in → authenticated state.
+- [ ] App backgrounded for 15 min → resume → access token auto-refreshed.
+- [ ] Kill app → relaunch → no re-sign-in required (stored refresh token used).
+- [ ] Sign out → re-open → login screen.
+- [ ] Airplane mode while authenticated → API calls surface `networkError` not `tokenExpired`.
+- [ ] WorkManager background sync → runs with authenticated runtime and returns data.
+- [ ] Mobile deep link → OAuth callback reaches the app correctly.
+
+Commit: none (QA only); attach checklist to the PR description.
+
+## Rollback plan
+
+All migration commits are on a feature branch. If production issues surface post-merge:
+
+1. Revert the feature-branch merge commit (single revert).
+2. Force-clear the `auth_runtime_migrated` SharedPreferences flag via a small patch so users don't lose their legacy-token state permanently.
+3. Release a hotfix pointing back at `AuthService`.
+
+Low risk given the one-time-migration design clears legacy keys — but the revert path exists.
+
+## Estimated effort
+
+- Implementation: 12–18 subagent hours (most of the time is in touching ~230 call sites).
+- QA on real devices (iOS + Android + desktop): 1 day.
+
+## Open questions
+
+- Does chat have any WorkManager task that MUST run before runtime.init() completes? If yes, add a synchronous cached-state path.
+- Is `contact_id` token claim always present or only post-verification? If conditional, `UserClaims.contactId` needs to tolerate null (already does per v0.3 design).

--- a/docs/superpowers/plans/2026-04-20-service-fintech-consolidation.md
+++ b/docs/superpowers/plans/2026-04-20-service-fintech-consolidation.md
@@ -1,0 +1,56 @@
+# `service-fintech/ui` — consolidation (prerequisite to auth migration)
+
+Status: sketch / planning only — implementation gated on product decision.
+Date: 2026-04-20
+
+## Observation
+
+`service-fintech/ui/` has no consolidated Flutter app. The directory contains feature-specific packages (`funding/`, `identity/`, `loans/`, `operations/`, `savings/`, `seed/`, `stawi/`, `default/`) with no unifying `pubspec.yaml` at the top level.
+
+This means "migrate fintech to `antinvestor_auth_runtime`" is ambiguous — which app? There is no app to migrate.
+
+## Decision required
+
+Before any auth migration plan for fintech can be written, product + engineering leadership must pick one of:
+
+### Option A — Consolidate into a single Flutter app
+- One `pubspec.yaml` at `service-fintech/ui/`.
+- Feature packages become internal modules (`lib/features/{funding,identity,loans,...}`).
+- Single auth runtime, single OAuth client, single deep-link scheme.
+- **Auth migration scope after consolidation:** similar to service-chat (medium-to-high depending on total call sites).
+- **Implication:** a shipping app can embed any feature without spawning multiple browser sessions for auth.
+
+### Option B — Keep feature packages; ship multiple apps
+- Each feature has its own app bundle + binary.
+- Each app independently integrates the auth runtime.
+- Multiple OAuth clients (one per app) registered with Hydra.
+- **Auth migration scope:** N small migrations, each ~same size as service-thesa.
+- **Implication:** users who want loans + savings install two apps and sign in twice. Unlikely acceptable UX.
+
+### Option C — Shared auth across feature apps via native OS credential sharing
+- Each feature ships as a separate app but they share credentials via:
+  - iOS: Keychain Sharing groups (com.antinvestor.*.sharedKeychain).
+  - Android: `android:sharedUserId` (deprecated) or custom ContentProvider.
+- Runtime gains an `AuthConfig.keychainAccessGroup` parameter (iOS) / `sharedAccountType` (Android).
+- **Auth migration scope:** N small migrations + one enhancement to the runtime for cross-app credential sharing.
+- **Implication:** technically feasible but operationally complex; not recommended unless product has a hard split.
+
+## Recommendation
+
+Option A, strongly. It matches the pattern service-chat and service-thesa follow, simplifies the auth story, and aligns with how Antinvestor apps present to end users.
+
+## Gated actions
+
+Once the decision lands:
+
+- If A: write `docs/superpowers/plans/YYYY-MM-DD-service-fintech-consolidation-then-migration.md` covering both the app consolidation and the subsequent auth migration. Treat as a major effort (scoping: 2–4 weeks).
+- If B: write N migration plans, one per feature app.
+- If C: first extend `antinvestor_auth_runtime` with credential-sharing support (v0.4+), then write migration plans.
+
+## Open questions
+
+1. Who owns the consolidation decision? (Likely fintech product + platform engineering.)
+2. Is there a business reason the features are currently split? (Different deployment cadences? Regulatory separation?)
+3. Are there existing plans for fintech UI that this doc is missing?
+
+Until answered, no implementation work should start on fintech migration.

--- a/docs/superpowers/plans/2026-04-20-service-thesa-migration.md
+++ b/docs/superpowers/plans/2026-04-20-service-thesa-migration.md
@@ -1,0 +1,122 @@
+# `service-thesa/ui` — migration to `antinvestor_auth_runtime`
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** retire `service-thesa/ui`'s custom `openid_client`-based auth (`AuthService` + `AuthRepository` + `ThesaAuthTokenBridge`) in favor of `antinvestor_auth_runtime`. ~58 call sites. Adds mobile support as a free by-product (thesa is desktop-only today; the runtime supports mobile out-of-the-box).
+
+**Prereq:** `antinvestor_auth_runtime` v0.3 merged (specifically the `audiences` parameter, which thesa uses).
+
+**Branch:** `feat/auth-runtime-migration` off `service-thesa/main`.
+
+## Pre-flight — confirmations
+
+1. Hydra accepts the 9 thesa audiences: `service_tenancy`, `service_device`, `service_profile`, `service_notification`, `service_payment`, `service_ledger`, `service_setting`, `service_thesa`, `service_file` — confirm with backend team. Verify that Hydra's `audience` parameter syntax matches what v0.3 emits (see v0.3 spec for comma vs space decision).
+2. Desktop loopback on port 5173 continues to work via `flutter_appauth`'s desktop backend — verify.
+3. `antinvestor_ui_core`'s `AuthTokenProvider` interface stays as a compatibility shim during the transition; new code targets the runtime directly.
+
+## Task breakdown
+
+### THESA-1 — Add dependency + construct runtime at app root
+
+**Files:**
+- `service-thesa/ui/pubspec.yaml` — add `antinvestor_auth_runtime: ^0.3.0`.
+- `service-thesa/ui/lib/core/auth/runtime_provider.dart` — new.
+- `service-thesa/ui/lib/main.dart` — construct runtime before `runApp`.
+
+```dart
+// core/auth/runtime_provider.dart
+const kThesaAuthConfig = AuthConfig(
+  clientId: 'antinvestor-thesa',
+  idpBaseUrl: 'https://oauth2.antinvestor.com',
+  apiBaseUrl: 'https://api.antinvestor.com',
+  redirectScheme: 'com.antinvestor.thesa',  // mobile; ignored on desktop
+  redirectPort: 5173,                        // desktop loopback
+  scopes: ['openid', 'profile', 'offline_access'],
+  audiences: [
+    'service_tenancy', 'service_device', 'service_profile',
+    'service_notification', 'service_payment', 'service_ledger',
+    'service_setting', 'service_thesa', 'service_file',
+  ],
+);
+```
+
+Commit: `feat(thesa/auth): construct antinvestor_auth_runtime at app root`
+
+### THESA-2 — Rewire Connect RPC transport through runtime.fetch
+
+**Files:**
+- `service-thesa/ui/lib/core/networking/` — identify the Transport factory.
+- Point every RPC client at a `RuntimeBackedTransport` (copy the pattern from service-chat CHAT-2; add to `antinvestor_ui_core` if it should be shared across apps).
+
+Commit: `refactor(thesa/auth): Connect RPC transport uses runtime.fetch`
+
+### THESA-3 — Delete legacy auth files
+
+**Files to delete:**
+- `service-thesa/ui/lib/features/auth/data/auth_service.dart`
+- `service-thesa/ui/lib/features/auth/data/auth_repository.dart`
+- `service-thesa/ui/lib/core/services/auth_bridge.dart` (the `ThesaAuthTokenBridge` adapter — no longer needed since `antinvestor_ui_core` will consume the runtime's providers directly).
+
+**Files to update:**
+- `service-thesa/ui/lib/features/auth/data/auth_state_provider.dart` — re-export runtime's `authStateProvider`.
+- `antinvestor_ui_core` — update `AuthTokenProvider` consumers to accept `AuthRuntime` directly (separate PR in `antinvestor_ui_core` if that package is shared across apps).
+
+Commit: `refactor(thesa/auth): delete legacy AuthService + AuthBridge`
+
+### THESA-4 — Migrate route guards + login screen
+
+**Files:**
+- `service-thesa/ui/lib/app/router.dart` — use `authStateProvider`.
+- `service-thesa/ui/lib/features/auth/ui/login_page.dart` — replace custom button with `SignInButton` from runtime. Keep gradient / Material 3 styling via `ButtonStyle` prop.
+
+Commit: `refactor(thesa/auth): route guards + login page use runtime widgets`
+
+### THESA-5 — Add mobile support (free upgrade)
+
+Thesa is desktop-only today. Once the runtime is wired, iOS/Android become viable:
+
+- Confirm platform manifest entries exist for the `com.antinvestor.thesa` scheme:
+  - Android: add intent-filter to `service-thesa/ui/android/app/src/main/AndroidManifest.xml`.
+  - iOS: add `CFBundleURLTypes` entry to `service-thesa/ui/ios/Runner/Info.plist`.
+- Smoke-test sign-in on iOS simulator + Android emulator.
+- Gate mobile behind a feature flag initially if product wants to control rollout.
+
+Commit: `feat(thesa/auth): add mobile platform manifests (iOS + Android)`
+
+### THESA-6 — One-time token storage migration
+
+Same pattern as CHAT-7: clear legacy secure-storage keys on first launch after migration so the runtime triggers a fresh sign-in. SharedPreferences flag prevents repeat.
+
+Commit: `refactor(thesa/auth): one-time migration clears legacy secure-storage keys`
+
+### THESA-7 — Update tests
+
+**Files:**
+- Replace `mockAuthService` with `MockAuthRuntime`.
+- Delete tests for the deleted legacy auth code.
+- Add `audiences` assertion: with `audiences` configured, the generated authorize URL includes the expected `audience` param.
+- Integration smoke: mocked OAuth → authenticated → RPC via runtime succeeds with a token whose `aud` claim matches configured audiences.
+
+Commit: `test(thesa/auth): migrate test harness to MockAuthRuntime + audiences assertion`
+
+### THESA-8 — End-to-end smoke
+
+- [ ] Desktop: fresh install → sign in via browser loopback → authenticated.
+- [ ] Mobile iOS: sign in via ASWebAuthenticationSession → authenticated.
+- [ ] Mobile Android: sign in via Chrome Custom Tabs → authenticated.
+- [ ] Token carries expected `aud` claim for each audience (decode and log in dev mode).
+- [ ] Sign out clears state across platforms.
+
+## Rollback plan
+
+Same as chat: revert the feature-branch merge. Low risk; the app is smaller and simpler than chat.
+
+## Estimated effort
+
+- Implementation: 5–7 subagent hours (58 call sites, no dual-cache, no background refresh).
+- QA on desktop + mobile: 0.5 day.
+
+## Open questions
+
+- Does thesa's backend validate the `aud` claim per-service, or is it informational only? If validated, the audiences list must match exactly what's registered in Hydra. Verify with backend team.
+- Is mobile thesa a product ask for this iteration or purely a "we get it for free, flag it off" situation? Decide before THESA-5.

--- a/docs/superpowers/specs/2026-04-20-auth-runtime-roadmap-design.md
+++ b/docs/superpowers/specs/2026-04-20-auth-runtime-roadmap-design.md
@@ -1,0 +1,270 @@
+# `antinvestor_auth_runtime` — roadmap design (v0.3 additions, v1.1 Web, consumer migrations)
+
+Status: draft
+Date: 2026-04-20
+Scope: three follow-on tracks after v0.2.0 ships.
+
+---
+
+## 1. Context
+
+Three Antinvestor Flutter apps currently reimplement authentication from scratch with `openid_client` + `flutter_secure_storage`:
+
+- `service-chat/ui` — production, ~230 auth call sites, mobile + desktop, background refresh in WorkManager, custom `contact_id` claim.
+- `service-thesa/ui` — production, ~58 auth call sites, desktop-only, passes a 9-element `audiences` array at authorize-time.
+- `service-fintech/ui` — no consolidated app; feature packages only.
+
+Goal: retire those ad-hoc implementations in favor of `antinvestor_auth_runtime`. Scouting (recon report in conversation history) identified four gaps to close before migration:
+
+1. **`audiences` parameter** not in `AuthConfig` — thesa requires it.
+2. **Custom-claim surfacing** — chat needs `contact_id`; today consumers call `runtime.getClaims()` and cast, which works but is undiscoverable.
+3. **Background-task friendly** — chat's WorkManager path needs an `AuthRuntime` that is safe to construct outside a Riverpod scope and safe to dispose aggressively.
+4. **Web target** — service-thesa is desktop-only today but the brief is "replace the current auth with a standardized reusable implementation" — web support is strongly implied for admin UIs.
+
+This doc covers three tracks:
+
+- **Track A: v0.3 runtime additions** — audiences, custom-claim helper, background-safe construction.
+- **Track B: v1.1 Web target** — pure-Dart implementation with `dart:js_interop` + `package:web`.
+- **Track C: consumer migrations** — chat, thesa, fintech.
+
+Each is self-contained and can ship independently. Sequencing preference: v0.3 → chat migration → thesa migration → v1.1 Web → fintech (pending consolidation).
+
+---
+
+## 2. Track A — v0.3 runtime additions
+
+### A.1 `audiences` parameter
+
+**Motivation:** thesa passes resource-based audience hints to Hydra so issued tokens carry the right `aud` claim for each downstream service.
+
+**Spec:**
+
+- `AuthConfig.audiences: List<String>?` — optional, default `null` (omitted from authorize URL).
+- When non-null, the runtime appends `audience=<comma-separated list>` to the authorize URL per Hydra's convention (Hydra accepts space-separated via RFC 8707 or comma-separated per its docs — default to comma).
+- `ResolvedConfig` mirrors with non-nullable default empty list.
+- Token exchange grant body also carries `audience` when configured.
+
+**Backward compatibility:** additive; existing v0.2 callers unaffected.
+
+**Tests:** assert authorize URL + token body both include `audience` when configured; omit when null.
+
+### A.2 Custom-claim surfacing — `UserClaims` typed getters + helper
+
+**Motivation:** chat's `contact_id` claim is a repeat pattern (non-standard OIDC claim used by multiple Antinvestor services). Today consumers call `runtime.getClaims()` which returns a `Map<String, dynamic>` and they cast. This works but is error-prone and undiscoverable.
+
+**Spec:**
+
+- `UserClaims` class already wraps the claims map (v0.1). Extend with typed getters for Antinvestor-specific claims:
+  - `String? get contactId => _map['contact_id'] as String?;`
+  - `String? get tenantId => _map['tenant_id'] as String?;`
+  - `String? get partitionId => _map['partition_id'] as String?;`
+  - `Map<String, dynamic> get customClaims;` — escape hatch returning the raw map minus the standard OIDC claims, for apps that have their own bespoke claims.
+- `AuthRuntime.getUserClaims(): Future<UserClaims>` — new method returning the typed wrapper. `getClaims()` stays, returns raw map.
+- Riverpod: `userClaimsProvider` already exists; document the typed getters.
+
+**Tests:** unit tests for each getter with standard Hydra token shapes.
+
+### A.3 Background-task friendly construction
+
+**Motivation:** chat's `SharedTokenService` uses a standalone `AuthService` inside WorkManager tasks (no Riverpod / UI Isolate context).
+
+**Spec:**
+
+- `createAuthRuntime(cfg)` already works without Riverpod (factory is standalone). Verify + document.
+- Add `AuthRuntime.isAuthenticated` synchronous getter for background task pre-check (avoids unnecessary work if the user is signed out).
+- Document the pattern:
+  ```dart
+  // In a WorkManager task:
+  final runtime = createAuthRuntime(kBackgroundAuthConfig);
+  if (!runtime.isAuthenticated) { runtime.dispose(); return; }
+  final response = await runtime.fetch('/v1/sync', method: 'POST');
+  await runtime.dispose();
+  ```
+- Add warning in the README about NOT sharing runtime instances across isolates — each isolate constructs + disposes its own.
+
+**No new code beyond the `isAuthenticated` getter.** Mostly documentation.
+
+### A.4 Release
+
+`v0.3.0` stacked on v0.2 or post-merge of v0.2. Additive across the board.
+
+---
+
+## 3. Track B — v1.1 Web target (pure Dart)
+
+### B.1 Decision: implementation approach
+
+Two options considered:
+
+- **(a) Wrap `@stawi/auth-runtime` (JS)** via `dart:js_interop` + `package:web`.
+- **(b) Pure-Dart Web implementation** using `dart:js_interop` only for browser primitives (`crypto.subtle`, `IndexedDB`, `Worker`).
+
+**Chosen: (b).**
+
+Rationale:
+
+- **Long-term durability.** Flutter Web via Wasm is a Google strategic investment; pure Dart code compiles to both JS and Wasm. Wrapping an npm package ties us to JS-only and adds cross-boundary serialization overhead.
+- **Single source of truth.** Mobile + Desktop + Web all share the same `antinvestor_auth_runtime` Dart codebase. Bug fixes land once.
+- **Smaller bundle.** No separate JS runtime loaded; tree-shaking eliminates unused paths.
+- **Non-deprecated APIs.** Uses `dart:js_interop` (stable since Dart 3.2) + `package:web` (replaces deprecated `dart:html`) exclusively. Never uses `dart:js`, `dart:js_util`, `package:js`, `dart:html`, or `package:html`.
+- **FFI-style narrow interop.** Only `crypto.subtle`, `IndexedDB`, `Worker`, `BroadcastChannel`, `navigator.locks`, `FederatedCredential` touch JS-interop. The rest is pure Dart — DPoP proof builder, state machine, discovery, token exchange, API proxy, Riverpod providers, widgets — reused verbatim.
+
+### B.2 Platform abstraction seams
+
+v0.1 already has `KeyManager`, `TokenStore`, `KeyValueStore` abstractions. For Web, add:
+
+```dart
+// Per-platform implementations chosen at createAuthRuntime() via Platform probe.
+abstract class RuntimePlatform {
+  KeyManager buildKeyManager();
+  KeyValueStore buildKeyValueStore(String namespace);
+  WorkerBackend? buildWorkerBackend(ResolvedConfig cfg);  // null on non-Web; uses dedicated Web Worker on Web
+  FederatedCredentialProvider? buildFederatedProvider(ResolvedConfig cfg);  // FedCM wrapper, Web-only
+}
+```
+
+- `MobileRuntimePlatform` — existing v0.1 path (flutter_secure_storage + PointyCastle + Isolate).
+- `DesktopRuntimePlatform` — same as Mobile, minus Isolate backend by default.
+- **`WebRuntimePlatform`** — new:
+  - `KeyManager`: uses `crypto.subtle` via `dart:js_interop` for non-extractable ECDSA P-256 (matches JS runtime's design exactly).
+  - `KeyValueStore`: wraps IndexedDB via `package:web`.
+  - `WorkerBackend`: dedicated Web Worker loading the runtime's web-worker entry point, bundled at build time.
+  - `FederatedCredentialProvider`: FedCM wrapper (analogous to JS runtime's FedCM path) — silent + interactive + nonce binding + `preventSilentAccess` + `disconnect` on logout.
+
+### B.3 Web-specific Dart files
+
+```
+ui/runtime/lib/src/web/
+├── web_platform.dart                # exports WebRuntimePlatform
+├── web_crypto.dart                  # JS-interop to crypto.subtle; non-extractable CryptoKey
+├── web_storage.dart                 # JS-interop to IndexedDB (via package:web)
+├── web_worker_backend.dart          # main-thread side of the dedicated Worker
+├── web_worker_entry.dart            # compiles to a separate JS bundle for the Worker
+├── web_fedcm.dart                   # IdentityCredential / FedCMOutcome — mirrors JS runtime's adaptive-FedCM design
+└── web_broadcast.dart               # BroadcastChannel + navigator.locks
+```
+
+Conditional import pattern:
+
+```dart
+// ui/runtime/lib/src/platform.dart
+export 'mobile/mobile_platform.dart'
+    if (dart.library.js_interop) 'web/web_platform.dart';
+```
+
+### B.4 Web-only capabilities
+
+- **FedCM** adaptive: probes `/.well-known/web-identity`; if present, uses FedCM silent on mount (analogous to v0.2's native Apple/Google on mobile). `FedCMOutcome` shape mirrors JS runtime's.
+- **Cross-tab coordination:** `BroadcastChannel` for logout propagation + `navigator.locks` for refresh serialization (available on Web; polyfilled on mobile for Isolate coordination).
+- **Same-origin worker:** the worker's IndexedDB is same-origin with the embedder. Refresh token encrypted at rest by a non-extractable AES-GCM wrap key stored in IndexedDB (matches JS runtime).
+
+### B.5 Non-extractable key enforcement
+
+Critical: `crypto.subtle.generateKey(..., false, ...)` — the `false` is `extractable: false`. Web exposes this as `CryptoKey` objects that **cannot** be serialized to raw bytes. Verify at runtime via `assert(!key.extractable)` and throw `AuthError(cryptoUnsupported)` if the platform silently allows export.
+
+### B.6 OAuth flow on Web
+
+- On Web, `flutter_appauth` does not apply. Use `window.open(authUrl, ...)` synchronously from the user click to preserve gesture (same lesson as the JS runtime's popup fix).
+- Callback page (static HTML hosted by the relying party) `postMessage`s the code back to the opener. Main thread forwards to the worker.
+- Alternatively: same-page redirect flow (`window.location.href = authUrl`) with a dedicated callback route. Document both; default to popup for embedded widget scenarios.
+
+### B.7 Tests
+
+- Web-only tests require `flutter test --platform chrome`. Separate test file prefix (`web_*_test.dart`) gated by the `chrome` platform tag.
+- Mock IdP for integration tests runs in a Dart VM test isolate; Web tests use `package:http` MockClient.
+
+### B.8 Web target task breakdown (deferred plan)
+
+Separate plan doc to be written after v0.3 ships. High-level:
+
+1. Extract `RuntimePlatform` abstraction from v0.2.
+2. Conditional-import wiring.
+3. `web_crypto.dart` — non-extractable key gen + DPoP signing via `crypto.subtle.sign`.
+4. `web_storage.dart` — IDB wrapper.
+5. `web_fedcm.dart` — FedCM probe + silent/interactive attempts + nonce binding + disconnect.
+6. `web_worker_*.dart` — dedicated Worker topology.
+7. Integration tests.
+8. Web sample app (embed in a Flutter Web demo).
+9. README update.
+10. v1.1.0 release.
+
+Estimated scope: 10–15 commits.
+
+---
+
+## 4. Track C — Consumer migrations
+
+### C.1 Migration pattern (reusable across apps)
+
+1. **Add dependency** (path during feature branch, pub.dev version after release).
+2. **Construct runtime** in `main.dart` before `runApp`:
+   ```dart
+   void main() async {
+     WidgetsFlutterBinding.ensureInitialized();
+     final runtime = createAuthRuntime(kAuthConfig);
+     runApp(
+       ProviderScope(
+         overrides: [authRuntimeProvider.overrideWithValue(runtime)],
+         child: MyApp(runtime: runtime),
+       ),
+     );
+   }
+   ```
+3. **Delete legacy auth files**: `auth_service.dart`, `auth_repository.dart`, `token_refresh_coordinator.dart`, `shared_token_service.dart` (chat only).
+4. **Replace interceptor**: point API clients at `runtime.fetch` instead of `AuthInterceptor` manually attaching headers.
+5. **Migrate state provider**: `authStateProvider` now re-exports `authStateProvider` from the runtime package.
+6. **Rewire login screen** to `SignInButton` (or keep custom UI and call `ensureAuthenticated`).
+7. **Migrate route guards** to consume `authStateProvider`.
+8. **Purge stored tokens on first run** (one-time migration): trigger sign-in afresh since the runtime uses a different secure-storage key layout.
+9. **Update deep-link / URL scheme** in platform manifests to match `redirectScheme` in `AuthConfig`.
+10. **Test suite** updated to mock `AuthRuntime` instead of `AuthService`.
+
+### C.2 Per-app complexity and deltas
+
+| App | Call sites | Complexity | Key deltas needed |
+|---|---|---|---|
+| service-chat | ~230 | HIGH | `contact_id` getter, WorkManager-safe construction, custom deep-link scheme preserved, dual-cache removed in favor of runtime-owned state |
+| service-thesa | ~58 | MEDIUM | `audiences` in config, desktop-only loopback (already supported by `flutter_appauth`), mobile support added as free by-product |
+| service-fintech | N/A | BLOCKED | Consolidate feature packages into a single Flutter app first (separate scoping exercise) |
+
+### C.3 Separate plans
+
+- `docs/superpowers/plans/2026-04-20-service-chat-migration.md`
+- `docs/superpowers/plans/2026-04-20-service-thesa-migration.md`
+- `docs/superpowers/plans/2026-04-20-service-fintech-consolidation.md` (sketch; actual migration gated on consolidation decision)
+
+These live in the `service-authentication` repo because the auth contract owns the migration story; app-level repos pick them up.
+
+---
+
+## 5. Sequencing
+
+```
+v0.1 PR #640 → merge
+    ↓
+v0.2 PR #641 → rebase onto main → merge
+    ↓
+v0.3 PR (audiences + typed UserClaims + background-task doc) → merge
+    ↓
+service-chat migration PR → merge (validates v0.3 additions)
+    ↓
+service-thesa migration PR → merge (validates desktop path + audiences)
+    ↓
+v1.1 Web PR → merge
+    ↓
+service-thesa Web release (admin console)
+    ↓
+service-fintech consolidation → then migration
+```
+
+Each step validates the previous — no speculative work. Fintech is gated on a product decision outside this doc.
+
+---
+
+## 6. Open questions flagged for owners
+
+1. **Hydra `audience` parameter syntax** — comma-separated vs repeated `audience=` per RFC 8707. Confirm before A.1 implementation. Owner: service-authentication Go team.
+2. **Custom claim canonical names** — `contact_id`, `tenant_id`, `partition_id` — confirm the standardized set, since adding getters freezes the names. Owner: platform architecture.
+3. **Fintech consolidation direction** — monorepo app with feature modules vs multi-app per feature. Owner: fintech product.
+4. **Web callback-page hosting** — where is the static `auth-callback.html` served from in the Antinvestor stack? Reuse the one bundled in `@stawi/profile/dist/auth-callback.html`? Owner: platform.
+5. **Rollout strategy per app** — big-bang replace vs run-alongside-then-switch. Owner: each app team.

--- a/ui/runtime/CHANGELOG.md
+++ b/ui/runtime/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to `antinvestor_auth_runtime` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 — 2026-04-20
+
+### Added
+- Native sign-in providers: `AppleCredentialProvider` (Sign in with Apple via `sign_in_with_apple`) and `GoogleCredentialProvider` (via `google_sign_in` v7; Android backed by CredentialManager).
+- `NativeCredentialProvider` abstraction — consumers can ship custom providers for enterprise IdPs.
+- OIDC token-exchange grant support (RFC 8693) in `TokenExchange` and `TokenWorker.completeNativeCredential`.
+- Native → OAuth2 sign-in waterfall: proactive silent attempt on mount; interactive attempt on sign-in click; OAuth2 fallback when all native providers decline.
+- `AuthRuntime.availableNativeProviders()` helper + `credentialEventStream` telemetry.
+- `authNativeProvidersProvider` Riverpod override hook.
+- Four new `AuthErrorCode` values: `nativeCredentialCancelled`, `nativeCredentialUnavailable`, `nativeCredentialIssuerMismatch`, `nativeCredentialExchangeFailed`.
+- IdP operator guide: `docs/auth-runtime-native-credentials.md`.
+
+### Changed
+- `createAuthRuntime` now accepts an optional `nativeProviders` parameter. Existing callers are unaffected.
+- `logout()` calls `signOut()` on each configured native provider before the server revocation/end-session path.
+
+### Security
+- Provider-issued ID tokens are validated for issuer match before exchange (trust boundary not delegated to the provider).
+- Per-attempt nonce binding with Apple's SHA-256 hashing accommodated.
+
 ## 0.1.0 — 2026-04-19
 
 Initial public release.

--- a/ui/runtime/README.md
+++ b/ui/runtime/README.md
@@ -66,6 +66,125 @@ No per-platform manifest entries are required: `flutter_appauth` uses the
 system browser directly and receives the callback over an embedded
 listener. The scheme only has to match `AuthConfig.redirectScheme`.
 
+## Native sign-in (Apple + Google)
+
+The runtime ships built-in support for Sign in with Apple and Google
+Sign-In so iOS / macOS / Android users can skip the browser hop and get
+signed in through the platform's native credential sheet. This is
+entirely opt-in; callers that pass no providers to `createAuthRuntime`
+get the v0.1 OAuth2-only behaviour.
+
+### Why use it
+
+- Fastest UX on platforms where the user is already signed into Apple
+  or Google — no browser context switch, no password typing.
+- Fewer sign-in abandonments on mobile where the redirect dance is most
+  fragile.
+- Graceful degradation: when native providers decline (no session, user
+  cancels, platform unavailable) the runtime falls back to the existing
+  OAuth2 + PKCE flow automatically.
+
+### How the waterfall works
+
+On every `ensureAuthenticated()`:
+
+1. **Proactive silent** (on mount): each configured native provider is
+   asked for an auto-select credential. No UI. If one succeeds the
+   runtime exchanges the ID token via RFC 8693 token-exchange and
+   transitions to `authenticated`.
+2. **Interactive** (on sign-in click): for each provider in order, the
+   runtime calls `attemptInteractive`. The first `Ok` outcome is
+   exchanged via token-exchange.
+3. **OAuth2 fallback**: if every native provider returns `Cancelled`,
+   `NoSession`, `Unavailable`, or `ErrorOutcome`, the runtime opens
+   the system browser via `flutter_appauth` exactly as in v0.1.
+
+### Consumer setup
+
+```dart
+import 'dart:io';
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+
+final providers = <NativeCredentialProvider>[
+  if (Platform.isIOS || Platform.isMacOS) AppleCredentialProvider(),
+  GoogleCredentialProvider(serverClientId: googleServerClientId),
+];
+
+final runtime = createAuthRuntime(cfg, nativeProviders: providers);
+```
+
+With Riverpod, also override `authNativeProvidersProvider` so widgets
+can render platform-aware sign-in buttons:
+
+```dart
+ProviderScope(
+  overrides: [
+    authNativeProvidersProvider.overrideWithValue(providers),
+    authRuntimeProvider.overrideWithValue(runtime),
+  ],
+  child: const MyApp(),
+);
+```
+
+### Platform requirements
+
+**iOS**
+
+- Enable the "Sign In with Apple" capability for your target in Xcode
+  (`Signing & Capabilities` → `+ Capability`).
+- The Bundle ID must match the one registered at
+  [developer.apple.com](https://developer.apple.com) under your
+  services ID.
+- Minimum deployment target iOS 13.
+
+**Android**
+
+- Create a Google OAuth client in Google Cloud Console of type
+  "Android" and record the **server client ID** (type "Web
+  application") — the latter is what you pass to
+  `GoogleCredentialProvider(serverClientId: …)`.
+- Register the app's SHA-256 fingerprint on the Android OAuth client.
+- `android/app/build.gradle` must have `minSdkVersion >= 23`
+  (Credential Manager requirement).
+- No `google-services.json` is required: the Credential-Manager-backed
+  `google_sign_in` v7 flow does not use Firebase.
+
+**macOS**
+
+- Same Apple developer configuration as iOS.
+- Add the Sign in with Apple entitlement in both
+  `macos/Runner/DebugProfile.entitlements` and
+  `macos/Runner/Release.entitlements`:
+
+  ```xml
+  <key>com.apple.developer.applesignin</key>
+  <array>
+    <string>Default</string>
+  </array>
+  ```
+
+### Failure-mode table
+
+| `NativeCredentialOutcome`        | Effect                                                                    |
+|----------------------------------|---------------------------------------------------------------------------|
+| `Ok(result)`                     | ID token exchanged via RFC 8693; runtime transitions to `authenticated`.  |
+| `Cancelled()`                    | User dismissed the native sheet. Runtime falls through to the next provider, then OAuth2. |
+| `NoSession()`                    | Silent attempt found no credential. Waterfall moves on.                   |
+| `Unavailable(reason)`            | Provider cannot run on this platform / OS version. Waterfall moves on.    |
+| `ErrorOutcome(AuthError)`        | Recorded as a `CredentialOutcomeEvent`; waterfall moves on.               |
+
+The `credentialEventStream` emits probe / silent / interactive / outcome
+/ sign-out events for telemetry; subscribe in debug builds to observe
+the waterfall in action.
+
+### Backend requirements
+
+The authentication service (Ory Hydra or equivalent) must accept the
+RFC 8693 `urn:ietf:params:oauth:grant-type:token-exchange` grant and
+treat Apple / Google as trusted subject issuers. See
+[docs/auth-runtime-native-credentials.md](../../docs/auth-runtime-native-credentials.md)
+for the operator-side configuration guide.
+
 ## Quick start (Riverpod — preferred)
 
 ```dart
@@ -158,6 +277,7 @@ All widgets honour the Material `ThemeData` of the surrounding app.
 | `userClaimsProvider` | `FutureProvider<UserClaims>` | ID token claims, wrapped for convenient access. |
 | `rolesProvider` | `FutureProvider<List<String>>` | Roles extracted from the access token. |
 | `securityEventsProvider` | `StreamProvider<SecurityEvent>` | Security signals (`refreshReuseDetected`, `storageCorruption`, …). |
+| `authNativeProvidersProvider` | `Provider<List<NativeCredentialProvider>>` | Configured native credential providers. Defaults to `[]`; override at app root alongside `authRuntimeProvider`. |
 
 ## Security posture
 

--- a/ui/runtime/lib/antinvestor_auth_runtime.dart
+++ b/ui/runtime/lib/antinvestor_auth_runtime.dart
@@ -46,6 +46,7 @@ export 'src/models/token_set.dart' show TokenSet, TokenType;
 export 'src/models/user_claims.dart' show UserClaims;
 export 'src/providers/auth_providers.dart'
     show
+        authNativeProvidersProvider,
         authRuntimeProvider,
         authStateProvider,
         isAuthenticatedProvider,

--- a/ui/runtime/lib/antinvestor_auth_runtime.dart
+++ b/ui/runtime/lib/antinvestor_auth_runtime.dart
@@ -8,6 +8,29 @@ library;
 
 export 'src/auth_runtime.dart' show AuthRuntime, authRuntimeVersion;
 export 'src/config/auth_config.dart' show AuthConfig;
+export 'src/credentials/apple_credential_provider.dart'
+    show AppleCredentialProvider, SignInWithAppleAdapter;
+export 'src/credentials/credential_event.dart'
+    show
+        CredentialEvent,
+        CredentialInteractiveAttemptEvent,
+        CredentialOutcomeEvent,
+        CredentialProbeEvent,
+        CredentialSignOutEvent,
+        CredentialSilentAttemptEvent;
+export 'src/credentials/google_credential_provider.dart'
+    show GoogleCredentialProvider, GoogleSignInAdapter;
+export 'src/credentials/native_credential.dart'
+    show
+        Cancelled,
+        ErrorOutcome,
+        NativeCredentialOutcome,
+        NativeCredentialProvider,
+        NativeCredentialProviderKind,
+        NativeCredentialResult,
+        NoSession,
+        Ok,
+        Unavailable;
 export 'src/errors/auth_error.dart' show AuthError, AuthErrorCode;
 export 'src/factory.dart' show createAuthRuntime;
 export 'src/models/api_response.dart' show ApiResponse;

--- a/ui/runtime/lib/src/auth_runtime.dart
+++ b/ui/runtime/lib/src/auth_runtime.dart
@@ -98,4 +98,4 @@ abstract class AuthRuntime {
 /// Version of the runtime. Callers include this in telemetry / bug
 /// reports. Kept as a bare constant for now; wired through
 /// `--dart-define=AUTH_RUNTIME_VERSION=...` in a follow-up task.
-const String authRuntimeVersion = '0.1.0';
+const String authRuntimeVersion = '0.2.0';

--- a/ui/runtime/lib/src/auth_runtime.dart
+++ b/ui/runtime/lib/src/auth_runtime.dart
@@ -1,3 +1,5 @@
+import 'package:antinvestor_auth_runtime/src/credentials/credential_event.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
 import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
@@ -68,6 +70,18 @@ abstract class AuthRuntime {
 
   /// Synchronous snapshot of [authStateStream]'s latest value.
   AuthState get state;
+
+  /// Set of native credential providers advertised as currently available
+  /// on this platform. Callers use this to decide whether to render a
+  /// "Continue with Apple/Google" button; the runtime additionally
+  /// attempts a proactive silent sign-in on each available provider when
+  /// [AuthState] settles in `unauthenticated`.
+  Future<Set<NativeCredentialProviderKind>> availableNativeProviders();
+
+  /// Fine-grained stream of native-credential lifecycle events (probe,
+  /// silent attempt, interactive attempt, outcome, sign-out). Independent
+  /// of [authStateStream] — useful for telemetry and debug UIs.
+  Stream<CredentialEvent> get credentialEventStream;
 
   /// Warms the OIDC discovery cache. Optional — but reduces perceived
   /// latency on the first sign-in when called from app startup.

--- a/ui/runtime/lib/src/auth_runtime_impl.dart
+++ b/ui/runtime/lib/src/auth_runtime_impl.dart
@@ -95,6 +95,9 @@ class AuthRuntimeImpl implements AuthRuntime {
     if (next != AuthState.unauthenticated) return;
     if (_proactiveSilentAttempted) return;
     if (_proactiveSilentScheduled) return;
+    // An explicit ensureAuthenticated() is already running — let it drive
+    // the waterfall rather than racing a silent attempt onto the worker.
+    if (_inflightEnsureAuthenticated != null) return;
     _proactiveSilentScheduled = true;
     scheduleMicrotask(_proactiveSilentAttempt);
   }

--- a/ui/runtime/lib/src/auth_runtime_impl.dart
+++ b/ui/runtime/lib/src/auth_runtime_impl.dart
@@ -320,7 +320,13 @@ class AuthRuntimeImpl implements AuthRuntime {
       }
       _emitCredentialEvent(CredentialEvent.signOut(p.kind));
     }
-    await worker.logout();
+    try {
+      await worker.logout();
+    } catch (_) {
+      // worker.logout() already wipes local state on failure internally;
+      // swallow so the documented "logout always clears local state"
+      // contract is honoured from the caller's perspective.
+    }
   }
 
   @override

--- a/ui/runtime/lib/src/auth_runtime_impl.dart
+++ b/ui/runtime/lib/src/auth_runtime_impl.dart
@@ -1,7 +1,11 @@
 import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
 
 import 'package:antinvestor_auth_runtime/src/auth_runtime.dart';
 import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/credential_event.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
 import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
@@ -31,19 +35,126 @@ class AuthRuntimeImpl implements AuthRuntime {
     required this.config,
     required this.worker,
     required this.oauthFlow,
-  });
+    List<NativeCredentialProvider> nativeProviders = const [],
+    Random? random,
+  })  : _nativeProviders = List<NativeCredentialProvider>.unmodifiable(
+          nativeProviders,
+        ),
+        _random = random ?? Random.secure(),
+        _credentialController =
+            StreamController<CredentialEvent>.broadcast() {
+    if (_nativeProviders.isNotEmpty) {
+      _authStateSub = worker.authStateStream.listen(_onAuthStateChanged);
+    }
+  }
 
   final ResolvedConfig config;
   final TokenWorker worker;
   final OAuthFlow oauthFlow;
+  final List<NativeCredentialProvider> _nativeProviders;
+  final Random _random;
+  final StreamController<CredentialEvent> _credentialController;
 
   bool _disposed = false;
+  bool _proactiveSilentScheduled = false;
+  bool _proactiveSilentAttempted = false;
   Future<void>? _initFuture;
   Future<void>? _inflightEnsureAuthenticated;
+  StreamSubscription<AuthState>? _authStateSub;
 
   /// Kicks off the worker's initial reload. Idempotent: every caller
   /// awaits the same future so first-use races settle correctly.
-  Future<void> init() => _initFuture ??= worker.init();
+  Future<void> init() => _initFuture ??= _runInit();
+
+  Future<void> _runInit() async {
+    // Probe providers in parallel before the worker settles so callers
+    // subscribing to [credentialEventStream] receive availability hints
+    // without blocking the main init path.
+    unawaited(_probeProviders());
+    await worker.init();
+  }
+
+  Future<void> _probeProviders() async {
+    for (final p in _nativeProviders) {
+      try {
+        final avail = await p.isAvailable();
+        _emitCredentialEvent(CredentialEvent.probe(
+          kind: p.kind,
+          available: avail,
+        ));
+      } catch (_) {
+        _emitCredentialEvent(CredentialEvent.probe(
+          kind: p.kind,
+          available: false,
+        ));
+      }
+    }
+  }
+
+  void _onAuthStateChanged(AuthState next) {
+    if (next != AuthState.unauthenticated) return;
+    if (_proactiveSilentAttempted) return;
+    if (_proactiveSilentScheduled) return;
+    _proactiveSilentScheduled = true;
+    scheduleMicrotask(_proactiveSilentAttempt);
+  }
+
+  Future<void> _proactiveSilentAttempt() async {
+    // Mark as attempted before running so a synchronous failure that
+    // bounces state back to unauthenticated doesn't re-enter.
+    _proactiveSilentAttempted = true;
+    try {
+      for (final p in _nativeProviders) {
+        if (_disposed) return;
+        if (worker.state == AuthState.authenticated) return;
+        bool available;
+        try {
+          available = await p.isAvailable();
+        } catch (_) {
+          available = false;
+        }
+        if (!available) continue;
+
+        final nonce = generateNonce();
+        _emitCredentialEvent(CredentialEvent.silentAttempt(p.kind));
+        NativeCredentialOutcome outcome;
+        try {
+          outcome = await p.attemptSilent(nonce: nonce);
+        } catch (_) {
+          outcome = const NativeCredentialOutcome.noSession();
+        }
+        _emitCredentialEvent(CredentialEvent.outcome(p.kind, outcome));
+
+        if (outcome is Ok) {
+          try {
+            await worker.completeNativeCredential(
+              credential: outcome.result,
+              expectedNonce: nonce,
+            );
+            return;
+          } catch (_) {
+            // Fall through to next provider.
+          }
+        }
+      }
+    } finally {
+      _proactiveSilentScheduled = false;
+    }
+  }
+
+  void _emitCredentialEvent(CredentialEvent event) {
+    if (!_credentialController.isClosed) {
+      _credentialController.add(event);
+    }
+  }
+
+  /// Generates a 16-byte cryptographically random nonce, base64url-encoded
+  /// without padding. Seeded from [Random.secure] unless overridden at
+  /// construction — tests inject a deterministic [Random].
+  String generateNonce() {
+    final bytes = List<int>.generate(16, (_) => _random.nextInt(256));
+    return base64Url.encode(bytes).replaceAll('=', '');
+  }
 
   @override
   Future<void> ensureAuthenticated() async {
@@ -56,13 +167,62 @@ class AuthRuntimeImpl implements AuthRuntime {
     final inflight = _inflightEnsureAuthenticated;
     if (inflight != null) return inflight;
 
-    final future = _startOAuthFlow();
+    final future = _runWaterfall();
     _inflightEnsureAuthenticated = future;
     try {
       await future;
     } finally {
       _inflightEnsureAuthenticated = null;
     }
+  }
+
+  /// Native → OAuth2 waterfall.
+  ///
+  /// For each configured [NativeCredentialProvider], attempts an
+  /// interactive sign-in; on `ok` exchanges the ID token via
+  /// [TokenWorker.completeNativeCredential]. All other outcomes (cancel,
+  /// noSession, unavailable, error) move on to the next provider. When
+  /// every native provider has been exhausted, falls through to the
+  /// existing OAuth2 popup path.
+  Future<void> _runWaterfall() async {
+    for (final p in _nativeProviders) {
+      if (worker.state == AuthState.authenticated) return;
+      bool available;
+      try {
+        available = await p.isAvailable();
+      } catch (_) {
+        available = false;
+      }
+      if (!available) continue;
+
+      final nonce = generateNonce();
+      _emitCredentialEvent(CredentialEvent.interactiveAttempt(p.kind));
+      NativeCredentialOutcome outcome;
+      try {
+        outcome = await p.attemptInteractive(nonce: nonce);
+      } catch (_) {
+        // Provider threw unexpectedly — treat as unavailable and move on.
+        outcome = const NativeCredentialOutcome.unavailable(
+          'provider threw unexpectedly',
+        );
+      }
+      _emitCredentialEvent(CredentialEvent.outcome(p.kind, outcome));
+
+      if (outcome is Ok) {
+        try {
+          await worker.completeNativeCredential(
+            credential: outcome.result,
+            expectedNonce: nonce,
+          );
+          return;
+        } catch (_) {
+          // Exchange failed — fall through to the next provider / OAuth2.
+        }
+      }
+      // Cancelled / NoSession / Unavailable / ErrorOutcome → fall through.
+    }
+
+    await _startOAuthFlow();
   }
 
   Future<void> _startOAuthFlow() async {
@@ -138,8 +298,37 @@ class AuthRuntimeImpl implements AuthRuntime {
   @override
   Future<void> logout() async {
     _ensureAlive();
+    // Best-effort native sign-out first so the provider's session is
+    // cleared even if the subsequent local wipe fails. Errors from any
+    // single provider never block the remainder.
+    for (final p in _nativeProviders) {
+      try {
+        await p.signOut();
+      } catch (_) {
+        // Best-effort only.
+      }
+      _emitCredentialEvent(CredentialEvent.signOut(p.kind));
+    }
     await worker.logout();
   }
+
+  @override
+  Future<Set<NativeCredentialProviderKind>> availableNativeProviders() async {
+    _ensureAlive();
+    final out = <NativeCredentialProviderKind>{};
+    for (final p in _nativeProviders) {
+      try {
+        if (await p.isAvailable()) out.add(p.kind);
+      } catch (_) {
+        // Skip providers that error out during probe.
+      }
+    }
+    return out;
+  }
+
+  @override
+  Stream<CredentialEvent> get credentialEventStream =>
+      _credentialController.stream;
 
   @override
   Stream<AuthState> get authStateStream => worker.authStateStream;
@@ -169,6 +358,9 @@ class AuthRuntimeImpl implements AuthRuntime {
   Future<void> dispose() async {
     if (_disposed) return;
     _disposed = true;
+    await _authStateSub?.cancel();
+    _authStateSub = null;
+    await _credentialController.close();
     await worker.destroy();
   }
 

--- a/ui/runtime/lib/src/auth_runtime_impl.dart
+++ b/ui/runtime/lib/src/auth_runtime_impl.dart
@@ -116,9 +116,11 @@ class AuthRuntimeImpl implements AuthRuntime {
         } catch (_) {
           available = false;
         }
+        if (_disposed) return;
         if (!available) continue;
 
         final nonce = generateNonce();
+        if (_disposed) return;
         _emitCredentialEvent(CredentialEvent.silentAttempt(p.kind));
         NativeCredentialOutcome outcome;
         try {
@@ -126,14 +128,20 @@ class AuthRuntimeImpl implements AuthRuntime {
         } catch (_) {
           outcome = const NativeCredentialOutcome.noSession();
         }
+        if (_disposed) return;
         _emitCredentialEvent(CredentialEvent.outcome(p.kind, outcome));
 
         if (outcome is Ok) {
+          if (_disposed) return;
           try {
             await worker.completeNativeCredential(
               credential: outcome.result,
               expectedNonce: nonce,
             );
+            return;
+          } on StateError {
+            // Worker was destroyed mid-flight (dispose() ran). Treat as
+            // a clean shutdown, not an unhandled error.
             return;
           } catch (_) {
             // Fall through to next provider.

--- a/ui/runtime/lib/src/credentials/apple_credential_provider.dart
+++ b/ui/runtime/lib/src/credentials/apple_credential_provider.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:crypto/crypto.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+
+/// Thin seam over the `sign_in_with_apple` static API so that tests can
+/// inject a fake. Exposes only the calls the runtime actually uses.
+abstract class SignInWithAppleAdapter {
+  const SignInWithAppleAdapter();
+
+  /// Default adapter backed by the real `SignInWithApple` static methods.
+  const factory SignInWithAppleAdapter.defaultAdapter() =
+      _RealSignInWithAppleAdapter;
+
+  Future<bool> isAvailable();
+
+  Future<AuthorizationCredentialAppleID> getAppleIDCredential({
+    required List<AppleIDAuthorizationScopes> scopes,
+    String? nonce,
+  });
+}
+
+class _RealSignInWithAppleAdapter extends SignInWithAppleAdapter {
+  const _RealSignInWithAppleAdapter();
+
+  @override
+  Future<bool> isAvailable() => SignInWithApple.isAvailable();
+
+  @override
+  Future<AuthorizationCredentialAppleID> getAppleIDCredential({
+    required List<AppleIDAuthorizationScopes> scopes,
+    String? nonce,
+  }) =>
+      SignInWithApple.getAppleIDCredential(scopes: scopes, nonce: nonce);
+}
+
+/// [NativeCredentialProvider] implementation backed by Sign in with Apple.
+///
+/// Apple's SDK has no silent / auto-select API — an ID token is only
+/// issued after an explicit user gesture. Consequently
+/// [attemptSilent] always returns `noSession()`. Callers should invoke
+/// [attemptInteractive] from a button press handler.
+///
+/// Apple requires the `nonce` sent in the authorization request to be
+/// the SHA-256 hash of the raw nonce that will be verified on the
+/// server. We compute that hash here so callers only ever deal in the
+/// raw runtime-generated nonce.
+class AppleCredentialProvider implements NativeCredentialProvider {
+  AppleCredentialProvider({SignInWithAppleAdapter? adapter})
+      : _adapter = adapter ?? const SignInWithAppleAdapter.defaultAdapter();
+
+  final SignInWithAppleAdapter _adapter;
+
+  @override
+  NativeCredentialProviderKind get kind => NativeCredentialProviderKind.apple;
+
+  @override
+  Future<bool> isAvailable() => _adapter.isAvailable();
+
+  /// Apple requires an explicit user gesture; silent attempts are not
+  /// supported. Use [attemptInteractive] from a button handler.
+  @override
+  Future<NativeCredentialOutcome> attemptSilent({required String nonce}) async {
+    return const NativeCredentialOutcome.noSession();
+  }
+
+  @override
+  Future<NativeCredentialOutcome> attemptInteractive({
+    required String nonce,
+  }) async {
+    final hashedNonce = sha256.convert(utf8.encode(nonce)).toString();
+    try {
+      final credential = await _adapter.getAppleIDCredential(
+        scopes: const [
+          AppleIDAuthorizationScopes.email,
+          AppleIDAuthorizationScopes.fullName,
+        ],
+        nonce: hashedNonce,
+      );
+
+      final idToken = credential.identityToken;
+      if (idToken == null) {
+        return NativeCredentialOutcome.error(
+          AuthError(
+            AuthErrorCode.nativeCredentialUnavailable,
+            'Apple returned no identityToken',
+          ),
+        );
+      }
+
+      return NativeCredentialOutcome.ok(
+        NativeCredentialResult(
+          provider: NativeCredentialProviderKind.apple,
+          idToken: idToken,
+          authorizationCode: credential.authorizationCode,
+          nonce: nonce,
+          autoSelected: false,
+        ),
+      );
+    } on SignInWithAppleAuthorizationException catch (e) {
+      if (e.code == AuthorizationErrorCode.canceled) {
+        return const NativeCredentialOutcome.cancelled();
+      }
+      return NativeCredentialOutcome.error(
+        AuthError(
+          AuthErrorCode.nativeCredentialUnavailable,
+          'Sign in with Apple failed: ${e.code.name} (${e.message})',
+          cause: e,
+        ),
+      );
+    } catch (e) {
+      return NativeCredentialOutcome.error(
+        AuthError(
+          AuthErrorCode.nativeCredentialExchangeFailed,
+          'Sign in with Apple threw: $e',
+          cause: e,
+        ),
+      );
+    }
+  }
+
+  /// No-op — Apple's session lives at the IdP, there is nothing local to
+  /// clear.
+  @override
+  Future<void> signOut() async {}
+}

--- a/ui/runtime/lib/src/credentials/apple_credential_provider.dart
+++ b/ui/runtime/lib/src/credentials/apple_credential_provider.dart
@@ -100,16 +100,36 @@ class AppleCredentialProvider implements NativeCredentialProvider {
         ),
       );
     } on SignInWithAppleAuthorizationException catch (e) {
-      if (e.code == AuthorizationErrorCode.canceled) {
-        return const NativeCredentialOutcome.cancelled();
+      // Split taxonomy so callers can distinguish "user bailed" from
+      // "this device / install can't do Sign in with Apple right now"
+      // from "it broke and we don't know why":
+      //   canceled                          → Cancelled()
+      //   notHandled | unknown              → Unavailable error
+      //   failed | invalidResponse | other  → ExchangeFailed error
+      switch (e.code) {
+        case AuthorizationErrorCode.canceled:
+          return const NativeCredentialOutcome.cancelled();
+        case AuthorizationErrorCode.notHandled:
+        case AuthorizationErrorCode.unknown:
+          return NativeCredentialOutcome.error(
+            AuthError(
+              AuthErrorCode.nativeCredentialUnavailable,
+              'Sign in with Apple unavailable: ${e.code.name} (${e.message})',
+              cause: e,
+            ),
+          );
+        case AuthorizationErrorCode.failed:
+        case AuthorizationErrorCode.invalidResponse:
+        // ignore: no_default_cases
+        default:
+          return NativeCredentialOutcome.error(
+            AuthError(
+              AuthErrorCode.nativeCredentialExchangeFailed,
+              'Sign in with Apple failed: ${e.code.name} (${e.message})',
+              cause: e,
+            ),
+          );
       }
-      return NativeCredentialOutcome.error(
-        AuthError(
-          AuthErrorCode.nativeCredentialUnavailable,
-          'Sign in with Apple failed: ${e.code.name} (${e.message})',
-          cause: e,
-        ),
-      );
     } catch (e) {
       return NativeCredentialOutcome.error(
         AuthError(

--- a/ui/runtime/lib/src/credentials/credential_event.dart
+++ b/ui/runtime/lib/src/credentials/credential_event.dart
@@ -1,0 +1,72 @@
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
+
+/// Runtime-level signal surfaced on [AuthRuntime.credentialEventStream].
+///
+/// Lets apps observe the native-credential waterfall (probe → silent
+/// attempt → interactive attempt → outcome → sign-out) for telemetry and
+/// lifecycle hooks, independent of the coarser [AuthState] stream.
+sealed class CredentialEvent {
+  const CredentialEvent();
+
+  const factory CredentialEvent.probe({
+    required NativeCredentialProviderKind kind,
+    required bool available,
+  }) = CredentialProbeEvent;
+
+  const factory CredentialEvent.silentAttempt(
+    NativeCredentialProviderKind kind,
+  ) = CredentialSilentAttemptEvent;
+
+  const factory CredentialEvent.interactiveAttempt(
+    NativeCredentialProviderKind kind,
+  ) = CredentialInteractiveAttemptEvent;
+
+  const factory CredentialEvent.outcome(
+    NativeCredentialProviderKind kind,
+    NativeCredentialOutcome outcome,
+  ) = CredentialOutcomeEvent;
+
+  const factory CredentialEvent.signOut(
+    NativeCredentialProviderKind kind,
+  ) = CredentialSignOutEvent;
+
+  /// Which provider this event concerns.
+  NativeCredentialProviderKind get kind;
+}
+
+final class CredentialProbeEvent extends CredentialEvent {
+  const CredentialProbeEvent({required this.kind, required this.available});
+
+  @override
+  final NativeCredentialProviderKind kind;
+  final bool available;
+}
+
+final class CredentialSilentAttemptEvent extends CredentialEvent {
+  const CredentialSilentAttemptEvent(this.kind);
+
+  @override
+  final NativeCredentialProviderKind kind;
+}
+
+final class CredentialInteractiveAttemptEvent extends CredentialEvent {
+  const CredentialInteractiveAttemptEvent(this.kind);
+
+  @override
+  final NativeCredentialProviderKind kind;
+}
+
+final class CredentialOutcomeEvent extends CredentialEvent {
+  const CredentialOutcomeEvent(this.kind, this.outcome);
+
+  @override
+  final NativeCredentialProviderKind kind;
+  final NativeCredentialOutcome outcome;
+}
+
+final class CredentialSignOutEvent extends CredentialEvent {
+  const CredentialSignOutEvent(this.kind);
+
+  @override
+  final NativeCredentialProviderKind kind;
+}

--- a/ui/runtime/lib/src/credentials/google_credential_provider.dart
+++ b/ui/runtime/lib/src/credentials/google_credential_provider.dart
@@ -1,0 +1,207 @@
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+
+/// Minimal view of a google_sign_in account — only the fields the runtime
+/// reads. Keeps the adapter / tests from depending on the full
+/// [GoogleSignInAccount] surface.
+abstract class GoogleSignInAccountView {
+  String? get idToken;
+}
+
+class _AccountView implements GoogleSignInAccountView {
+  _AccountView(this._account);
+
+  final GoogleSignInAccount _account;
+
+  @override
+  String? get idToken => _account.authentication.idToken;
+}
+
+/// Thin seam over the `google_sign_in` v7 API.
+///
+/// The v7 SDK binds the OIDC `nonce` at `initialize()` time (not per
+/// authenticate call). Because the runtime rotates the nonce per sign-in
+/// attempt, the default adapter re-invokes `initialize()` with the new
+/// nonce on every attempt. This is intentionally hidden behind the
+/// adapter so provider logic doesn't have to care about the SDK's
+/// lifecycle quirk.
+abstract class GoogleSignInAdapter {
+  const GoogleSignInAdapter();
+
+  /// Default adapter backed by `GoogleSignIn.instance`.
+  const factory GoogleSignInAdapter.defaultAdapter() =
+      _RealGoogleSignInAdapter;
+
+  Future<void> initialize({
+    required String serverClientId,
+    required String nonce,
+  });
+
+  /// Returns `null` if there is no cached session; throws
+  /// [GoogleSignInException] for failures.
+  Future<GoogleSignInAccountView?> attemptLightweightAuthentication();
+
+  Future<GoogleSignInAccountView> authenticate({
+    List<String> scopeHint = const <String>[],
+  });
+
+  Future<void> signOut();
+}
+
+class _RealGoogleSignInAdapter extends GoogleSignInAdapter {
+  const _RealGoogleSignInAdapter();
+
+  @override
+  Future<void> initialize({
+    required String serverClientId,
+    required String nonce,
+  }) =>
+      GoogleSignIn.instance.initialize(
+        serverClientId: serverClientId,
+        nonce: nonce,
+      );
+
+  @override
+  Future<GoogleSignInAccountView?>
+      attemptLightweightAuthentication() async {
+    final future = GoogleSignIn.instance.attemptLightweightAuthentication();
+    if (future == null) {
+      // The SDK returns null synchronously on platforms (e.g. FedCM on
+      // web) where lightweight auth is push-based through
+      // `authenticationEvents`. In this mode there is nothing to await,
+      // so we surface it as "no session" from a silent attempt — the
+      // worker will still fall through to the web flow.
+      return null;
+    }
+    final account = await future;
+    if (account == null) return null;
+    return _AccountView(account);
+  }
+
+  @override
+  Future<GoogleSignInAccountView> authenticate({
+    List<String> scopeHint = const <String>[],
+  }) async {
+    final account = await GoogleSignIn.instance.authenticate(
+      scopeHint: scopeHint,
+    );
+    return _AccountView(account);
+  }
+
+  @override
+  Future<void> signOut() => GoogleSignIn.instance.signOut();
+}
+
+/// [NativeCredentialProvider] backed by `google_sign_in` v7. On Android
+/// this is the Credential Manager / One Tap flow.
+class GoogleCredentialProvider implements NativeCredentialProvider {
+  GoogleCredentialProvider({
+    required String serverClientId,
+    GoogleSignInAdapter? adapter,
+  })  : _serverClientId = serverClientId,
+        _adapter = adapter ?? const GoogleSignInAdapter.defaultAdapter();
+
+  final String _serverClientId;
+  final GoogleSignInAdapter _adapter;
+
+  @override
+  NativeCredentialProviderKind get kind => NativeCredentialProviderKind.google;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Future<NativeCredentialOutcome> attemptSilent({
+    required String nonce,
+  }) async {
+    try {
+      await _adapter.initialize(
+        serverClientId: _serverClientId,
+        nonce: nonce,
+      );
+      final account = await _adapter.attemptLightweightAuthentication();
+      if (account == null) {
+        return const NativeCredentialOutcome.noSession();
+      }
+      return _buildOk(account, nonce: nonce, autoSelected: true);
+    } on GoogleSignInException catch (e) {
+      return NativeCredentialOutcome.error(
+        AuthError(
+          AuthErrorCode.nativeCredentialExchangeFailed,
+          'Google silent sign-in failed: ${e.code.name} (${e.description})',
+          cause: e,
+        ),
+      );
+    } catch (e) {
+      return NativeCredentialOutcome.error(
+        AuthError(
+          AuthErrorCode.nativeCredentialExchangeFailed,
+          'Google silent sign-in threw: $e',
+          cause: e,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<NativeCredentialOutcome> attemptInteractive({
+    required String nonce,
+  }) async {
+    try {
+      await _adapter.initialize(
+        serverClientId: _serverClientId,
+        nonce: nonce,
+      );
+      final account =
+          await _adapter.authenticate(scopeHint: const <String>['openid']);
+      return _buildOk(account, nonce: nonce, autoSelected: false);
+    } on GoogleSignInException catch (e) {
+      if (e.code == GoogleSignInExceptionCode.canceled) {
+        return const NativeCredentialOutcome.cancelled();
+      }
+      return NativeCredentialOutcome.error(
+        AuthError(
+          AuthErrorCode.nativeCredentialExchangeFailed,
+          'Google sign-in failed: ${e.code.name} (${e.description})',
+          cause: e,
+        ),
+      );
+    } catch (e) {
+      return NativeCredentialOutcome.error(
+        AuthError(
+          AuthErrorCode.nativeCredentialExchangeFailed,
+          'Google sign-in threw: $e',
+          cause: e,
+        ),
+      );
+    }
+  }
+
+  @override
+  Future<void> signOut() => _adapter.signOut();
+
+  NativeCredentialOutcome _buildOk(
+    GoogleSignInAccountView account, {
+    required String nonce,
+    required bool autoSelected,
+  }) {
+    final idToken = account.idToken;
+    if (idToken == null) {
+      return NativeCredentialOutcome.error(
+        AuthError(
+          AuthErrorCode.nativeCredentialUnavailable,
+          'Google returned no id_token',
+        ),
+      );
+    }
+    return NativeCredentialOutcome.ok(
+      NativeCredentialResult(
+        provider: NativeCredentialProviderKind.google,
+        idToken: idToken,
+        nonce: nonce,
+        autoSelected: autoSelected,
+      ),
+    );
+  }
+}

--- a/ui/runtime/lib/src/credentials/google_credential_provider.dart
+++ b/ui/runtime/lib/src/credentials/google_credential_provider.dart
@@ -126,13 +126,7 @@ class GoogleCredentialProvider implements NativeCredentialProvider {
       }
       return _buildOk(account, nonce: nonce, autoSelected: true);
     } on GoogleSignInException catch (e) {
-      return NativeCredentialOutcome.error(
-        AuthError(
-          AuthErrorCode.nativeCredentialExchangeFailed,
-          'Google silent sign-in failed: ${e.code.name} (${e.description})',
-          cause: e,
-        ),
-      );
+      return _mapGoogleException(e, interactive: false);
     } catch (e) {
       return NativeCredentialOutcome.error(
         AuthError(
@@ -157,16 +151,7 @@ class GoogleCredentialProvider implements NativeCredentialProvider {
           await _adapter.authenticate(scopeHint: const <String>['openid']);
       return _buildOk(account, nonce: nonce, autoSelected: false);
     } on GoogleSignInException catch (e) {
-      if (e.code == GoogleSignInExceptionCode.canceled) {
-        return const NativeCredentialOutcome.cancelled();
-      }
-      return NativeCredentialOutcome.error(
-        AuthError(
-          AuthErrorCode.nativeCredentialExchangeFailed,
-          'Google sign-in failed: ${e.code.name} (${e.description})',
-          cause: e,
-        ),
-      );
+      return _mapGoogleException(e, interactive: true);
     } catch (e) {
       return NativeCredentialOutcome.error(
         AuthError(
@@ -175,6 +160,51 @@ class GoogleCredentialProvider implements NativeCredentialProvider {
           cause: e,
         ),
       );
+    }
+  }
+
+  /// Maps [GoogleSignInException] codes onto the runtime's outcome
+  /// taxonomy. [interactive] distinguishes a user-driven attempt from a
+  /// silent one so that `canceled` can be reported correctly (interactive:
+  /// user cancelled; silent: just means "no session").
+  ///
+  /// Dispatch:
+  ///   canceled (silent)                                      → NoSession
+  ///   canceled (interactive)                                 → Cancelled
+  ///   uiUnavailable                                          → NoSession
+  ///   clientConfigurationError | providerConfigurationError  → Unavailable
+  ///   interrupted | unknownError | other                     → ExchangeFailed
+  NativeCredentialOutcome _mapGoogleException(
+    GoogleSignInException e, {
+    required bool interactive,
+  }) {
+    switch (e.code) {
+      case GoogleSignInExceptionCode.canceled:
+        return interactive
+            ? const NativeCredentialOutcome.cancelled()
+            : const NativeCredentialOutcome.noSession();
+      case GoogleSignInExceptionCode.uiUnavailable:
+        return const NativeCredentialOutcome.noSession();
+      case GoogleSignInExceptionCode.clientConfigurationError:
+      case GoogleSignInExceptionCode.providerConfigurationError:
+        return NativeCredentialOutcome.error(
+          AuthError(
+            AuthErrorCode.nativeCredentialUnavailable,
+            'Google sign-in unavailable: ${e.code.name} (${e.description})',
+            cause: e,
+          ),
+        );
+      case GoogleSignInExceptionCode.interrupted:
+      case GoogleSignInExceptionCode.unknownError:
+      // ignore: no_default_cases
+      default:
+        return NativeCredentialOutcome.error(
+          AuthError(
+            AuthErrorCode.nativeCredentialExchangeFailed,
+            'Google sign-in failed: ${e.code.name} (${e.description})',
+            cause: e,
+          ),
+        );
     }
   }
 

--- a/ui/runtime/lib/src/credentials/native_credential.dart
+++ b/ui/runtime/lib/src/credentials/native_credential.dart
@@ -1,0 +1,128 @@
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+
+/// Which native credential provider produced a result.
+enum NativeCredentialProviderKind { apple, google }
+
+/// A successful native credential acquisition.
+///
+/// The [idToken] is the signed JWT we will exchange upstream via
+/// `urn:ietf:params:oauth:grant-type:token-exchange` (RFC 8693). The
+/// [nonce] is the original random value the runtime generated and bound
+/// into the request; the worker must verify it matches the `nonce` claim
+/// of the ID token before trusting it.
+///
+/// [authorizationCode] is populated when the native SDK returned a code
+/// (Apple sets this); Google's ID-token flow does not.
+///
+/// [autoSelected] indicates the credential was obtained without any user
+/// interaction (silent / one-tap auto-select). The runtime treats these
+/// differently from interactive sign-ins (e.g. for analytics and for
+/// deciding whether to fall back to the web flow).
+class NativeCredentialResult {
+  const NativeCredentialResult({
+    required this.provider,
+    required this.idToken,
+    required this.autoSelected,
+    this.authorizationCode,
+    this.nonce,
+  });
+
+  final NativeCredentialProviderKind provider;
+  final String idToken;
+  final String? authorizationCode;
+  final String? nonce;
+  final bool autoSelected;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is NativeCredentialResult &&
+          runtimeType == other.runtimeType &&
+          provider == other.provider &&
+          idToken == other.idToken &&
+          authorizationCode == other.authorizationCode &&
+          nonce == other.nonce &&
+          autoSelected == other.autoSelected;
+
+  @override
+  int get hashCode => Object.hash(
+        provider,
+        idToken,
+        authorizationCode,
+        nonce,
+        autoSelected,
+      );
+}
+
+/// Outcome of a native credential attempt.
+///
+/// Sealed so callers (the worker, tests) can switch exhaustively. Mirrors
+/// the [StateInput] pattern elsewhere in the runtime.
+sealed class NativeCredentialOutcome {
+  const NativeCredentialOutcome();
+
+  const factory NativeCredentialOutcome.ok(NativeCredentialResult result) = Ok;
+  const factory NativeCredentialOutcome.noSession() = NoSession;
+  const factory NativeCredentialOutcome.cancelled() = Cancelled;
+  const factory NativeCredentialOutcome.unavailable(String reason) =
+      Unavailable;
+  const factory NativeCredentialOutcome.error(AuthError error) = ErrorOutcome;
+}
+
+final class Ok extends NativeCredentialOutcome {
+  const Ok(this.result);
+
+  final NativeCredentialResult result;
+}
+
+final class NoSession extends NativeCredentialOutcome {
+  const NoSession();
+}
+
+final class Cancelled extends NativeCredentialOutcome {
+  const Cancelled();
+}
+
+final class Unavailable extends NativeCredentialOutcome {
+  const Unavailable(this.reason);
+
+  final String reason;
+}
+
+final class ErrorOutcome extends NativeCredentialOutcome {
+  const ErrorOutcome(this.error);
+
+  final AuthError error;
+}
+
+/// A platform-specific native credential provider (Apple / Google / ...).
+///
+/// Concrete implementations wrap a platform SDK (Sign in with Apple,
+/// google_sign_in / CredentialManager, etc.) and normalise success and
+/// failure modes into a [NativeCredentialOutcome].
+///
+/// Providers must NOT perform any upstream token exchange — they return a
+/// raw IdP ID token; the worker owns the exchange with the authentication
+/// service.
+abstract class NativeCredentialProvider {
+  /// Which provider this is. Used for routing and telemetry.
+  NativeCredentialProviderKind get kind;
+
+  /// Whether the provider can run on this platform right now.
+  ///
+  /// Should be safe to call before any user interaction — e.g. used to
+  /// decide whether to render a "Continue with Apple" button.
+  Future<bool> isAvailable();
+
+  /// Attempt a silent / auto-select sign-in. Must never show UI. Returns
+  /// [NoSession] if there is no existing credential and [Ok] if one was
+  /// obtained without user interaction.
+  Future<NativeCredentialOutcome> attemptSilent({required String nonce});
+
+  /// Attempt an interactive sign-in (shows the native sheet / browser).
+  /// Must be called from a user gesture.
+  Future<NativeCredentialOutcome> attemptInteractive({required String nonce});
+
+  /// Clear any cached session with this provider.
+  Future<void> signOut();
+}

--- a/ui/runtime/lib/src/errors/auth_error.dart
+++ b/ui/runtime/lib/src/errors/auth_error.dart
@@ -49,6 +49,12 @@ enum AuthErrorCode {
   deepLinkMismatch,
   biometricRequired,
   biometricUnavailable,
+
+  // Native credential providers (Apple / Google / CredentialManager)
+  nativeCredentialCancelled,
+  nativeCredentialUnavailable,
+  nativeCredentialIssuerMismatch,
+  nativeCredentialExchangeFailed,
 }
 
 const Set<AuthErrorCode> _nonRetryable = {
@@ -57,6 +63,7 @@ const Set<AuthErrorCode> _nonRetryable = {
   AuthErrorCode.cryptoUnsupported,
   AuthErrorCode.deepLinkMismatch,
   AuthErrorCode.securityWipe,
+  AuthErrorCode.nativeCredentialIssuerMismatch,
 };
 
 /// Non-fatal, structured error raised throughout the runtime.

--- a/ui/runtime/lib/src/factory.dart
+++ b/ui/runtime/lib/src/factory.dart
@@ -4,6 +4,8 @@ import 'package:antinvestor_auth_runtime/src/auth_runtime.dart';
 import 'package:antinvestor_auth_runtime/src/auth_runtime_impl.dart';
 import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
 import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/credential_event.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
@@ -36,6 +38,7 @@ import 'package:antinvestor_auth_runtime/src/worker/token_worker.dart';
 AuthRuntime createAuthRuntime(
   AuthConfig config, {
   bool useIsolate = false,
+  List<NativeCredentialProvider> nativeProviders = const [],
   KeyManager? keyManager,
   RootKeyStore? rootKeyStore,
   TokenStore? tokenStore,
@@ -91,6 +94,7 @@ AuthRuntime createAuthRuntime(
     config: resolved,
     worker: worker,
     oauthFlow: flow,
+    nativeProviders: nativeProviders,
   );
   // Kick off session reload immediately so apps subscribing to
   // `authStateStream` don't miss the first transition while they're
@@ -190,6 +194,16 @@ class _LazyIsolatedAuthRuntime implements AuthRuntime {
 
   @override
   AuthState get state => AuthState.initializing;
+
+  @override
+  Future<Set<NativeCredentialProviderKind>> availableNativeProviders() async =>
+      (await _ready).availableNativeProviders();
+
+  @override
+  Stream<CredentialEvent> get credentialEventStream async* {
+    final rt = await _ready;
+    yield* rt.credentialEventStream;
+  }
 
   @override
   Future<void> prefetchDiscovery() async =>

--- a/ui/runtime/lib/src/isolated_auth_runtime.dart
+++ b/ui/runtime/lib/src/isolated_auth_runtime.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:antinvestor_auth_runtime/src/auth_runtime.dart';
 import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/credential_event.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
 import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
@@ -133,6 +135,18 @@ class IsolatedAuthRuntime implements AuthRuntime {
 
   @override
   AuthState get state => _state;
+
+  @override
+  Future<Set<NativeCredentialProviderKind>> availableNativeProviders() async {
+    _ensureAlive();
+    // Native credential providers run main-isolate-only in v0.2; isolate
+    // shell reports an empty set.
+    return const <NativeCredentialProviderKind>{};
+  }
+
+  @override
+  Stream<CredentialEvent> get credentialEventStream =>
+      const Stream<CredentialEvent>.empty();
 
   @override
   Future<void> prefetchDiscovery() async {

--- a/ui/runtime/lib/src/protocol/api_proxy.dart
+++ b/ui/runtime/lib/src/protocol/api_proxy.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';

--- a/ui/runtime/lib/src/protocol/token_exchange.dart
+++ b/ui/runtime/lib/src/protocol/token_exchange.dart
@@ -72,6 +72,37 @@ class TokenExchange {
     return _parseTokenBody(res.body);
   }
 
+  /// `urn:ietf:params:oauth:grant-type:token-exchange` grant for native
+  /// credentials (RFC 8693).
+  ///
+  /// The runtime presents a provider-issued ID token (Apple / Google)
+  /// with `subject_token_type: id_token`; the IdP verifies the upstream
+  /// signature + audience and mints a Hydra session in exchange. DPoP is
+  /// attached on the same terms as [exchangeCode] so the bound session is
+  /// consistent with every other grant path.
+  Future<TokenSet> exchangeIdToken(
+    ResolvedConfig cfg,
+    DpopContext ctx, {
+    required String subjectToken,
+    required String subjectIssuer,
+  }) async {
+    final form = <String, String>{
+      'grant_type': 'urn:ietf:params:oauth:grant-type:token-exchange',
+      'client_id': cfg.clientId,
+      'subject_token': subjectToken,
+      'subject_token_type': 'urn:ietf:params:oauth:token-type:id_token',
+      'subject_issuer': subjectIssuer,
+    };
+    final res = await _postForm(cfg, ctx, form);
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw AuthError(
+        AuthErrorCode.tokenExchangeFailed,
+        'id-token exchange failed ${res.statusCode} ${_truncate(res.body)}',
+      );
+    }
+    return _parseTokenBody(res.body);
+  }
+
   /// `refresh_token` grant with rotation + reuse-detection semantics.
   Future<RefreshOutcome> refresh(
     ResolvedConfig cfg,

--- a/ui/runtime/lib/src/providers/auth_providers.dart
+++ b/ui/runtime/lib/src/providers/auth_providers.dart
@@ -1,4 +1,5 @@
 import 'package:antinvestor_auth_runtime/src/auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
 import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -77,3 +78,34 @@ final rolesProvider = FutureProvider<List<String>>(
 final securityEventsProvider = StreamProvider<SecurityEvent>(
   (ref) => ref.watch(authRuntimeProvider).securityEventStream,
 );
+
+/// Native credential providers the runtime should consult before falling
+/// back to OAuth2. Defaults to an empty list — the runtime behaves exactly
+/// as in v0.1 when no override is supplied.
+///
+/// Consumers override this provider at the app root alongside
+/// [authRuntimeProvider] with their platform-appropriate mix, e.g.:
+///
+/// ```dart
+/// final providers = <NativeCredentialProvider>[
+///   if (Platform.isIOS || Platform.isMacOS) AppleCredentialProvider(),
+///   GoogleCredentialProvider(serverClientId: googleServerClientId),
+/// ];
+///
+/// ProviderScope(
+///   overrides: [
+///     authNativeProvidersProvider.overrideWithValue(providers),
+///     authRuntimeProvider.overrideWithValue(
+///       createAuthRuntime(cfg, nativeProviders: providers),
+///     ),
+///   ],
+///   child: const MyApp(),
+/// );
+/// ```
+///
+/// Hand the same list to [createAuthRuntime] so the runtime actually
+/// wires them: this provider is a declarative hook (widgets can `watch`
+/// it to render platform-aware sign-in buttons) rather than a back
+/// channel into the runtime.
+final authNativeProvidersProvider =
+    Provider<List<NativeCredentialProvider>>((ref) => const []);

--- a/ui/runtime/lib/src/worker/messages.dart
+++ b/ui/runtime/lib/src/worker/messages.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
 import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
@@ -30,6 +31,8 @@ sealed class WorkerRequest {
       'init' => InitRequest._fromMap(map),
       'prepareAuth' => PrepareAuthRequest._fromMap(map),
       'completeAuth' => CompleteAuthRequest._fromMap(map),
+      'completeNativeCredential' =>
+        CompleteNativeCredentialRequest._fromMap(map),
       'fetch' => FetchRequest._fromMap(map),
       'upload' => UploadRequest._fromMap(map),
       'getRoles' => GetRolesRequest._fromMap(map),
@@ -94,6 +97,61 @@ final class CompleteAuthRequest extends WorkerRequest {
         state: map['state'] as String,
         nonce: map['nonce'] as String,
       );
+}
+
+final class CompleteNativeCredentialRequest extends WorkerRequest {
+  const CompleteNativeCredentialRequest({
+    required super.correlationId,
+    required this.provider,
+    required this.idToken,
+    required this.autoSelected,
+    required this.expectedNonce,
+    this.authorizationCode,
+    this.nonce,
+  });
+
+  final NativeCredentialProviderKind provider;
+  final String idToken;
+  final String? authorizationCode;
+  final String? nonce;
+  final bool autoSelected;
+  final String expectedNonce;
+
+  NativeCredentialResult toResult() => NativeCredentialResult(
+        provider: provider,
+        idToken: idToken,
+        autoSelected: autoSelected,
+        authorizationCode: authorizationCode,
+        nonce: nonce,
+      );
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'completeNativeCredential',
+        _corrId: correlationId,
+        'provider': provider.name,
+        'idToken': idToken,
+        'autoSelected': autoSelected,
+        'expectedNonce': expectedNonce,
+        if (authorizationCode != null) 'authorizationCode': authorizationCode,
+        if (nonce != null) 'nonce': nonce,
+      };
+
+  factory CompleteNativeCredentialRequest._fromMap(Map<String, Object?> map) {
+    final name = map['provider'] as String;
+    final provider = NativeCredentialProviderKind.values.firstWhere(
+      (v) => v.name == name,
+    );
+    return CompleteNativeCredentialRequest(
+      correlationId: map[_corrId] as String,
+      provider: provider,
+      idToken: map['idToken'] as String,
+      autoSelected: map['autoSelected'] as bool,
+      expectedNonce: map['expectedNonce'] as String,
+      authorizationCode: map['authorizationCode'] as String?,
+      nonce: map['nonce'] as String?,
+    );
+  }
 }
 
 final class FetchRequest extends WorkerRequest {
@@ -246,6 +304,8 @@ sealed class WorkerEvent {
       'response' => ResponseEvent._fromMap(map),
       'error' => ErrorEvent._fromMap(map),
       'ok' => OkEvent._fromMap(map),
+      'completeNativeCredentialOk' =>
+        CompleteNativeCredentialOkEvent._fromMap(map),
       'roles' => RolesEvent._fromMap(map),
       'claims' => ClaimsEvent._fromMap(map),
       'securityEvent' => SecurityEventWire._fromMap(map),
@@ -381,6 +441,37 @@ final class OkEvent extends WorkerEvent {
 
   factory OkEvent._fromMap(Map<String, Object?> map) =>
       OkEvent(correlationId: map[_corrId] as String?);
+}
+
+/// Success ack for [CompleteNativeCredentialRequest]. Carries the
+/// [NativeCredentialProviderKind] so the main-isolate side can emit
+/// matching telemetry / credential events after the worker has
+/// transitioned to `authenticated`.
+final class CompleteNativeCredentialOkEvent extends WorkerEvent {
+  const CompleteNativeCredentialOkEvent({
+    required this.provider,
+    super.correlationId,
+  });
+
+  final NativeCredentialProviderKind provider;
+
+  @override
+  Map<String, Object?> toMap() => {
+        _kind: 'completeNativeCredentialOk',
+        _corrId: correlationId,
+        'provider': provider.name,
+      };
+
+  factory CompleteNativeCredentialOkEvent._fromMap(Map<String, Object?> map) {
+    final name = map['provider'] as String;
+    final provider = NativeCredentialProviderKind.values.firstWhere(
+      (v) => v.name == name,
+    );
+    return CompleteNativeCredentialOkEvent(
+      correlationId: map[_corrId] as String?,
+      provider: provider,
+    );
+  }
 }
 
 final class RolesEvent extends WorkerEvent {

--- a/ui/runtime/lib/src/worker/token_worker.dart
+++ b/ui/runtime/lib/src/worker/token_worker.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
 import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
@@ -20,6 +21,7 @@ import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
 import 'package:antinvestor_auth_runtime/src/runtime/refresh_lock.dart';
 import 'package:antinvestor_auth_runtime/src/runtime/state_machine.dart';
 import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
+import 'package:crypto/crypto.dart' as crypto;
 import 'package:http/http.dart' as http;
 
 /// Signature for the injected clock. Default is [DateTime.now].
@@ -292,6 +294,86 @@ class TokenWorker implements TokenProvider {
               cause: err);
       _transition(StateInput.signInFail(ae));
       rethrow;
+    }
+  }
+
+  /// Completes sign-in from a native credential (Apple / Google) by
+  /// exchanging the provider ID token for a Hydra session via RFC 8693
+  /// token-exchange grant.
+  ///
+  /// Pre-exchange guards (see spec §14):
+  ///
+  /// 1. `iss` claim must match the expected issuer for
+  ///    [NativeCredentialResult.provider].
+  /// 2. When the provider surfaced a nonce, the ID token's `nonce` claim
+  ///    must match either [expectedNonce] directly (Google) or
+  ///    `sha256Hex(expectedNonce)` (Apple hashes the nonce before minting).
+  ///
+  /// Guard failures never touch the state machine except to mark a
+  /// failed sign-in; the worker stays `unauthenticated`.
+  Future<void> completeNativeCredential({
+    required NativeCredentialResult credential,
+    required String expectedNonce,
+  }) async {
+    _ensureAlive();
+    _transition(const StateInput.signInStart());
+
+    try {
+      final Map<String, dynamic> claims;
+      try {
+        claims = decodeJwtPayload(credential.idToken);
+      } on FormatException catch (e) {
+        throw AuthError(
+          AuthErrorCode.nativeCredentialExchangeFailed,
+          'native credential id-token is malformed',
+          cause: e,
+        );
+      }
+
+      final expectedIssuer = _expectedIssuer(credential.provider);
+      final actualIssuer = claims['iss'];
+      if (actualIssuer is! String || actualIssuer != expectedIssuer) {
+        throw AuthError(
+          AuthErrorCode.nativeCredentialIssuerMismatch,
+          'iss $actualIssuer does not match expected for '
+          '${credential.provider.name}',
+        );
+      }
+
+      // Nonce binding check. Apple hashes the nonce platform-side so the
+      // token's `nonce` claim is the sha256-hex of the raw value; Google
+      // echoes the raw nonce. Accept either.
+      if (credential.nonce != null) {
+        final actualNonce = claims['nonce'];
+        if (actualNonce is! String ||
+            !_nonceMatches(actualNonce, expectedNonce)) {
+          throw AuthError(
+            AuthErrorCode.nativeCredentialExchangeFailed,
+            'native credential nonce mismatch',
+          );
+        }
+      }
+
+      final ctx = await _ensureDpop();
+      final tokens = await tokenExchange.exchangeIdToken(
+        config,
+        ctx,
+        subjectToken: credential.idToken,
+        subjectIssuer: actualIssuer,
+      );
+      _tokens = tokens;
+      await _persistSession(tokens);
+      _transition(const StateInput.signInDone());
+    } catch (err) {
+      final ae = err is AuthError
+          ? err
+          : AuthError(
+              AuthErrorCode.nativeCredentialExchangeFailed,
+              'native credential exchange failed',
+              cause: err,
+            );
+      _transition(StateInput.signInFail(ae));
+      throw ae;
     }
   }
 
@@ -628,3 +710,18 @@ String _encodeForm(Map<String, String> form) => form.entries
     .map((e) =>
         '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}')
     .join('&');
+
+String _expectedIssuer(NativeCredentialProviderKind kind) {
+  switch (kind) {
+    case NativeCredentialProviderKind.apple:
+      return 'https://appleid.apple.com';
+    case NativeCredentialProviderKind.google:
+      return 'https://accounts.google.com';
+  }
+}
+
+bool _nonceMatches(String actual, String expected) {
+  if (actual == expected) return true;
+  final hashed = crypto.sha256.convert(utf8.encode(expected)).toString();
+  return actual == hashed;
+}

--- a/ui/runtime/lib/src/worker/token_worker.dart
+++ b/ui/runtime/lib/src/worker/token_worker.dart
@@ -305,9 +305,11 @@ class TokenWorker implements TokenProvider {
   ///
   /// 1. `iss` claim must match the expected issuer for
   ///    [NativeCredentialResult.provider].
-  /// 2. When the provider surfaced a nonce, the ID token's `nonce` claim
-  ///    must match either [expectedNonce] directly (Google) or
-  ///    `sha256Hex(expectedNonce)` (Apple hashes the nonce before minting).
+  /// 2. The ID token's `nonce` claim must match either [expectedNonce]
+  ///    directly (Google) or `sha256Hex(expectedNonce)` (Apple hashes the
+  ///    nonce before minting). This check is unconditional — callers
+  ///    always pass an [expectedNonce] and the runtime relies on the bind
+  ///    for replay protection.
   ///
   /// Guard failures never touch the state machine except to mark a
   /// failed sign-in; the worker stays `unauthenticated`.
@@ -342,16 +344,16 @@ class TokenWorker implements TokenProvider {
 
       // Nonce binding check. Apple hashes the nonce platform-side so the
       // token's `nonce` claim is the sha256-hex of the raw value; Google
-      // echoes the raw nonce. Accept either.
-      if (credential.nonce != null) {
-        final actualNonce = claims['nonce'];
-        if (actualNonce is! String ||
-            !_nonceMatches(actualNonce, expectedNonce)) {
-          throw AuthError(
-            AuthErrorCode.nativeCredentialExchangeFailed,
-            'native credential nonce mismatch',
-          );
-        }
+      // echoes the raw nonce. Accept either. The check runs
+      // unconditionally — the runtime always supplies an [expectedNonce]
+      // and replay protection depends on it.
+      final actualNonce = claims['nonce'];
+      if (actualNonce is! String ||
+          !_nonceMatches(actualNonce, expectedNonce)) {
+        throw AuthError(
+          AuthErrorCode.nativeCredentialExchangeFailed,
+          'native credential nonce mismatch',
+        );
       }
 
       final ctx = await _ensureDpop();

--- a/ui/runtime/pubspec.yaml
+++ b/ui/runtime/pubspec.yaml
@@ -35,6 +35,8 @@ dependencies:
   uuid: ^4.5.1
   meta: ^1.15.0
   collection: ^1.18.0
+  sign_in_with_apple: ^6.1.2
+  google_sign_in: ^7.1.1
 
 dev_dependencies:
   flutter_test:

--- a/ui/runtime/pubspec.yaml
+++ b/ui/runtime/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Auth runtime for Antinvestor Flutter apps. OAuth2 + PKCE, adaptive DPoP,
   rotating refresh tokens with reuse detection, Isolate-isolated tokens,
   hardware-backed storage, Riverpod providers, Material widgets.
-version: 0.1.0
+version: 0.2.0
 repository: https://github.com/antinvestor/service-authentication
 homepage: https://github.com/antinvestor/service-authentication/tree/main/ui/runtime
 issue_tracker: https://github.com/antinvestor/service-authentication/issues

--- a/ui/runtime/test/auth_runtime_native_test.dart
+++ b/ui/runtime/test/auth_runtime_native_test.dart
@@ -393,6 +393,36 @@ void main() {
       await h.runtime.dispose();
     });
 
+    test(
+        'ensureAuthenticated called immediately after construction runs '
+        'OAuth exactly once (no proactive-silent race)', () async {
+      // Provider reports unavailable so the waterfall falls straight
+      // through to OAuth. If the proactive-silent microtask were
+      // permitted to race an explicit ensureAuthenticated(), we would
+      // see the OAuth flow invoked more than once or the worker state
+      // thrash; neither should happen.
+      final provider = _StubProvider(
+        kind: NativeCredentialProviderKind.google,
+        availability: false,
+      );
+      final h = _build(providers: [provider]);
+      h.exchange.codeQueue.add(_tokenSet(access: 'oauth-at'));
+
+      // Do NOT await init(); call ensureAuthenticated() straight away.
+      final ensuring = h.runtime.ensureAuthenticated();
+      // Let microtasks settle so any would-be proactive-silent attempt
+      // has a chance to run alongside the in-flight waterfall.
+      for (var i = 0; i < 20; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      await ensuring;
+
+      expect(h.worker.state, AuthState.authenticated);
+      expect(h.oauth.calls, 1);
+      expect(h.exchange.codeCalls, 1);
+      await h.runtime.dispose();
+    });
+
     test('provider throwing in isAvailable does not crash the waterfall',
         () async {
       final bad = _StubProvider(

--- a/ui/runtime/test/auth_runtime_native_test.dart
+++ b/ui/runtime/test/auth_runtime_native_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
@@ -423,6 +424,40 @@ void main() {
       await h.runtime.dispose();
     });
 
+    test(
+        'dispose() while proactive silent is mid-flight does not raise '
+        'unhandled errors', () async {
+      final provider = _BlockingSilentProvider();
+      final h = _build(providers: [provider]);
+
+      await h.runtime.init();
+      // Let the proactive silent microtask spin up and park on the
+      // pending Future inside attemptSilent().
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(provider.silentCalls, 1);
+
+      // Capture any unhandled zone errors.
+      final unhandled = <Object>[];
+      await runZonedGuarded<Future<void>>(
+        () async {
+          await h.runtime.dispose();
+          // Release the provider's pending Future so the microtask
+          // resumes post-dispose. It must exit cleanly.
+          provider.releaseSilent(
+            const NativeCredentialOutcome.noSession(),
+          );
+          for (var i = 0; i < 20; i++) {
+            await Future<void>.delayed(Duration.zero);
+          }
+        },
+        (err, _) => unhandled.add(err),
+      );
+
+      expect(unhandled, isEmpty, reason: 'dispose should be clean');
+    });
+
     test('provider throwing in isAvailable does not crash the waterfall',
         () async {
       final bad = _StubProvider(
@@ -547,3 +582,40 @@ class _NonceEchoingProvider implements NativeCredentialProvider {
   }
 }
 
+/// Provider whose [attemptSilent] blocks on a manually-released Completer,
+/// so tests can inject a dispose() call while the runtime is parked
+/// inside the proactive-silent microtask.
+class _BlockingSilentProvider implements NativeCredentialProvider {
+  final Completer<NativeCredentialOutcome> _gate =
+      Completer<NativeCredentialOutcome>();
+
+  int silentCalls = 0;
+
+  @override
+  NativeCredentialProviderKind get kind =>
+      NativeCredentialProviderKind.google;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Future<NativeCredentialOutcome> attemptSilent({
+    required String nonce,
+  }) {
+    silentCalls++;
+    return _gate.future;
+  }
+
+  @override
+  Future<NativeCredentialOutcome> attemptInteractive({
+    required String nonce,
+  }) async =>
+      const NativeCredentialOutcome.cancelled();
+
+  @override
+  Future<void> signOut() async {}
+
+  void releaseSilent(NativeCredentialOutcome outcome) {
+    if (!_gate.isCompleted) _gate.complete(outcome);
+  }
+}

--- a/ui/runtime/test/auth_runtime_native_test.dart
+++ b/ui/runtime/test/auth_runtime_native_test.dart
@@ -1,0 +1,519 @@
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:antinvestor_auth_runtime/src/auth_runtime_impl.dart';
+import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
+import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
+import 'package:antinvestor_auth_runtime/src/oauth/oauth_flow.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/api_proxy.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/discovery.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/dpop.dart';
+import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
+import 'package:antinvestor_auth_runtime/src/runtime/refresh_lock.dart';
+import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
+import 'package:antinvestor_auth_runtime/src/worker/token_worker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes — copied in spirit from token_worker_test but tuned for
+// AuthRuntimeImpl level scenarios.
+// ---------------------------------------------------------------------------
+
+class _FakeDiscoveryClient implements DiscoveryClient {
+  @override
+  Future<OidcDiscovery> getDiscovery(
+    String idpBaseUrl,
+    Duration timeout,
+  ) async =>
+      OidcDiscovery(
+        issuer: idpBaseUrl,
+        authorizationEndpoint: '$idpBaseUrl/oauth2/auth',
+        tokenEndpoint: '$idpBaseUrl/oauth2/token',
+        endSessionEndpoint: '$idpBaseUrl/oauth2/sessions/logout',
+        revocationEndpoint: '$idpBaseUrl/oauth2/revoke',
+      );
+}
+
+class _FakeTokenExchange extends TokenExchange {
+  _FakeTokenExchange() : super(timeout: const Duration(seconds: 5));
+
+  List<TokenSet> codeQueue = <TokenSet>[];
+  List<TokenSet> idTokenQueue = <TokenSet>[];
+  AuthError? idTokenError;
+  int idTokenCalls = 0;
+  int codeCalls = 0;
+
+  @override
+  Future<TokenSet> exchangeCode(
+    ResolvedConfig cfg,
+    DpopContext ctx, {
+    required String code,
+    required String verifier,
+  }) async {
+    codeCalls++;
+    if (codeQueue.isEmpty) {
+      throw AuthError(AuthErrorCode.tokenExchangeFailed, 'no code queued');
+    }
+    return codeQueue.removeAt(0);
+  }
+
+  @override
+  Future<TokenSet> exchangeIdToken(
+    ResolvedConfig cfg,
+    DpopContext ctx, {
+    required String subjectToken,
+    required String subjectIssuer,
+  }) async {
+    idTokenCalls++;
+    if (idTokenError != null) throw idTokenError!;
+    if (idTokenQueue.isEmpty) {
+      throw AuthError(
+        AuthErrorCode.tokenExchangeFailed,
+        'no id-token queued',
+      );
+    }
+    return idTokenQueue.removeAt(0);
+  }
+}
+
+class _FakeOAuthFlow implements OAuthFlow {
+  _FakeOAuthFlow();
+
+  int calls = 0;
+
+  @override
+  Future<OAuthResult> authorize(ResolvedConfig cfg) async {
+    calls++;
+    return const OAuthResult(
+      code: 'fake-code',
+      verifier: 'fake-verifier',
+      state: null,
+      nonce: null,
+    );
+  }
+}
+
+class _StubProvider implements NativeCredentialProvider {
+  _StubProvider({
+    required this.kind,
+    required this.availability,
+    List<NativeCredentialOutcome> interactiveOutcomes = const <NativeCredentialOutcome>[],
+    this.throwOnAvailable = false,
+  }) : interactiveOutcomes = List<NativeCredentialOutcome>.of(interactiveOutcomes);
+
+  @override
+  final NativeCredentialProviderKind kind;
+  final bool availability;
+  final bool throwOnAvailable;
+  List<NativeCredentialOutcome> interactiveOutcomes;
+
+  int availableCalls = 0;
+  int silentCalls = 0;
+  int interactiveCalls = 0;
+  int signOutCalls = 0;
+
+  @override
+  Future<bool> isAvailable() async {
+    availableCalls++;
+    if (throwOnAvailable) throw StateError('boom');
+    return availability;
+  }
+
+  @override
+  Future<NativeCredentialOutcome> attemptSilent({
+    required String nonce,
+  }) async {
+    silentCalls++;
+    return const NativeCredentialOutcome.noSession();
+  }
+
+  @override
+  Future<NativeCredentialOutcome> attemptInteractive({
+    required String nonce,
+  }) async {
+    interactiveCalls++;
+    if (interactiveOutcomes.isEmpty) {
+      return const NativeCredentialOutcome.cancelled();
+    }
+    return interactiveOutcomes.removeAt(0);
+  }
+
+  @override
+  Future<void> signOut() async {
+    signOutCalls++;
+  }
+}
+
+TokenSet _tokenSet({
+  String access = 'access-tok',
+  String refresh = 'refresh-tok',
+  String? idToken,
+}) =>
+    TokenSet(
+      accessToken: access,
+      refreshToken: refresh,
+      expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+      tokenType: TokenType.bearer,
+      idToken: idToken,
+    );
+
+String _makeJwt(Map<String, dynamic> payload) {
+  String strip(String s) => s.replaceAll('=', '');
+  final header = strip(base64Url.encode(utf8.encode(
+    json.encode(<String, String>{'alg': 'none'}),
+  )));
+  final body = strip(base64Url.encode(utf8.encode(json.encode(payload))));
+  final sig = strip(base64Url.encode(const <int>[1, 2, 3]));
+  return '$header.$body.$sig';
+}
+
+class _Harness {
+  _Harness({
+    required this.runtime,
+    required this.worker,
+    required this.exchange,
+    required this.oauth,
+  });
+
+  final AuthRuntimeImpl runtime;
+  final TokenWorker worker;
+  final _FakeTokenExchange exchange;
+  final _FakeOAuthFlow oauth;
+}
+
+_Harness _build({
+  required List<NativeCredentialProvider> providers,
+}) {
+  final cfg = resolveConfig(const AuthConfig(
+    clientId: 'c',
+    idpBaseUrl: 'https://idp.example.com',
+    apiBaseUrl: 'https://api.example.com',
+    redirectScheme: 'com.example.app',
+  ));
+  final exchange = _FakeTokenExchange();
+  final worker = TokenWorker(
+    config: cfg,
+    keyManager: DefaultKeyManager(),
+    rootKeyStore: DefaultRootKeyStore(kv: InMemoryKeyValueStore()),
+    tokenStore: SecureTokenStore(kv: InMemoryKeyValueStore()),
+    discoveryClient: _FakeDiscoveryClient(),
+    tokenExchange: exchange,
+    apiProxy: ApiProxy(),
+    refreshLock: RefreshLock(),
+  );
+  final oauth = _FakeOAuthFlow();
+  final runtime = AuthRuntimeImpl(
+    config: cfg,
+    worker: worker,
+    oauthFlow: oauth,
+    nativeProviders: providers,
+  );
+  return _Harness(
+    runtime: runtime,
+    worker: worker,
+    exchange: exchange,
+    oauth: oauth,
+  );
+}
+
+void main() {
+  tearDown(clearDiscoveryCache);
+
+  group('AuthRuntimeImpl native credential waterfall', () {
+    test('availableNativeProviders reports only available providers',
+        () async {
+      final h = _build(providers: [
+        _StubProvider(
+          kind: NativeCredentialProviderKind.apple,
+          availability: false,
+        ),
+        _StubProvider(
+          kind: NativeCredentialProviderKind.google,
+          availability: true,
+        ),
+      ]);
+      await h.runtime.init();
+      final avail = await h.runtime.availableNativeProviders();
+      expect(avail, {NativeCredentialProviderKind.google});
+      await h.runtime.dispose();
+    });
+
+    test('proactive silent attempt: ok → authenticated; no OAuth fallback',
+        () async {
+      final provider = _NonceEchoingProvider(
+        kind: NativeCredentialProviderKind.google,
+      );
+      final h = _build(providers: [provider]);
+      h.exchange.idTokenQueue.add(_tokenSet(access: 'native-at'));
+
+      final credEvents = <CredentialEvent>[];
+      final credSub = h.runtime.credentialEventStream.listen(credEvents.add);
+
+      await h.runtime.init();
+      // Let init flush + proactive silent microtask + worker completion settle.
+      for (var i = 0; i < 20; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+
+      expect(h.worker.state, AuthState.authenticated);
+      expect(provider.silentCalls, 1);
+      expect(h.exchange.idTokenCalls, 1);
+      expect(h.oauth.calls, 0);
+      expect(
+        credEvents.whereType<CredentialSilentAttemptEvent>().length,
+        1,
+      );
+      expect(
+        credEvents.whereType<CredentialOutcomeEvent>().length,
+        1,
+      );
+      await credSub.cancel();
+      await h.runtime.dispose();
+    });
+
+    test(
+        'silent-noSession + interactive-success → authenticated; no OAuth fallback',
+        () async {
+      final provider = _NonceEchoingProvider(
+        kind: NativeCredentialProviderKind.google,
+        silentOutcome: const NativeCredentialOutcome.noSession(),
+        // Interactive will yield ok-with-matching-nonce.
+      );
+      final h = _build(providers: [provider]);
+      // Queue two token-exchange responses: one for the (absent) silent,
+      // one for the interactive attempt.
+      h.exchange.idTokenQueue.add(_tokenSet(access: 'native-at'));
+      await h.runtime.init();
+
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      // Silent consumed: no worker exchange happened.
+      expect(h.worker.state, AuthState.unauthenticated);
+      expect(h.exchange.idTokenCalls, 0);
+
+      await h.runtime.ensureAuthenticated();
+      expect(h.worker.state, AuthState.authenticated);
+      expect(provider.interactiveCalls, 1);
+      expect(h.oauth.calls, 0);
+      expect(h.exchange.idTokenCalls, 1);
+      await h.runtime.dispose();
+    });
+
+    test('all providers decline → OAuth2 fallback', () async {
+      final provider = _StubProvider(
+        kind: NativeCredentialProviderKind.apple,
+        availability: true,
+        interactiveOutcomes: const [NativeCredentialOutcome.cancelled()],
+      );
+      final h = _build(providers: [provider]);
+      h.exchange.codeQueue.add(_tokenSet(access: 'oauth-at'));
+      await h.runtime.init();
+
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      // Proactive silent attempt ran; noSession → no authentication.
+      expect(h.worker.state, AuthState.unauthenticated);
+
+      await h.runtime.ensureAuthenticated();
+      expect(h.worker.state, AuthState.authenticated);
+      expect(provider.interactiveCalls, 1);
+      expect(h.oauth.calls, 1);
+      expect(h.exchange.codeCalls, 1);
+      await h.runtime.dispose();
+    });
+
+    test(
+        'worker exchange failure after interactive-ok → falls through to OAuth2',
+        () async {
+      final provider = _NonceEchoingProvider(
+        kind: NativeCredentialProviderKind.google,
+        silentOutcome: const NativeCredentialOutcome.noSession(),
+      );
+      final h = _build(providers: [provider]);
+      // id-token exchange raises; OAuth2 leg succeeds.
+      h.exchange.idTokenError = AuthError(
+        AuthErrorCode.tokenExchangeFailed,
+        'boom',
+      );
+      h.exchange.codeQueue.add(_tokenSet(access: 'oauth-at'));
+      await h.runtime.init();
+
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      await h.runtime.ensureAuthenticated();
+      expect(h.worker.state, AuthState.authenticated);
+      expect(h.oauth.calls, 1);
+      expect(h.exchange.codeCalls, 1);
+      await h.runtime.dispose();
+    });
+
+    test(
+        'silent id-token with bogus iss is rejected by the worker; '
+        'proactive attempt leaves state unauthenticated', () async {
+      final provider = _BadIssuerProvider();
+      final h = _build(providers: [provider]);
+      await h.runtime.init();
+
+      for (var i = 0; i < 5; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(h.worker.state, AuthState.unauthenticated);
+      // The worker rejected the token before any exchange call went out.
+      expect(h.exchange.idTokenCalls, 0);
+      await h.runtime.dispose();
+    });
+
+    test('logout calls signOut on all providers', () async {
+      final apple = _StubProvider(
+        kind: NativeCredentialProviderKind.apple,
+        availability: true,
+      );
+      final google = _StubProvider(
+        kind: NativeCredentialProviderKind.google,
+        availability: true,
+      );
+      final h = _build(providers: [apple, google]);
+      await h.runtime.init();
+      final events = <CredentialEvent>[];
+      final sub = h.runtime.credentialEventStream.listen(events.add);
+      await h.runtime.logout();
+      expect(apple.signOutCalls, 1);
+      expect(google.signOutCalls, 1);
+      final signOuts = events.whereType<CredentialSignOutEvent>().toList();
+      expect(signOuts.length, 2);
+      expect(
+        signOuts.map((e) => e.kind).toSet(),
+        {NativeCredentialProviderKind.apple, NativeCredentialProviderKind.google},
+      );
+      await sub.cancel();
+      await h.runtime.dispose();
+    });
+
+    test('provider throwing in isAvailable does not crash the waterfall',
+        () async {
+      final bad = _StubProvider(
+        kind: NativeCredentialProviderKind.apple,
+        availability: true,
+        throwOnAvailable: true,
+      );
+      final h = _build(providers: [bad]);
+      h.exchange.codeQueue.add(_tokenSet(access: 'oauth-at'));
+      await h.runtime.init();
+      // Runtime can still recover via OAuth2.
+      await h.runtime.ensureAuthenticated();
+      expect(h.worker.state, AuthState.authenticated);
+      expect(h.oauth.calls, 1);
+      await h.runtime.dispose();
+    });
+  });
+}
+
+/// Provider whose silent attempt returns an OK outcome with an iss that
+/// is NOT the expected issuer for the declared provider kind. The worker
+/// should reject this before any token-exchange is attempted.
+class _BadIssuerProvider implements NativeCredentialProvider {
+  _BadIssuerProvider();
+
+  @override
+  NativeCredentialProviderKind get kind =>
+      NativeCredentialProviderKind.google;
+
+  int silentCalls = 0;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Future<NativeCredentialOutcome> attemptSilent({
+    required String nonce,
+  }) async {
+    silentCalls++;
+    return NativeCredentialOutcome.ok(
+      NativeCredentialResult(
+        provider: NativeCredentialProviderKind.google,
+        idToken: _makeJwt(<String, dynamic>{
+          'iss': 'https://evil.example.com',
+          'sub': 'u',
+          'nonce': nonce,
+        }),
+        autoSelected: true,
+        nonce: nonce,
+      ),
+    );
+  }
+
+  @override
+  Future<NativeCredentialOutcome> attemptInteractive({
+    required String nonce,
+  }) async =>
+      const NativeCredentialOutcome.cancelled();
+
+  @override
+  Future<void> signOut() async {}
+}
+
+/// Provider that synthesises a matching-nonce ID token from whatever the
+/// runtime passes to [attemptSilent] / [attemptInteractive]. Keeps tests
+/// decoupled from the randomness of the runtime's nonce generator.
+class _NonceEchoingProvider implements NativeCredentialProvider {
+  _NonceEchoingProvider({
+    required this.kind,
+    this.silentOutcome,
+  });
+
+  @override
+  final NativeCredentialProviderKind kind;
+  final NativeCredentialOutcome? silentOutcome;
+
+  int silentCalls = 0;
+  int interactiveCalls = 0;
+  int signOutCalls = 0;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  NativeCredentialOutcome _okFor(String nonce) {
+    final issuer = kind == NativeCredentialProviderKind.apple
+        ? 'https://appleid.apple.com'
+        : 'https://accounts.google.com';
+    return NativeCredentialOutcome.ok(
+      NativeCredentialResult(
+        provider: kind,
+        idToken: _makeJwt(<String, dynamic>{
+          'iss': issuer,
+          'sub': 'u',
+          'aud': 'c',
+          'nonce': nonce,
+        }),
+        autoSelected: true,
+        nonce: nonce,
+      ),
+    );
+  }
+
+  @override
+  Future<NativeCredentialOutcome> attemptSilent({
+    required String nonce,
+  }) async {
+    silentCalls++;
+    return silentOutcome ?? _okFor(nonce);
+  }
+
+  @override
+  Future<NativeCredentialOutcome> attemptInteractive({
+    required String nonce,
+  }) async {
+    interactiveCalls++;
+    return _okFor(nonce);
+  }
+
+  @override
+  Future<void> signOut() async {
+    signOutCalls++;
+  }
+}
+

--- a/ui/runtime/test/auth_runtime_test.dart
+++ b/ui/runtime/test/auth_runtime_test.dart
@@ -318,7 +318,7 @@ void main() {
   test('version exposes authRuntimeVersion constant', () async {
     final rt = _Harness().build();
     expect(rt.version, authRuntimeVersion);
-    expect(rt.version, '0.1.0');
+    expect(rt.version, '0.2.0');
     await rt.dispose();
   });
 

--- a/ui/runtime/test/credentials/apple_credential_provider_test.dart
+++ b/ui/runtime/test/credentials/apple_credential_provider_test.dart
@@ -157,8 +157,7 @@ void main() {
       expect(outcome, isA<Cancelled>());
     });
 
-    test('attemptInteractive maps other auth error codes → unavailable',
-        () async {
+    test('attemptInteractive maps notHandled → unavailable', () async {
       final adapter = _MockAdapter();
       when(
         () => adapter.getAppleIDCredential(
@@ -178,6 +177,71 @@ void main() {
       final e = outcome as ErrorOutcome;
       expect(e.error.code, AuthErrorCode.nativeCredentialUnavailable);
       expect(e.error.message, contains('notHandled'));
+    });
+
+    test('attemptInteractive maps unknown → unavailable', () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.getAppleIDCredential(
+          scopes: any(named: 'scopes'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenThrow(
+        const SignInWithAppleAuthorizationException(
+          code: AuthorizationErrorCode.unknown,
+          message: 'unknown',
+        ),
+      );
+
+      final provider = AppleCredentialProvider(adapter: adapter);
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialUnavailable);
+    });
+
+    test('attemptInteractive maps failed → exchangeFailed', () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.getAppleIDCredential(
+          scopes: any(named: 'scopes'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenThrow(
+        const SignInWithAppleAuthorizationException(
+          code: AuthorizationErrorCode.failed,
+          message: 'fail',
+        ),
+      );
+
+      final provider = AppleCredentialProvider(adapter: adapter);
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialExchangeFailed);
+      expect(e.error.message, contains('failed'));
+    });
+
+    test('attemptInteractive maps invalidResponse → exchangeFailed',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.getAppleIDCredential(
+          scopes: any(named: 'scopes'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenThrow(
+        const SignInWithAppleAuthorizationException(
+          code: AuthorizationErrorCode.invalidResponse,
+          message: 'bad response',
+        ),
+      );
+
+      final provider = AppleCredentialProvider(adapter: adapter);
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialExchangeFailed);
     });
 
     test('attemptInteractive maps other exceptions → exchangeFailed',

--- a/ui/runtime/test/credentials/apple_credential_provider_test.dart
+++ b/ui/runtime/test/credentials/apple_credential_provider_test.dart
@@ -1,0 +1,207 @@
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/src/credentials/apple_credential_provider.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+
+class _MockAdapter extends Mock implements SignInWithAppleAdapter {}
+
+class _FakeCredential implements AuthorizationCredentialAppleID {
+  _FakeCredential({
+    required this.identityToken,
+    required this.authorizationCode,
+  });
+
+  @override
+  final String? identityToken;
+
+  @override
+  final String authorizationCode;
+
+  @override
+  String? get email => null;
+  @override
+  String? get familyName => null;
+  @override
+  String? get givenName => null;
+  @override
+  String? get state => null;
+  @override
+  String? get userIdentifier => 'user-1';
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<AppleIDAuthorizationScopes>[]);
+  });
+
+  group('AppleCredentialProvider', () {
+    test('kind is apple', () {
+      final provider = AppleCredentialProvider(adapter: _MockAdapter());
+      expect(provider.kind, NativeCredentialProviderKind.apple);
+    });
+
+    test('isAvailable delegates to adapter', () async {
+      final adapter = _MockAdapter();
+      when(adapter.isAvailable).thenAnswer((_) async => true);
+      final provider = AppleCredentialProvider(adapter: adapter);
+
+      expect(await provider.isAvailable(), isTrue);
+      verify(adapter.isAvailable).called(1);
+    });
+
+    test('attemptSilent always returns noSession', () async {
+      final adapter = _MockAdapter();
+      final provider = AppleCredentialProvider(adapter: adapter);
+
+      final outcome = await provider.attemptSilent(nonce: 'n');
+      expect(outcome, isA<NoSession>());
+      verifyNever(
+        () => adapter.getAppleIDCredential(
+          scopes: any(named: 'scopes'),
+          nonce: any(named: 'nonce'),
+        ),
+      );
+    });
+
+    test('attemptInteractive passes SHA-256 hex of nonce and wraps result',
+        () async {
+      const nonce = 'raw-nonce-xyz';
+      final expectedHash = sha256.convert(utf8.encode(nonce)).toString();
+
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.getAppleIDCredential(
+          scopes: any(named: 'scopes'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer(
+        (_) async => _FakeCredential(
+          identityToken: 'id.token',
+          authorizationCode: 'code-abc',
+        ),
+      );
+
+      final provider = AppleCredentialProvider(adapter: adapter);
+      final outcome = await provider.attemptInteractive(nonce: nonce);
+
+      expect(outcome, isA<Ok>());
+      final ok = outcome as Ok;
+      expect(ok.result.provider, NativeCredentialProviderKind.apple);
+      expect(ok.result.idToken, 'id.token');
+      expect(ok.result.authorizationCode, 'code-abc');
+      expect(ok.result.nonce, nonce);
+      expect(ok.result.autoSelected, isFalse);
+
+      final captured = verify(
+        () => adapter.getAppleIDCredential(
+          scopes: captureAny(named: 'scopes'),
+          nonce: captureAny(named: 'nonce'),
+        ),
+      ).captured;
+      final capturedScopes =
+          captured[0] as List<AppleIDAuthorizationScopes>;
+      final capturedNonce = captured[1] as String?;
+      expect(
+        capturedScopes,
+        containsAll(<AppleIDAuthorizationScopes>[
+          AppleIDAuthorizationScopes.email,
+          AppleIDAuthorizationScopes.fullName,
+        ]),
+      );
+      expect(capturedNonce, expectedHash);
+    });
+
+    test('attemptInteractive with null identityToken returns error', () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.getAppleIDCredential(
+          scopes: any(named: 'scopes'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer(
+        (_) async => _FakeCredential(
+          identityToken: null,
+          authorizationCode: 'code-abc',
+        ),
+      );
+
+      final provider = AppleCredentialProvider(adapter: adapter);
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialUnavailable);
+    });
+
+    test('attemptInteractive maps canceled → cancelled()', () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.getAppleIDCredential(
+          scopes: any(named: 'scopes'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenThrow(
+        const SignInWithAppleAuthorizationException(
+          code: AuthorizationErrorCode.canceled,
+          message: 'user cancelled',
+        ),
+      );
+
+      final provider = AppleCredentialProvider(adapter: adapter);
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<Cancelled>());
+    });
+
+    test('attemptInteractive maps other auth error codes → unavailable',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.getAppleIDCredential(
+          scopes: any(named: 'scopes'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenThrow(
+        const SignInWithAppleAuthorizationException(
+          code: AuthorizationErrorCode.notHandled,
+          message: 'no handler',
+        ),
+      );
+
+      final provider = AppleCredentialProvider(adapter: adapter);
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialUnavailable);
+      expect(e.error.message, contains('notHandled'));
+    });
+
+    test('attemptInteractive maps other exceptions → exchangeFailed',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.getAppleIDCredential(
+          scopes: any(named: 'scopes'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenThrow(StateError('boom'));
+
+      final provider = AppleCredentialProvider(adapter: adapter);
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialExchangeFailed);
+    });
+
+    test('signOut is a no-op', () async {
+      final adapter = _MockAdapter();
+      final provider = AppleCredentialProvider(adapter: adapter);
+      await provider.signOut();
+      verifyZeroInteractions(adapter);
+    });
+  });
+}

--- a/ui/runtime/test/credentials/google_credential_provider_test.dart
+++ b/ui/runtime/test/credentials/google_credential_provider_test.dart
@@ -1,0 +1,229 @@
+import 'package:antinvestor_auth_runtime/src/credentials/google_credential_provider.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_sign_in/google_sign_in.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAdapter extends Mock implements GoogleSignInAdapter {}
+
+/// Fake account exposing only what the provider reads.
+class _FakeGoogleAccount implements GoogleSignInAccountView {
+  _FakeGoogleAccount({required this.idToken});
+
+  @override
+  final String? idToken;
+}
+
+void main() {
+  group('GoogleCredentialProvider', () {
+    test('kind is google', () {
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'server-id',
+        adapter: _MockAdapter(),
+      );
+      expect(provider.kind, NativeCredentialProviderKind.google);
+    });
+
+    test('isAvailable returns true', () async {
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'server-id',
+        adapter: _MockAdapter(),
+      );
+      expect(await provider.isAvailable(), isTrue);
+    });
+
+    test('attemptSilent returns noSession when adapter returns null',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(adapter.attemptLightweightAuthentication)
+          .thenAnswer((_) async => null);
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptSilent(nonce: 'n1');
+
+      expect(outcome, isA<NoSession>());
+      verify(
+        () => adapter.initialize(serverClientId: 'sc', nonce: 'n1'),
+      ).called(1);
+    });
+
+    test('attemptSilent returns unavailable when account has no idToken',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(adapter.attemptLightweightAuthentication)
+          .thenAnswer((_) async => _FakeGoogleAccount(idToken: null));
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptSilent(nonce: 'n1');
+
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialUnavailable);
+    });
+
+    test('attemptSilent returns ok with autoSelected=true on account',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(adapter.attemptLightweightAuthentication).thenAnswer(
+        (_) async => _FakeGoogleAccount(idToken: 'id.silent'),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptSilent(nonce: 'n1');
+
+      expect(outcome, isA<Ok>());
+      final ok = outcome as Ok;
+      expect(ok.result.idToken, 'id.silent');
+      expect(ok.result.provider, NativeCredentialProviderKind.google);
+      expect(ok.result.nonce, 'n1');
+      expect(ok.result.autoSelected, isTrue);
+      expect(ok.result.authorizationCode, isNull);
+    });
+
+    test('attemptInteractive returns ok with autoSelected=false', () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => adapter.authenticate(scopeHint: any(named: 'scopeHint')),
+      ).thenAnswer(
+        (_) async => _FakeGoogleAccount(idToken: 'id.interactive'),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptInteractive(nonce: 'n2');
+
+      expect(outcome, isA<Ok>());
+      final ok = outcome as Ok;
+      expect(ok.result.idToken, 'id.interactive');
+      expect(ok.result.autoSelected, isFalse);
+      expect(ok.result.nonce, 'n2');
+      verify(() => adapter.initialize(serverClientId: 'sc', nonce: 'n2'))
+          .called(1);
+    });
+
+    test('attemptInteractive maps canceled → cancelled()', () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => adapter.authenticate(scopeHint: any(named: 'scopeHint')),
+      ).thenThrow(
+        const GoogleSignInException(
+          code: GoogleSignInExceptionCode.canceled,
+          description: 'user cancelled',
+        ),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<Cancelled>());
+    });
+
+    test('attemptInteractive maps other exceptions → exchangeFailed',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => adapter.authenticate(scopeHint: any(named: 'scopeHint')),
+      ).thenThrow(StateError('boom'));
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialExchangeFailed);
+    });
+
+    test('attemptInteractive with GoogleSignInException (non-cancel) → error',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => adapter.authenticate(scopeHint: any(named: 'scopeHint')),
+      ).thenThrow(
+        const GoogleSignInException(
+          code: GoogleSignInExceptionCode.clientConfigurationError,
+          description: 'bad client id',
+        ),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialExchangeFailed);
+      expect(e.error.message, contains('clientConfigurationError'));
+    });
+
+    test('signOut delegates to adapter', () async {
+      final adapter = _MockAdapter();
+      when(adapter.signOut).thenAnswer((_) async {});
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+
+      await provider.signOut();
+      verify(adapter.signOut).called(1);
+    });
+  });
+}

--- a/ui/runtime/test/credentials/google_credential_provider_test.dart
+++ b/ui/runtime/test/credentials/google_credential_provider_test.dart
@@ -185,7 +185,8 @@ void main() {
       expect(e.error.code, AuthErrorCode.nativeCredentialExchangeFailed);
     });
 
-    test('attemptInteractive with GoogleSignInException (non-cancel) → error',
+    test(
+        'attemptInteractive maps clientConfigurationError → unavailable',
         () async {
       final adapter = _MockAdapter();
       when(
@@ -210,8 +211,167 @@ void main() {
       final outcome = await provider.attemptInteractive(nonce: 'n');
       expect(outcome, isA<ErrorOutcome>());
       final e = outcome as ErrorOutcome;
-      expect(e.error.code, AuthErrorCode.nativeCredentialExchangeFailed);
+      expect(e.error.code, AuthErrorCode.nativeCredentialUnavailable);
       expect(e.error.message, contains('clientConfigurationError'));
+    });
+
+    test(
+        'attemptInteractive maps providerConfigurationError → unavailable',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => adapter.authenticate(scopeHint: any(named: 'scopeHint')),
+      ).thenThrow(
+        const GoogleSignInException(
+          code: GoogleSignInExceptionCode.providerConfigurationError,
+          description: 'sdk misconfigured',
+        ),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialUnavailable);
+    });
+
+    test('attemptInteractive maps uiUnavailable → noSession', () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => adapter.authenticate(scopeHint: any(named: 'scopeHint')),
+      ).thenThrow(
+        const GoogleSignInException(
+          code: GoogleSignInExceptionCode.uiUnavailable,
+          description: 'no activity',
+        ),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<NoSession>());
+    });
+
+    test('attemptInteractive maps interrupted → exchangeFailed', () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => adapter.authenticate(scopeHint: any(named: 'scopeHint')),
+      ).thenThrow(
+        const GoogleSignInException(
+          code: GoogleSignInExceptionCode.interrupted,
+          description: 'network blip',
+        ),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialExchangeFailed);
+    });
+
+    test('attemptInteractive maps unknownError → exchangeFailed', () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => adapter.authenticate(scopeHint: any(named: 'scopeHint')),
+      ).thenThrow(
+        const GoogleSignInException(
+          code: GoogleSignInExceptionCode.unknownError,
+          description: 'mystery',
+        ),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptInteractive(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialExchangeFailed);
+    });
+
+    test('attemptSilent maps canceled → noSession (not cancelled)',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(adapter.attemptLightweightAuthentication).thenThrow(
+        const GoogleSignInException(
+          code: GoogleSignInExceptionCode.canceled,
+          description: 'no user',
+        ),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptSilent(nonce: 'n');
+      expect(outcome, isA<NoSession>());
+    });
+
+    test(
+        'attemptSilent maps clientConfigurationError → unavailable',
+        () async {
+      final adapter = _MockAdapter();
+      when(
+        () => adapter.initialize(
+          serverClientId: any(named: 'serverClientId'),
+          nonce: any(named: 'nonce'),
+        ),
+      ).thenAnswer((_) async {});
+      when(adapter.attemptLightweightAuthentication).thenThrow(
+        const GoogleSignInException(
+          code: GoogleSignInExceptionCode.clientConfigurationError,
+          description: 'bad client id',
+        ),
+      );
+
+      final provider = GoogleCredentialProvider(
+        serverClientId: 'sc',
+        adapter: adapter,
+      );
+      final outcome = await provider.attemptSilent(nonce: 'n');
+      expect(outcome, isA<ErrorOutcome>());
+      final e = outcome as ErrorOutcome;
+      expect(e.error.code, AuthErrorCode.nativeCredentialUnavailable);
     });
 
     test('signOut delegates to adapter', () async {

--- a/ui/runtime/test/credentials/native_credential_test.dart
+++ b/ui/runtime/test/credentials/native_credential_test.dart
@@ -1,0 +1,135 @@
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
+import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('NativeCredentialProviderKind', () {
+    test('has apple and google values', () {
+      expect(NativeCredentialProviderKind.values, hasLength(2));
+      expect(
+        NativeCredentialProviderKind.values,
+        containsAll(<NativeCredentialProviderKind>[
+          NativeCredentialProviderKind.apple,
+          NativeCredentialProviderKind.google,
+        ]),
+      );
+    });
+  });
+
+  group('NativeCredentialResult', () {
+    test('preserves fields', () {
+      const r = NativeCredentialResult(
+        provider: NativeCredentialProviderKind.google,
+        idToken: 'id.token',
+        authorizationCode: 'code-1',
+        nonce: 'nonce-1',
+        autoSelected: true,
+      );
+      expect(r.provider, NativeCredentialProviderKind.google);
+      expect(r.idToken, 'id.token');
+      expect(r.authorizationCode, 'code-1');
+      expect(r.nonce, 'nonce-1');
+      expect(r.autoSelected, isTrue);
+    });
+
+    test('allows optional authorizationCode and nonce', () {
+      const r = NativeCredentialResult(
+        provider: NativeCredentialProviderKind.apple,
+        idToken: 'id.token',
+        autoSelected: false,
+      );
+      expect(r.authorizationCode, isNull);
+      expect(r.nonce, isNull);
+    });
+
+    test('equality and hashCode by value', () {
+      const a = NativeCredentialResult(
+        provider: NativeCredentialProviderKind.apple,
+        idToken: 'id',
+        authorizationCode: 'code',
+        nonce: 'n',
+        autoSelected: false,
+      );
+      const b = NativeCredentialResult(
+        provider: NativeCredentialProviderKind.apple,
+        idToken: 'id',
+        authorizationCode: 'code',
+        nonce: 'n',
+        autoSelected: false,
+      );
+      const c = NativeCredentialResult(
+        provider: NativeCredentialProviderKind.apple,
+        idToken: 'different',
+        authorizationCode: 'code',
+        nonce: 'n',
+        autoSelected: false,
+      );
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(equals(c)));
+    });
+  });
+
+  group('NativeCredentialOutcome', () {
+    test('ok carries a result and matches exhaustively', () {
+      const result = NativeCredentialResult(
+        provider: NativeCredentialProviderKind.google,
+        idToken: 'id',
+        autoSelected: true,
+      );
+      const NativeCredentialOutcome outcome = NativeCredentialOutcome.ok(
+        result,
+      );
+
+      final matched = switch (outcome) {
+        Ok(result: final r) => 'ok-${r.idToken}',
+        NoSession() => 'no-session',
+        Cancelled() => 'cancelled',
+        Unavailable() => 'unavailable',
+        ErrorOutcome() => 'error',
+      };
+      expect(matched, 'ok-id');
+    });
+
+    test('noSession, cancelled, unavailable, error variants', () {
+      const NativeCredentialOutcome noSession =
+          NativeCredentialOutcome.noSession();
+      const NativeCredentialOutcome cancelled =
+          NativeCredentialOutcome.cancelled();
+      const NativeCredentialOutcome unavailable =
+          NativeCredentialOutcome.unavailable('reason-xyz');
+      final NativeCredentialOutcome error = NativeCredentialOutcome.error(
+        AuthError(AuthErrorCode.nativeCredentialExchangeFailed, 'fail'),
+      );
+
+      expect(noSession, isA<NoSession>());
+      expect(cancelled, isA<Cancelled>());
+      expect(unavailable, isA<Unavailable>());
+      expect((unavailable as Unavailable).reason, 'reason-xyz');
+      expect(error, isA<ErrorOutcome>());
+      expect(
+        (error as ErrorOutcome).error.code,
+        AuthErrorCode.nativeCredentialExchangeFailed,
+      );
+    });
+  });
+
+  group('AuthErrorCode native credential codes', () {
+    test('retryability: issuerMismatch is non-retryable', () {
+      expect(
+        AuthError(AuthErrorCode.nativeCredentialIssuerMismatch, 'x').retryable,
+        isFalse,
+      );
+    });
+
+    test('retryability: other native credential codes are retryable', () {
+      for (final c in const [
+        AuthErrorCode.nativeCredentialCancelled,
+        AuthErrorCode.nativeCredentialUnavailable,
+        AuthErrorCode.nativeCredentialExchangeFailed,
+      ]) {
+        expect(AuthError(c, 'm').retryable, isTrue, reason: c.name);
+      }
+    });
+  });
+}

--- a/ui/runtime/test/integration/_helpers.dart
+++ b/ui/runtime/test/integration/_helpers.dart
@@ -121,6 +121,7 @@ Future<IntegrationHarness> buildHarness({
   FakeOAuthFlow? fakeOAuth,
   KeyValueStore? sessionKv,
   KeyValueStore? rootKv,
+  List<NativeCredentialProvider> nativeProviders = const [],
 }) async {
   final m = mock ?? MockIdp();
   // Idempotent start: if the mock hasn't listened yet, start it. Tests
@@ -167,6 +168,7 @@ Future<IntegrationHarness> buildHarness({
     config: cfg,
     worker: worker,
     oauthFlow: fake,
+    nativeProviders: nativeProviders,
   );
   await runtime.init();
 

--- a/ui/runtime/test/integration/mock_idp.dart
+++ b/ui/runtime/test/integration/mock_idp.dart
@@ -56,6 +56,14 @@ class MockIdp {
   /// reason about which tokens came from which rotation.
   int _rotationCounter = 0;
 
+  /// Allowlist of issuers accepted by the `token-exchange` grant path.
+  /// Defaults to Apple + Google; tests can widen or tighten via
+  /// [setAllowedIssuers].
+  List<String> _allowedExchangeIssuers = const <String>[
+    'https://appleid.apple.com',
+    'https://accounts.google.com',
+  ];
+
   /// The issuer URL advertised in discovery + ID tokens. Populated at
   /// `start` time.
   String get baseUrl => _baseUrl!;
@@ -99,6 +107,12 @@ class MockIdp {
     clockSkewChallengeArmed = true;
   }
 
+  /// Replace the allowlist of issuers accepted by the `token-exchange`
+  /// grant path. Useful for tests that want to verify enforcement.
+  void setAllowedIssuers(List<String> issuers) {
+    _allowedExchangeIssuers = List<String>.unmodifiable(issuers);
+  }
+
   /// Resets the counters / recorded requests so a single MockIdp can be
   /// reused across scenarios.
   void reset() {
@@ -110,6 +124,10 @@ class MockIdp {
     _consumedRefreshTokens.clear();
     _liveRefreshTokens.clear();
     _rotationCounter = 0;
+    _allowedExchangeIssuers = const <String>[
+      'https://appleid.apple.com',
+      'https://accounts.google.com',
+    ];
   }
 
   // Handlers ----------------------------------------------------------------
@@ -186,6 +204,8 @@ class MockIdp {
     switch (grant) {
       case 'authorization_code':
         return _issueTokens(newFamily: true);
+      case 'urn:ietf:params:oauth:grant-type:token-exchange':
+        return _handleTokenExchange(form);
       case 'refresh_token':
         final rt = form['refresh_token'];
         if (rt == null || rt.isEmpty) {
@@ -227,13 +247,17 @@ class MockIdp {
     }
   }
 
-  Response _issueTokens({required bool newFamily}) {
+  Response _issueTokens({
+    required bool newFamily,
+    String sub = 'user-1',
+    String aud = 'antinvestor-mobile',
+  }) {
     _rotationCounter += 1;
     final n = _rotationCounter;
     final accessToken = _makeUnsignedJwt(<String, dynamic>{
       'iss': baseUrl,
-      'sub': 'user-1',
-      'aud': 'antinvestor-mobile',
+      'sub': sub,
+      'aud': aud,
       'iat': DateTime.now().millisecondsSinceEpoch ~/ 1000,
       'exp': DateTime.now()
               .add(tokenLifetime)
@@ -244,8 +268,8 @@ class MockIdp {
     });
     final idToken = _makeUnsignedJwt(<String, dynamic>{
       'iss': baseUrl,
-      'sub': 'user-1',
-      'aud': 'antinvestor-mobile',
+      'sub': sub,
+      'aud': aud,
       'iat': DateTime.now().millisecondsSinceEpoch ~/ 1000,
       'exp': DateTime.now()
               .add(tokenLifetime)
@@ -269,6 +293,94 @@ class MockIdp {
       json.encode(body),
       headers: <String, String>{'Content-Type': 'application/json'},
     );
+  }
+
+  /// Handles RFC 8693 `urn:ietf:params:oauth:grant-type:token-exchange`.
+  ///
+  /// Validates `subject_token_type`, `subject_issuer`, parses the subject
+  /// token without signature verification (this is a mock), asserts that
+  /// `iss` matches the declared `subject_issuer`, then mints a fresh
+  /// session tied to the subject's `sub` claim. `aud` is synthesised from
+  /// the request `client_id` so callers can verify audience mapping.
+  Response _handleTokenExchange(Map<String, String> form) {
+    const expectedTokenType = 'urn:ietf:params:oauth:token-type:id_token';
+    final subjectTokenType = form['subject_token_type'];
+    if (subjectTokenType != expectedTokenType) {
+      return Response(
+        400,
+        headers: <String, String>{'Content-Type': 'application/json'},
+        body: json.encode(<String, String>{
+          'error': 'invalid_request',
+          'error_description':
+              'subject_token_type must be $expectedTokenType',
+        }),
+      );
+    }
+
+    final subjectIssuer = form['subject_issuer'];
+    if (subjectIssuer == null ||
+        !_allowedExchangeIssuers.contains(subjectIssuer)) {
+      return Response(
+        400,
+        headers: <String, String>{'Content-Type': 'application/json'},
+        body: json.encode(<String, String>{
+          'error': 'invalid_grant',
+          'error_description': 'subject_issuer not in allowlist',
+        }),
+      );
+    }
+
+    final subjectToken = form['subject_token'];
+    if (subjectToken == null || subjectToken.isEmpty) {
+      return Response(
+        400,
+        headers: <String, String>{'Content-Type': 'application/json'},
+        body: json.encode(<String, String>{
+          'error': 'invalid_request',
+          'error_description': 'missing subject_token',
+        }),
+      );
+    }
+
+    Map<String, dynamic>? claims;
+    final parts = subjectToken.split('.');
+    if (parts.length >= 2) {
+      try {
+        final decoded = json.decode(
+          utf8.decode(_b64urlDecode(parts[1])),
+        );
+        if (decoded is Map<String, dynamic>) claims = decoded;
+      } catch (_) {
+        claims = null;
+      }
+    }
+    if (claims == null) {
+      return Response(
+        400,
+        headers: <String, String>{'Content-Type': 'application/json'},
+        body: json.encode(<String, String>{
+          'error': 'invalid_grant',
+          'error_description': 'subject_token is not a parseable JWT',
+        }),
+      );
+    }
+    if (claims['iss'] != subjectIssuer) {
+      return Response(
+        400,
+        headers: <String, String>{'Content-Type': 'application/json'},
+        body: json.encode(<String, String>{
+          'error': 'invalid_grant',
+          'error_description':
+              'subject_token iss does not match subject_issuer',
+        }),
+      );
+    }
+
+    final sub = claims['sub'] is String
+        ? claims['sub'] as String
+        : 'exchange-user';
+    final aud = form['client_id'] ?? 'antinvestor-mobile';
+    return _issueTokens(newFamily: true, sub: sub, aud: aud);
   }
 
   Future<Response> _revocation(Request req) async {

--- a/ui/runtime/test/integration/mock_idp_token_exchange_test.dart
+++ b/ui/runtime/test/integration/mock_idp_token_exchange_test.dart
@@ -1,0 +1,185 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import 'mock_idp.dart';
+
+/// Constructs an unsigned JWT with the given payload. Mirrors the helper
+/// used in worker tests — sufficient for MockIdp which does not verify
+/// signatures.
+String _jwt(Map<String, dynamic> payload) {
+  String strip(String s) => s.replaceAll('=', '');
+  final header = strip(base64Url.encode(utf8.encode(
+    json.encode(const <String, String>{'alg': 'none'}),
+  )));
+  final body = strip(base64Url.encode(utf8.encode(json.encode(payload))));
+  final sig = strip(base64Url.encode(const <int>[1, 2, 3]));
+  return '$header.$body.$sig';
+}
+
+Future<http.Response> _postTokenExchange(
+  String base, {
+  required String subjectToken,
+  required String subjectIssuer,
+  String subjectTokenType = 'urn:ietf:params:oauth:token-type:id_token',
+  String clientId = 'antinvestor-mobile',
+}) {
+  final body = <String, String>{
+    'grant_type': 'urn:ietf:params:oauth:grant-type:token-exchange',
+    'client_id': clientId,
+    'subject_token': subjectToken,
+    'subject_token_type': subjectTokenType,
+    'subject_issuer': subjectIssuer,
+  }
+      .entries
+      .map((e) =>
+          '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}')
+      .join('&');
+  return http.post(
+    Uri.parse('$base/token'),
+    headers: const <String, String>{
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: body,
+  );
+}
+
+void main() {
+  late MockIdp mock;
+  late String base;
+
+  setUp(() async {
+    mock = MockIdp();
+    base = await mock.start();
+  });
+
+  tearDown(() async {
+    await mock.stop();
+  });
+
+  test('accepts RFC 8693 token-exchange for Apple issuer', () async {
+    final idToken = _jwt(<String, dynamic>{
+      'iss': 'https://appleid.apple.com',
+      'sub': 'apple-sub',
+      'aud': 'antinvestor-mobile',
+    });
+    final res = await _postTokenExchange(
+      base,
+      subjectToken: idToken,
+      subjectIssuer: 'https://appleid.apple.com',
+    );
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    expect(body['access_token'], isA<String>());
+    expect(body['refresh_token'], isA<String>());
+    expect(body['id_token'], isA<String>());
+    expect(mock.tokenRequests, hasLength(1));
+    expect(mock.tokenRequests.single.grantType,
+        'urn:ietf:params:oauth:grant-type:token-exchange');
+  });
+
+  test('accepts RFC 8693 token-exchange for Google issuer', () async {
+    final idToken = _jwt(<String, dynamic>{
+      'iss': 'https://accounts.google.com',
+      'sub': 'google-sub',
+      'aud': 'antinvestor-mobile',
+    });
+    final res = await _postTokenExchange(
+      base,
+      subjectToken: idToken,
+      subjectIssuer: 'https://accounts.google.com',
+    );
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+    expect(body['access_token'], isA<String>());
+  });
+
+  test('rejects subject_token_type other than id_token', () async {
+    final idToken = _jwt(<String, dynamic>{
+      'iss': 'https://accounts.google.com',
+      'sub': 's',
+    });
+    final res = await _postTokenExchange(
+      base,
+      subjectToken: idToken,
+      subjectIssuer: 'https://accounts.google.com',
+      subjectTokenType: 'urn:ietf:params:oauth:token-type:access_token',
+    );
+    expect(res.statusCode, 400);
+    expect(json.decode(res.body)['error'], 'invalid_request');
+  });
+
+  test('rejects subject_issuer outside the allowlist', () async {
+    final idToken = _jwt(<String, dynamic>{
+      'iss': 'https://evil.example.com',
+      'sub': 's',
+    });
+    final res = await _postTokenExchange(
+      base,
+      subjectToken: idToken,
+      subjectIssuer: 'https://evil.example.com',
+    );
+    expect(res.statusCode, 400);
+    expect(json.decode(res.body)['error'], 'invalid_grant');
+  });
+
+  test('rejects when subject_token iss does not match subject_issuer',
+      () async {
+    final idToken = _jwt(<String, dynamic>{
+      'iss': 'https://appleid.apple.com',
+      'sub': 's',
+    });
+    final res = await _postTokenExchange(
+      base,
+      subjectToken: idToken,
+      subjectIssuer: 'https://accounts.google.com',
+    );
+    expect(res.statusCode, 400);
+    expect(json.decode(res.body)['error'], 'invalid_grant');
+  });
+
+  test('setAllowedIssuers tightens the allowlist', () async {
+    mock.setAllowedIssuers(const <String>['https://accounts.google.com']);
+    final idToken = _jwt(<String, dynamic>{
+      'iss': 'https://appleid.apple.com',
+      'sub': 's',
+    });
+    final res = await _postTokenExchange(
+      base,
+      subjectToken: idToken,
+      subjectIssuer: 'https://appleid.apple.com',
+    );
+    expect(res.statusCode, 400);
+    expect(json.decode(res.body)['error'], 'invalid_grant');
+  });
+
+  test('echoes subject claims: sub preserved, aud synthesised from client_id',
+      () async {
+    final idToken = _jwt(<String, dynamic>{
+      'iss': 'https://accounts.google.com',
+      'sub': 'user-42',
+      'aud': 'ignored',
+    });
+    final res = await _postTokenExchange(
+      base,
+      subjectToken: idToken,
+      subjectIssuer: 'https://accounts.google.com',
+      clientId: 'custom-client',
+    );
+    expect(res.statusCode, 200);
+    final body = json.decode(res.body) as Map<String, dynamic>;
+
+    String decodeJwtPayload(String t) {
+      final parts = t.split('.');
+      final pad = (4 - parts[1].length % 4) % 4;
+      return utf8.decode(base64Url.decode(parts[1] + ('=' * pad)));
+    }
+
+    final idBody = json.decode(decodeJwtPayload(body['id_token'] as String))
+        as Map<String, dynamic>;
+    expect(idBody['sub'], 'user-42');
+    expect(idBody['aud'], 'custom-client');
+    expect(idBody['exp'], isA<int>());
+  });
+}

--- a/ui/runtime/test/integration/native_credential_flow_test.dart
+++ b/ui/runtime/test/integration/native_credential_flow_test.dart
@@ -1,0 +1,151 @@
+import 'dart:convert';
+
+import 'package:antinvestor_auth_runtime/antinvestor_auth_runtime.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '_helpers.dart';
+import 'mock_idp.dart';
+
+/// Unsigned JWT builder — MockIdp does not verify signatures, so a plain
+/// `header.payload.` suffices to exercise the exchange path.
+String _jwt(Map<String, dynamic> payload) {
+  String strip(String s) => s.replaceAll('=', '');
+  final header = strip(base64Url.encode(utf8.encode(
+    json.encode(const <String, String>{'alg': 'none'}),
+  )));
+  final body = strip(base64Url.encode(utf8.encode(json.encode(payload))));
+  return '$header.$body.';
+}
+
+/// Native provider stub that issues a matching-iss / matching-nonce
+/// ID token the real `TokenWorker.completeNativeCredential` and the real
+/// MockIdp will both accept. The goal of this test is to exercise every
+/// production layer below the platform SDK — HTTP, DPoP, token-exchange,
+/// session persistence — without spinning up a real Apple/Google stack.
+class _StubGoogleProvider implements NativeCredentialProvider {
+  _StubGoogleProvider();
+
+  int silentCalls = 0;
+  int interactiveCalls = 0;
+  int signOutCalls = 0;
+
+  @override
+  NativeCredentialProviderKind get kind =>
+      NativeCredentialProviderKind.google;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Future<NativeCredentialOutcome> attemptSilent({
+    required String nonce,
+  }) async {
+    silentCalls++;
+    // Silent returns noSession so the waterfall proceeds to interactive
+    // on `ensureAuthenticated`; keeps the test flow deterministic.
+    return const NativeCredentialOutcome.noSession();
+  }
+
+  @override
+  Future<NativeCredentialOutcome> attemptInteractive({
+    required String nonce,
+  }) async {
+    interactiveCalls++;
+    return NativeCredentialOutcome.ok(
+      NativeCredentialResult(
+        provider: NativeCredentialProviderKind.google,
+        idToken: _jwt(<String, dynamic>{
+          'iss': 'https://accounts.google.com',
+          'sub': 'google-user-1',
+          'aud': 'antinvestor-mobile',
+          'nonce': nonce,
+          'email': 'user@example.com',
+          'email_verified': true,
+          'name': 'Test User',
+        }),
+        autoSelected: false,
+        nonce: nonce,
+      ),
+    );
+  }
+
+  @override
+  Future<void> signOut() async {
+    signOutCalls++;
+  }
+}
+
+void main() {
+  late IntegrationHarness harness;
+  late _StubGoogleProvider provider;
+
+  setUp(() async {
+    // Pre-start the mock so we can configure the allowlist before the
+    // runtime's first call — MockIdp defaults already cover Apple+Google
+    // but we set the list explicitly to match the task spec.
+    final mock = MockIdp();
+    await mock.start();
+    mock.setAllowedIssuers(const <String>[
+      'https://appleid.apple.com',
+      'https://accounts.google.com',
+    ]);
+    provider = _StubGoogleProvider();
+    harness = await buildHarness(
+      mock: mock,
+      nativeProviders: <NativeCredentialProvider>[provider],
+    );
+  });
+
+  tearDown(() async {
+    await harness.dispose();
+  });
+
+  test(
+    'ensureAuthenticated completes via RFC 8693 token-exchange through the '
+    'real MockIdp; no authorization_code grant; no OAuth popup',
+    () async {
+      // Let any proactive silent microtask drain before the interactive
+      // call lands, so the recorded-request count reflects only the
+      // interactive leg.
+      for (var i = 0; i < 10; i++) {
+        await Future<void>.delayed(Duration.zero);
+      }
+      expect(harness.runtime.state, AuthState.unauthenticated);
+      expect(provider.silentCalls, 1);
+      // Silent path returned noSession → no HTTP exchange happened yet.
+      expect(harness.mock.tokenRequests, isEmpty);
+
+      await harness.runtime.ensureAuthenticated();
+
+      // Runtime is authenticated off the back of the token-exchange
+      // response from MockIdp.
+      expect(harness.runtime.state, AuthState.authenticated);
+
+      // Exactly one /token hit, and it was the token-exchange grant —
+      // the authorization_code path was never taken.
+      expect(harness.mock.tokenRequests, hasLength(1));
+      final req = harness.mock.tokenRequests.single;
+      expect(
+        req.grantType,
+        'urn:ietf:params:oauth:grant-type:token-exchange',
+      );
+      expect(req.form['subject_issuer'], 'https://accounts.google.com');
+      expect(
+        req.form['subject_token_type'],
+        'urn:ietf:params:oauth:token-type:id_token',
+      );
+      expect(req.form['client_id'], 'antinvestor-mobile');
+
+      // Interactive was exercised exactly once; the OAuth popup (the
+      // FakeOAuthFlow) was never invoked.
+      expect(provider.interactiveCalls, 1);
+      expect(harness.fakeOAuth.calls, 0);
+
+      // Claims from the exchanged session are populated from the
+      // MockIdp-issued ID token (sub carried over from the subject
+      // token via the mock's claim-mapping rule).
+      final claims = await harness.runtime.getClaims();
+      expect(claims['sub'], 'google-user-1');
+    },
+  );
+}

--- a/ui/runtime/test/protocol/token_exchange_test.dart
+++ b/ui/runtime/test/protocol/token_exchange_test.dart
@@ -256,4 +256,105 @@ void main() {
       expect(label, 'rotated');
     });
   });
+
+  group('exchangeIdToken', () {
+    test('posts RFC 8693 token-exchange grant with id_token subject_token_type',
+        () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        expect(req.url.toString(), 'https://idp.example.com/oauth2/token');
+        expect(req.headers['content-type'],
+            startsWith('application/x-www-form-urlencoded'));
+        final form = Uri.splitQueryString(req.body);
+        expect(form['grant_type'],
+            'urn:ietf:params:oauth:grant-type:token-exchange');
+        expect(form['client_id'], 'c');
+        expect(form['subject_token'], 'apple-id-token');
+        expect(form['subject_token_type'],
+            'urn:ietf:params:oauth:token-type:id_token');
+        expect(form['subject_issuer'], 'https://appleid.apple.com');
+        return http.Response(jsonEncode(_tokenResp()), 200,
+            headers: {'content-type': 'application/json'});
+      });
+
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      final tokens = await exchange.exchangeIdToken(
+        cfg,
+        ctx,
+        subjectToken: 'apple-id-token',
+        subjectIssuer: 'https://appleid.apple.com',
+      );
+      expect(tokens.accessToken, 'at-1');
+      expect(tokens.refreshToken, 'rt-1');
+      expect(tokens.tokenType, TokenType.bearer);
+    });
+
+    test('DPoP mode attaches a DPoP proof and handles the nonce challenge',
+        () async {
+      final cfg = _cfg();
+      var tokenCalls = 0;
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc(dpop: true)), 200);
+        }
+        tokenCalls++;
+        expect(req.headers.containsKey('dpop'), isTrue);
+        if (tokenCalls == 1) {
+          return http.Response(
+            jsonEncode({'error': 'use_dpop_nonce'}),
+            401,
+            headers: {'dpop-nonce': 'n-fresh'},
+          );
+        }
+        final proof = req.headers['dpop']!;
+        final payloadB64 = proof.split('.')[1];
+        final padded = payloadB64.padRight(
+            payloadB64.length + (4 - payloadB64.length % 4) % 4, '=');
+        final payload =
+            jsonDecode(utf8.decode(base64Url.decode(padded))) as Map;
+        expect(payload['nonce'], 'n-fresh');
+        return http.Response(jsonEncode(_tokenResp(tokenType: 'DPoP')), 200);
+      });
+
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      final tokens = await exchange.exchangeIdToken(
+        cfg,
+        ctx,
+        subjectToken: 'google-id-token',
+        subjectIssuer: 'https://accounts.google.com',
+      );
+      expect(tokens.tokenType, TokenType.dpop);
+      expect(tokenCalls, 2);
+    });
+
+    test('non-2xx raises tokenExchangeFailed', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        return http.Response('{"error":"invalid_grant"}', 400);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      await expectLater(
+        exchange.exchangeIdToken(
+          cfg,
+          ctx,
+          subjectToken: 'bad',
+          subjectIssuer: 'https://accounts.google.com',
+        ),
+        throwsA(isA<AuthError>()
+            .having((e) => e.code, 'code', AuthErrorCode.tokenExchangeFailed)),
+      );
+    });
+  });
 }

--- a/ui/runtime/test/providers/auth_providers_test.dart
+++ b/ui/runtime/test/providers/auth_providers_test.dart
@@ -168,4 +168,64 @@ void main() {
     );
     expect(seen, isNull);
   });
+
+  group('authNativeProvidersProvider', () {
+    test('defaults to empty list', () {
+      final bare = ProviderContainer();
+      addTearDown(bare.dispose);
+      expect(bare.read(authNativeProvidersProvider), isEmpty);
+    });
+
+    test('can be overridden at the root', () {
+      final stub = _StubNativeProvider(NativeCredentialProviderKind.google);
+      final scoped = ProviderContainer(
+        overrides: [
+          authNativeProvidersProvider
+              .overrideWithValue(<NativeCredentialProvider>[stub]),
+        ],
+      );
+      addTearDown(scoped.dispose);
+      final list = scoped.read(authNativeProvidersProvider);
+      expect(list, hasLength(1));
+      expect(list.single, same(stub));
+      expect(list.single.kind, NativeCredentialProviderKind.google);
+    });
+
+    test('default list does not accept mutations (const empty)', () {
+      final bare = ProviderContainer();
+      addTearDown(bare.dispose);
+      final list = bare.read(authNativeProvidersProvider);
+      expect(
+        () => list.add(_StubNativeProvider(
+          NativeCredentialProviderKind.apple,
+        )),
+        throwsUnsupportedError,
+      );
+    });
+  });
+}
+
+class _StubNativeProvider implements NativeCredentialProvider {
+  _StubNativeProvider(this.kind);
+
+  @override
+  final NativeCredentialProviderKind kind;
+
+  @override
+  Future<bool> isAvailable() async => true;
+
+  @override
+  Future<NativeCredentialOutcome> attemptSilent({
+    required String nonce,
+  }) async =>
+      const NativeCredentialOutcome.noSession();
+
+  @override
+  Future<NativeCredentialOutcome> attemptInteractive({
+    required String nonce,
+  }) async =>
+      const NativeCredentialOutcome.cancelled();
+
+  @override
+  Future<void> signOut() async {}
 }

--- a/ui/runtime/test/support/fake_auth_runtime.dart
+++ b/ui/runtime/test/support/fake_auth_runtime.dart
@@ -22,6 +22,11 @@ class FakeAuthRuntime implements AuthRuntime {
       StreamController<AuthState>.broadcast();
   final StreamController<SecurityEvent> _secCtl =
       StreamController<SecurityEvent>.broadcast();
+  final StreamController<CredentialEvent> _credCtl =
+      StreamController<CredentialEvent>.broadcast();
+
+  Set<NativeCredentialProviderKind> availableProviders =
+      const <NativeCredentialProviderKind>{};
 
   AuthState _state;
   Map<String, dynamic> _claims;
@@ -45,6 +50,13 @@ class FakeAuthRuntime implements AuthRuntime {
 
   @override
   Stream<SecurityEvent> get securityEventStream => _secCtl.stream;
+
+  @override
+  Future<Set<NativeCredentialProviderKind>> availableNativeProviders() async =>
+      availableProviders;
+
+  @override
+  Stream<CredentialEvent> get credentialEventStream => _credCtl.stream;
 
   @override
   String get version => authRuntimeVersion;
@@ -124,5 +136,6 @@ class FakeAuthRuntime implements AuthRuntime {
     _disposed = true;
     await _stateCtl.close();
     await _secCtl.close();
+    await _credCtl.close();
   }
 }

--- a/ui/runtime/test/worker/messages_test.dart
+++ b/ui/runtime/test/worker/messages_test.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
 import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
@@ -74,6 +75,28 @@ void main() {
       expect(r.bytes, bytes);
       expect(r.filename, 'a.bin');
       expect(r.contentType, 'application/octet-stream');
+    });
+
+    test('completeNativeCredential round-trips all fields', () {
+      final orig = const CompleteNativeCredentialRequest(
+        correlationId: 'c-nc',
+        provider: NativeCredentialProviderKind.google,
+        idToken: 'id-token-xyz',
+        autoSelected: true,
+        expectedNonce: 'expected-nonce',
+        nonce: 'nonce',
+        authorizationCode: 'auth-code',
+      );
+      final r = _roundTripRequest(orig);
+      expect(r.provider, NativeCredentialProviderKind.google);
+      expect(r.idToken, 'id-token-xyz');
+      expect(r.autoSelected, true);
+      expect(r.expectedNonce, 'expected-nonce');
+      expect(r.nonce, 'nonce');
+      expect(r.authorizationCode, 'auth-code');
+      final result = r.toResult();
+      expect(result.provider, NativeCredentialProviderKind.google);
+      expect(result.idToken, 'id-token-xyz');
     });
 
     test('getRoles, getClaims, logout, destroy round-trip', () {
@@ -153,6 +176,15 @@ void main() {
       final err = r.toAuthError();
       expect(err.code, AuthErrorCode.apiUnauthorized);
       expect(err.traceId, 'trace-xyz');
+    });
+
+    test('completeNativeCredentialOk round-trips provider', () {
+      final r = _roundTripEvent(const CompleteNativeCredentialOkEvent(
+        correlationId: 'c-nc-ok',
+        provider: NativeCredentialProviderKind.apple,
+      ));
+      expect(r.provider, NativeCredentialProviderKind.apple);
+      expect(r.correlationId, 'c-nc-ok');
     });
 
     test('roles + claims round-trip', () {

--- a/ui/runtime/test/worker/token_worker_test.dart
+++ b/ui/runtime/test/worker/token_worker_test.dart
@@ -761,6 +761,42 @@ void main() {
       await w.destroy();
     });
 
+    test(
+        'missing nonce claim → nativeCredentialExchangeFailed even when '
+        'credential.nonce is null', () async {
+      final d = _Deps();
+      final w = d.build();
+      const expected = 'nonce-expected';
+      // Token has NO `nonce` claim; credential reports nonce=null. Nonce
+      // binding must still be enforced because the runtime passes an
+      // expectedNonce on every call.
+      final idToken = _makeJwt(<String, dynamic>{
+        'iss': 'https://accounts.google.com',
+        'aud': 'c',
+        'sub': 'g-user-1',
+      });
+      await w.init();
+      await expectLater(
+        w.completeNativeCredential(
+          credential: NativeCredentialResult(
+            provider: NativeCredentialProviderKind.google,
+            idToken: idToken,
+            autoSelected: false,
+            nonce: null,
+          ),
+          expectedNonce: expected,
+        ),
+        throwsA(isA<AuthError>().having(
+          (e) => e.code,
+          'code',
+          AuthErrorCode.nativeCredentialExchangeFailed,
+        )),
+      );
+      expect(d.tokenExchange.idTokenExchangeCalls, 0);
+      expect(w.state, AuthState.unauthenticated);
+      await w.destroy();
+    });
+
     test('exchange failure transitions to unauthenticated and rethrows',
         () async {
       final d = _Deps();

--- a/ui/runtime/test/worker/token_worker_test.dart
+++ b/ui/runtime/test/worker/token_worker_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:antinvestor_auth_runtime/src/config/auth_config.dart';
 import 'package:antinvestor_auth_runtime/src/config/resolve_config.dart';
+import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/default_key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/key_manager.dart';
 import 'package:antinvestor_auth_runtime/src/crypto/root_key_store.dart';
@@ -20,6 +21,7 @@ import 'package:antinvestor_auth_runtime/src/runtime/refresh_lock.dart';
 import 'package:antinvestor_auth_runtime/src/storage/secure_token_store.dart';
 import 'package:antinvestor_auth_runtime/src/storage/token_store.dart';
 import 'package:antinvestor_auth_runtime/src/worker/token_worker.dart';
+import 'package:crypto/crypto.dart' as crypto;
 import 'package:flutter_test/flutter_test.dart';
 
 // ---------------------------------------------------------------------------
@@ -60,8 +62,13 @@ class _FakeTokenExchange extends TokenExchange {
 
   List<TokenSet> rotateQueue = [];
   List<RefreshOutcome> refreshQueue = [];
+  List<TokenSet> idTokenExchangeQueue = [];
+  AuthError? idTokenExchangeError;
   int exchangeCalls = 0;
   int refreshCalls = 0;
+  int idTokenExchangeCalls = 0;
+  String? lastSubjectToken;
+  String? lastSubjectIssuer;
 
   @override
   Future<TokenSet> exchangeCode(
@@ -78,6 +85,26 @@ class _FakeTokenExchange extends TokenExchange {
       );
     }
     return rotateQueue.removeAt(0);
+  }
+
+  @override
+  Future<TokenSet> exchangeIdToken(
+    ResolvedConfig cfg,
+    DpopContext ctx, {
+    required String subjectToken,
+    required String subjectIssuer,
+  }) async {
+    idTokenExchangeCalls++;
+    lastSubjectToken = subjectToken;
+    lastSubjectIssuer = subjectIssuer;
+    if (idTokenExchangeError != null) throw idTokenExchangeError!;
+    if (idTokenExchangeQueue.isEmpty) {
+      throw AuthError(
+        AuthErrorCode.tokenExchangeFailed,
+        'fake: no id-token exchange queued',
+      );
+    }
+    return idTokenExchangeQueue.removeAt(0);
   }
 
   @override
@@ -593,6 +620,183 @@ void main() {
     await w.destroy();
     expect(() => w.init(), throwsStateError);
     expect(() => w.prepareAuth(), throwsStateError);
+  });
+
+  group('completeNativeCredential', () {
+    test('google: happy path exchanges id-token and authenticates', () async {
+      final d = _Deps();
+      final w = d.build();
+      const nonce = 'nonce-google-1';
+      final idToken = _makeJwt(<String, dynamic>{
+        'iss': 'https://accounts.google.com',
+        'aud': 'c',
+        'sub': 'g-user-1',
+        'nonce': nonce,
+      });
+      d.tokenExchange.idTokenExchangeQueue
+          .add(_tokens(access: 'at-native', refresh: 'rt-native'));
+
+      final states = <AuthState>[];
+      w.authStateStream.listen(states.add);
+
+      await w.init();
+      await w.completeNativeCredential(
+        credential: NativeCredentialResult(
+          provider: NativeCredentialProviderKind.google,
+          idToken: idToken,
+          autoSelected: true,
+          nonce: nonce,
+        ),
+        expectedNonce: nonce,
+      );
+      await Future<void>.delayed(Duration.zero);
+
+      expect(d.tokenExchange.idTokenExchangeCalls, 1);
+      expect(d.tokenExchange.lastSubjectToken, idToken);
+      expect(d.tokenExchange.lastSubjectIssuer, 'https://accounts.google.com');
+      expect(w.state, AuthState.authenticated);
+      expect(states.last, AuthState.authenticated);
+      expect(await d.tokenStore.load(d.config.namespace), isNotNull);
+      await w.destroy();
+    });
+
+    test('apple: accepts sha256-hex of nonce as the nonce claim', () async {
+      final d = _Deps();
+      final w = d.build();
+      const rawNonce = 'nonce-apple-1';
+      final hashed =
+          crypto.sha256.convert(utf8.encode(rawNonce)).toString();
+      final idToken = _makeJwt(<String, dynamic>{
+        'iss': 'https://appleid.apple.com',
+        'aud': 'c',
+        'sub': 'a-user-1',
+        'nonce': hashed,
+      });
+      d.tokenExchange.idTokenExchangeQueue
+          .add(_tokens(access: 'at-apple', refresh: 'rt-apple'));
+
+      await w.init();
+      await w.completeNativeCredential(
+        credential: NativeCredentialResult(
+          provider: NativeCredentialProviderKind.apple,
+          idToken: idToken,
+          autoSelected: false,
+          nonce: rawNonce,
+        ),
+        expectedNonce: rawNonce,
+      );
+      expect(d.tokenExchange.idTokenExchangeCalls, 1);
+      expect(d.tokenExchange.lastSubjectIssuer, 'https://appleid.apple.com');
+      expect(w.state, AuthState.authenticated);
+      await w.destroy();
+    });
+
+    test('iss mismatch → nativeCredentialIssuerMismatch; no exchange',
+        () async {
+      final d = _Deps();
+      final w = d.build();
+      const nonce = 'nonce-bad-iss';
+      final idToken = _makeJwt(<String, dynamic>{
+        'iss': 'https://evil.example.com',
+        'aud': 'c',
+        'sub': 'g-user-1',
+        'nonce': nonce,
+      });
+      final states = <AuthState>[];
+      w.authStateStream.listen(states.add);
+
+      await w.init();
+      await expectLater(
+        w.completeNativeCredential(
+          credential: NativeCredentialResult(
+            provider: NativeCredentialProviderKind.google,
+            idToken: idToken,
+            autoSelected: false,
+            nonce: nonce,
+          ),
+          expectedNonce: nonce,
+        ),
+        throwsA(isA<AuthError>().having(
+          (e) => e.code,
+          'code',
+          AuthErrorCode.nativeCredentialIssuerMismatch,
+        )),
+      );
+      await Future<void>.delayed(Duration.zero);
+      expect(d.tokenExchange.idTokenExchangeCalls, 0);
+      expect(w.state, AuthState.unauthenticated);
+      await w.destroy();
+    });
+
+    test('nonce mismatch → nativeCredentialExchangeFailed; no exchange',
+        () async {
+      final d = _Deps();
+      final w = d.build();
+      const expected = 'nonce-expected';
+      final idToken = _makeJwt(<String, dynamic>{
+        'iss': 'https://accounts.google.com',
+        'aud': 'c',
+        'sub': 'g-user-1',
+        'nonce': 'nonce-wrong',
+      });
+      await w.init();
+      await expectLater(
+        w.completeNativeCredential(
+          credential: NativeCredentialResult(
+            provider: NativeCredentialProviderKind.google,
+            idToken: idToken,
+            autoSelected: false,
+            nonce: 'nonce-wrong',
+          ),
+          expectedNonce: expected,
+        ),
+        throwsA(isA<AuthError>().having(
+          (e) => e.code,
+          'code',
+          AuthErrorCode.nativeCredentialExchangeFailed,
+        )),
+      );
+      expect(d.tokenExchange.idTokenExchangeCalls, 0);
+      expect(w.state, AuthState.unauthenticated);
+      await w.destroy();
+    });
+
+    test('exchange failure transitions to unauthenticated and rethrows',
+        () async {
+      final d = _Deps();
+      final w = d.build();
+      const nonce = 'nonce-fail';
+      final idToken = _makeJwt(<String, dynamic>{
+        'iss': 'https://accounts.google.com',
+        'aud': 'c',
+        'sub': 'g-user-1',
+        'nonce': nonce,
+      });
+      d.tokenExchange.idTokenExchangeError = AuthError(
+        AuthErrorCode.tokenExchangeFailed,
+        'boom',
+      );
+
+      await w.init();
+      await expectLater(
+        w.completeNativeCredential(
+          credential: NativeCredentialResult(
+            provider: NativeCredentialProviderKind.google,
+            idToken: idToken,
+            autoSelected: false,
+            nonce: nonce,
+          ),
+          expectedNonce: nonce,
+        ),
+        throwsA(isA<AuthError>().having(
+          (e) => e.code,
+          'code',
+          AuthErrorCode.tokenExchangeFailed,
+        )),
+      );
+      expect(w.state, AuthState.unauthenticated);
+      await w.destroy();
+    });
   });
 }
 


### PR DESCRIPTION
**⚠ Stacked on #640. Merge that first; this PR will retarget to main after.**

Adds native silent-sign-in fast paths for Sign in with Apple (iOS/macOS) and Google (Android via CredentialManager, iOS via Google Sign-In SDK) on top of v0.1.0's OAuth2 flow. Additive — no breaking changes to the v0.1 public surface.

## Waterfall

\`\`\`
unauthenticated
  ├─ proactive silent → Apple (iOS/macOS) or Google CM (Android) [on mount]
  │    ↳ got id_token → token-exchange grant + DPoP → authenticated
  │    ↳ no session → fall through
  └─ on sign-in click → interactive native attempt
       ↳ success → token-exchange → authenticated
       ↳ decline/cancel/unavailable → OAuth2 popup (v0.1 path)
\`\`\`

## Security posture

- Main-thread \`iss\` pinning before token-exchange (\`https://appleid.apple.com\` / \`https://accounts.google.com\`).
- Per-attempt nonce binding, unconditionally enforced when \`expectedNonce\` is present (fixed in post-review pass).
- Apple's SHA-256 nonce hashing accommodated; worker accepts either raw or hashed match.
- \`signOut()\` called on every configured provider before server revocation.
- Four new \`AuthErrorCode\` values: \`nativeCredentialCancelled\`, \`nativeCredentialUnavailable\`, \`nativeCredentialIssuerMismatch\` (non-retryable), \`nativeCredentialExchangeFailed\`.

## Backend dependency

IdP (Ory Hydra) must enable the \`urn:ietf:params:oauth:grant-type:token-exchange\` grant and register Apple + Google as trusted issuers. Setup documented at \`docs/auth-runtime-native-credentials.md\`. **Coordinate with service-authentication Go team before production enablement.**

## Plan + review

- Plan: \`docs/superpowers/plans/2026-04-20-auth-runtime-native-credentials.md\`.
- Independent code review run after initial implementation surfaced 4 critical + 3 important issues; all fixed with 7 follow-up commits (see commit log: \`ebf7acd\`, \`8600cca\`, \`d763da9\`, \`03057f9\`, \`17419dc\`, \`b7827cc\`, \`3d4c09a\`).

## Test plan

- [x] 295 tests passing (unit + widget + integration via shelf MockIdp accepting token-exchange grant).
- [x] \`flutter analyze\` clean.
- [x] \`flutter pub publish --dry-run\` clean.
- [x] 12 regression tests covering the four critical paths found in review.

## Dependencies added

- \`sign_in_with_apple: ^6.1.4\`
- \`google_sign_in: ^7.2.0\` (CredentialManager backend on Android)