### PR TITLE
feat(ui/runtime): antinvestor_auth_runtime v0.3.0 — audiences + typed claims + background-task

### DIFF
--- a/ui/runtime/CHANGELOG.md
+++ b/ui/runtime/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to `antinvestor_auth_runtime` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.0 — 2026-04-20
+
+### Added
+- `AuthConfig.audiences` — optional resource audience hints passed to authorize + token-exchange. Addresses service-thesa's 9-element audiences array use case.
+- `AuthConfig.redirectUri` — explicit override of the OAuth redirect URI; takes precedence over `redirectScheme`. Supports desktop loopback flows (`http://localhost:5173/auth`).
+- `UserClaims.contactId`, `tenantId`, `partitionId` typed getters for Antinvestor-specific claims; plus `customClaims` escape hatch for bespoke per-app claims.
+- `AuthRuntime.getUserClaims()` — typed wrapper around `getClaims()`.
+- `AuthRuntime.isAuthenticated` — synchronous getter for background-task pre-check.
+
+### Changed
+- None. Purely additive; existing v0.2 callers are unaffected.
+
 ## 0.2.0 — 2026-04-20
 
 ### Added

--- a/ui/runtime/README.md
+++ b/ui/runtime/README.md
@@ -254,6 +254,82 @@ Supported methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`.
 use `runtime.upload(path, fieldName:, filename:, contentType:, bytes:,
 length:)` — multipart form-data with automatic retry on 401.
 
+## Audiences (thesa pattern)
+
+Apps that front several downstream services need their access tokens to
+carry a specific `aud` claim per service. `AuthConfig.audiences`
+forwards a comma-joined `audience` parameter to both the authorize
+endpoint and the token-exchange grant; Ory Hydra mints a token whose
+`aud` claim contains every requested value.
+
+```dart
+createAuthRuntime(const AuthConfig(
+  clientId: 'antinvestor-thesa-web',
+  idpBaseUrl: 'https://auth.antinvestor.com',
+  apiBaseUrl: 'https://api.antinvestor.com',
+  redirectScheme: 'com.antinvestor.thesa',
+  audiences: [
+    'service-notification',
+    'service-profile',
+    'service-partition',
+    'service-payment',
+    'service-ledger',
+    'service-contact',
+    'service-property',
+    'service-device',
+    'service-files',
+  ],
+));
+```
+
+Omit the field (the default) when your client talks to a single
+service.
+
+## Typed claim getters
+
+`AuthRuntime.getUserClaims()` wraps the raw claims map in a `UserClaims`
+with typed accessors — including the Antinvestor-wide non-standard
+claims (`contact_id`, `tenant_id`, `partition_id`).
+
+```dart
+final claims = await runtime.getUserClaims();
+debugPrint('contact=${claims.contactId} tenant=${claims.tenantId}');
+
+// Reach into bespoke per-app claims via the escape hatch:
+final extra = claims.customClaims;
+```
+
+`customClaims` returns every claim that is **not** part of the OIDC
+core / JWT registered set, so apps can surface their own fields without
+colliding with the typed getters.
+
+## Background tasks (WorkManager)
+
+Android WorkManager (and similar Isolate-spawning background frameworks)
+can instantiate the runtime inside a short-lived isolate and bail out
+early when the user is signed out. Use `AuthRuntime.isAuthenticated`
+for the synchronous pre-check so you don't pay for async warmup on a
+terminal device.
+
+```dart
+class BackgroundAuth {
+  static Future<T?> withRuntime<T>(Future<T> Function(AuthRuntime) fn) async {
+    final runtime = createAuthRuntime(kConfig);
+    try {
+      if (!runtime.isAuthenticated) return null;
+      return await fn(runtime);
+    } finally {
+      await runtime.dispose();
+    }
+  }
+}
+```
+
+> **Warning:** Do NOT share runtime instances across Isolates. Construct
+> and `dispose()` a fresh runtime per task — the token worker's streams,
+> storage handles, and DPoP key material are not safe to move across
+> isolate boundaries.
+
 ## Widget reference
 
 | Widget | Purpose |

--- a/ui/runtime/lib/src/auth_runtime.dart
+++ b/ui/runtime/lib/src/auth_runtime.dart
@@ -76,6 +76,13 @@ abstract class AuthRuntime {
   /// Synchronous snapshot of [authStateStream]'s latest value.
   AuthState get state;
 
+  /// Synchronous convenience for `state == AuthState.authenticated`.
+  ///
+  /// Useful in background-task contexts (e.g. Android WorkManager callbacks)
+  /// where the caller wants to bail out early without spinning up the
+  /// runtime's async surface.
+  bool get isAuthenticated;
+
   /// Set of native credential providers advertised as currently available
   /// on this platform. Callers use this to decide whether to render a
   /// "Continue with Apple/Google" button; the runtime additionally

--- a/ui/runtime/lib/src/auth_runtime.dart
+++ b/ui/runtime/lib/src/auth_runtime.dart
@@ -3,6 +3,7 @@ import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart'
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
 import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/models/user_claims.dart';
 
 /// Public, isolate-agnostic contract consumed by Flutter apps.
 ///
@@ -49,6 +50,10 @@ abstract class AuthRuntime {
   /// Claims decoded from the current ID token. Returns `{}` when no
   /// session is active or no ID token was issued.
   Future<Map<String, dynamic>> getClaims();
+
+  /// Typed-getter wrapper around [getClaims]. Returns an empty
+  /// [UserClaims] when no session is active.
+  Future<UserClaims> getUserClaims();
 
   /// Roles extracted from the current access token. Returns `[]` when
   /// unauthenticated. Supports both top-level `roles` and

--- a/ui/runtime/lib/src/auth_runtime.dart
+++ b/ui/runtime/lib/src/auth_runtime.dart
@@ -110,4 +110,4 @@ abstract class AuthRuntime {
 /// Version of the runtime. Callers include this in telemetry / bug
 /// reports. Kept as a bare constant for now; wired through
 /// `--dart-define=AUTH_RUNTIME_VERSION=...` in a follow-up task.
-const String authRuntimeVersion = '0.2.0';
+const String authRuntimeVersion = '0.3.0';

--- a/ui/runtime/lib/src/auth_runtime_impl.dart
+++ b/ui/runtime/lib/src/auth_runtime_impl.dart
@@ -9,6 +9,7 @@ import 'package:antinvestor_auth_runtime/src/credentials/native_credential.dart'
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
 import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/models/user_claims.dart';
 import 'package:antinvestor_auth_runtime/src/oauth/oauth_flow.dart';
 import 'package:antinvestor_auth_runtime/src/worker/token_worker.dart';
 
@@ -297,6 +298,13 @@ class AuthRuntimeImpl implements AuthRuntime {
       return const <String, dynamic>{};
     }
     return worker.getClaims();
+  }
+
+  @override
+  Future<UserClaims> getUserClaims() async {
+    _ensureAlive();
+    final raw = await getClaims();
+    return UserClaims(raw);
   }
 
   @override

--- a/ui/runtime/lib/src/auth_runtime_impl.dart
+++ b/ui/runtime/lib/src/auth_runtime_impl.dart
@@ -366,6 +366,9 @@ class AuthRuntimeImpl implements AuthRuntime {
   AuthState get state => worker.state;
 
   @override
+  bool get isAuthenticated => worker.state == AuthState.authenticated;
+
+  @override
   Future<void> prefetchDiscovery() async {
     _ensureAlive();
     // Piggyback on the worker's discovery client — result is cached at

--- a/ui/runtime/lib/src/config/auth_config.dart
+++ b/ui/runtime/lib/src/config/auth_config.dart
@@ -12,6 +12,7 @@ class AuthConfig extends Equatable {
     required this.apiBaseUrl,
     required this.redirectScheme,
     this.scopes,
+    this.audiences,
     this.installationId,
     this.discoveryTimeout,
     this.tokenTimeout,
@@ -24,6 +25,12 @@ class AuthConfig extends Equatable {
   final String apiBaseUrl;
   final String redirectScheme;
   final List<String>? scopes;
+
+  /// Optional resource audience hints passed to the authorize endpoint via
+  /// `audience=<comma-joined>`. Hydra accepts comma-separated values per
+  /// its docs. Omit when null (default).
+  final List<String>? audiences;
+
   final String? installationId;
   final Duration? discoveryTimeout;
   final Duration? tokenTimeout;
@@ -37,6 +44,7 @@ class AuthConfig extends Equatable {
         apiBaseUrl,
         redirectScheme,
         scopes,
+        audiences,
         installationId,
         discoveryTimeout,
         tokenTimeout,

--- a/ui/runtime/lib/src/config/auth_config.dart
+++ b/ui/runtime/lib/src/config/auth_config.dart
@@ -13,6 +13,7 @@ class AuthConfig extends Equatable {
     required this.redirectScheme,
     this.scopes,
     this.audiences,
+    this.redirectUri,
     this.installationId,
     this.discoveryTimeout,
     this.tokenTimeout,
@@ -31,6 +32,11 @@ class AuthConfig extends Equatable {
   /// its docs. Omit when null (default).
   final List<String>? audiences;
 
+  /// Explicit redirect URI; takes precedence over [redirectScheme] when
+  /// set. Use for desktop loopback (`http://localhost:5173/auth`) or when
+  /// a specific URI is required by the IdP.
+  final String? redirectUri;
+
   final String? installationId;
   final Duration? discoveryTimeout;
   final Duration? tokenTimeout;
@@ -45,6 +51,7 @@ class AuthConfig extends Equatable {
         redirectScheme,
         scopes,
         audiences,
+        redirectUri,
         installationId,
         discoveryTimeout,
         tokenTimeout,

--- a/ui/runtime/lib/src/config/resolve_config.dart
+++ b/ui/runtime/lib/src/config/resolve_config.dart
@@ -28,6 +28,7 @@ class ResolvedConfig {
     required this.idpBaseUrl,
     required this.apiBaseUrl,
     required this.redirectScheme,
+    required this.redirectUri,
     required this.scopes,
     required this.audiences,
     required this.installationId,
@@ -41,6 +42,12 @@ class ResolvedConfig {
   final String idpBaseUrl;
   final String apiBaseUrl;
   final String redirectScheme;
+
+  /// Fully-resolved OAuth redirect URI. Uses [AuthConfig.redirectUri] when
+  /// provided, otherwise derived from [redirectScheme] as
+  /// `{scheme}://callback` (the v0.2 convention).
+  final String redirectUri;
+
   final List<String> scopes;
 
   /// Resource audience hints forwarded to the IdP's authorize and
@@ -56,14 +63,19 @@ class ResolvedConfig {
 
   /// `"{clientId}::{idpBaseUrl}"` — cache and storage key suffix.
   String get namespace => '$clientId::$idpBaseUrl';
-
-  /// Convention-driven redirect URI: `{scheme}://callback`.
-  String get redirectUri => '$redirectScheme://callback';
 }
 
 /// Normalizes an [AuthConfig] into a fully-populated [ResolvedConfig].
 ///
 /// Throws `AuthError(invalidConfig)` if any required string is blank.
+///
+/// Redirect resolution order:
+/// 1. [AuthConfig.redirectUri] (explicit override, used verbatim).
+/// 2. Derived from [AuthConfig.redirectScheme] as `{scheme}://callback`.
+///
+/// At least one of the two must be non-empty; otherwise `invalidConfig`
+/// is thrown. The resolved [ResolvedConfig.redirectUri] is always
+/// non-null.
 ResolvedConfig resolveConfig(AuthConfig cfg) {
   if (cfg.clientId.isEmpty) {
     throw AuthError(AuthErrorCode.invalidConfig, 'clientId is required');
@@ -74,15 +86,25 @@ ResolvedConfig resolveConfig(AuthConfig cfg) {
   if (cfg.apiBaseUrl.isEmpty) {
     throw AuthError(AuthErrorCode.invalidConfig, 'apiBaseUrl is required');
   }
-  if (cfg.redirectScheme.isEmpty) {
-    throw AuthError(AuthErrorCode.invalidConfig, 'redirectScheme is required');
+  final explicitRedirect = cfg.redirectUri;
+  final hasExplicitRedirect =
+      explicitRedirect != null && explicitRedirect.isNotEmpty;
+  if (!hasExplicitRedirect && cfg.redirectScheme.isEmpty) {
+    throw AuthError(
+      AuthErrorCode.invalidConfig,
+      'redirectScheme or redirectUri is required',
+    );
   }
+  final redirectUri = hasExplicitRedirect
+      ? explicitRedirect
+      : '${cfg.redirectScheme}://callback';
 
   return ResolvedConfig(
     clientId: cfg.clientId,
     idpBaseUrl: _stripTrailingSlash(cfg.idpBaseUrl),
     apiBaseUrl: _stripTrailingSlash(cfg.apiBaseUrl),
     redirectScheme: cfg.redirectScheme,
+    redirectUri: redirectUri,
     scopes: List<String>.unmodifiable(cfg.scopes ?? defaultScopes),
     audiences: List<String>.unmodifiable(cfg.audiences ?? const <String>[]),
     installationId: cfg.installationId,

--- a/ui/runtime/lib/src/config/resolve_config.dart
+++ b/ui/runtime/lib/src/config/resolve_config.dart
@@ -29,6 +29,7 @@ class ResolvedConfig {
     required this.apiBaseUrl,
     required this.redirectScheme,
     required this.scopes,
+    required this.audiences,
     required this.installationId,
     required this.discoveryTimeout,
     required this.tokenTimeout,
@@ -41,6 +42,12 @@ class ResolvedConfig {
   final String apiBaseUrl;
   final String redirectScheme;
   final List<String> scopes;
+
+  /// Resource audience hints forwarded to the IdP's authorize and
+  /// token-exchange endpoints as a comma-joined `audience` parameter.
+  /// Defaults to an empty list when the caller omits [AuthConfig.audiences].
+  final List<String> audiences;
+
   final String? installationId;
   final Duration discoveryTimeout;
   final Duration tokenTimeout;
@@ -77,6 +84,7 @@ ResolvedConfig resolveConfig(AuthConfig cfg) {
     apiBaseUrl: _stripTrailingSlash(cfg.apiBaseUrl),
     redirectScheme: cfg.redirectScheme,
     scopes: List<String>.unmodifiable(cfg.scopes ?? defaultScopes),
+    audiences: List<String>.unmodifiable(cfg.audiences ?? const <String>[]),
     installationId: cfg.installationId,
     discoveryTimeout: cfg.discoveryTimeout ?? _defaultDiscoveryTimeout,
     tokenTimeout: cfg.tokenTimeout ?? _defaultTokenTimeout,

--- a/ui/runtime/lib/src/factory.dart
+++ b/ui/runtime/lib/src/factory.dart
@@ -13,6 +13,7 @@ import 'package:antinvestor_auth_runtime/src/isolated_auth_runtime.dart';
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
 import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/models/user_claims.dart';
 import 'package:antinvestor_auth_runtime/src/oauth/oauth_flow.dart';
 import 'package:antinvestor_auth_runtime/src/protocol/api_proxy.dart';
 import 'package:antinvestor_auth_runtime/src/protocol/token_exchange.dart';
@@ -173,6 +174,10 @@ class _LazyIsolatedAuthRuntime implements AuthRuntime {
   @override
   Future<Map<String, dynamic>> getClaims() async =>
       (await _ready).getClaims();
+
+  @override
+  Future<UserClaims> getUserClaims() async =>
+      (await _ready).getUserClaims();
 
   @override
   Future<List<String>> getRoles() async => (await _ready).getRoles();

--- a/ui/runtime/lib/src/factory.dart
+++ b/ui/runtime/lib/src/factory.dart
@@ -201,6 +201,9 @@ class _LazyIsolatedAuthRuntime implements AuthRuntime {
   AuthState get state => AuthState.initializing;
 
   @override
+  bool get isAuthenticated => state == AuthState.authenticated;
+
+  @override
   Future<Set<NativeCredentialProviderKind>> availableNativeProviders() async =>
       (await _ready).availableNativeProviders();
 

--- a/ui/runtime/lib/src/isolated_auth_runtime.dart
+++ b/ui/runtime/lib/src/isolated_auth_runtime.dart
@@ -144,6 +144,9 @@ class IsolatedAuthRuntime implements AuthRuntime {
   AuthState get state => _state;
 
   @override
+  bool get isAuthenticated => _state == AuthState.authenticated;
+
+  @override
   Future<Set<NativeCredentialProviderKind>> availableNativeProviders() async {
     _ensureAlive();
     // Native credential providers run main-isolate-only in v0.2; isolate

--- a/ui/runtime/lib/src/isolated_auth_runtime.dart
+++ b/ui/runtime/lib/src/isolated_auth_runtime.dart
@@ -8,6 +8,7 @@ import 'package:antinvestor_auth_runtime/src/errors/auth_error.dart';
 import 'package:antinvestor_auth_runtime/src/models/api_response.dart';
 import 'package:antinvestor_auth_runtime/src/models/auth_state.dart';
 import 'package:antinvestor_auth_runtime/src/models/security_event.dart';
+import 'package:antinvestor_auth_runtime/src/models/user_claims.dart';
 import 'package:antinvestor_auth_runtime/src/worker/messages.dart';
 import 'package:antinvestor_auth_runtime/src/worker/token_isolate.dart';
 
@@ -110,6 +111,12 @@ class IsolatedAuthRuntime implements AuthRuntime {
   Future<Map<String, dynamic>> getClaims() async {
     _ensureAlive();
     return const <String, dynamic>{};
+  }
+
+  @override
+  Future<UserClaims> getUserClaims() async {
+    _ensureAlive();
+    return const UserClaims(<String, dynamic>{});
   }
 
   @override

--- a/ui/runtime/lib/src/models/user_claims.dart
+++ b/ui/runtime/lib/src/models/user_claims.dart
@@ -1,7 +1,9 @@
 /// Thin wrapper around the claims map decoded from a JWT.
 ///
-/// Only surfaces canonical OIDC fields as typed getters; callers needing
-/// custom claims can reach through [raw]. Role extraction matches the JS
+/// Surfaces canonical OIDC fields as typed getters plus a few
+/// Antinvestor-wide non-standard claims (`contact_id`, `tenant_id`,
+/// `partition_id`). Callers needing anything else can reach through
+/// [raw] directly or via [customClaims]. Role extraction matches the JS
 /// `extractRolesFromToken` — supporting both `roles` and
 /// `realm_access.roles`.
 class UserClaims {
@@ -13,6 +15,16 @@ class UserClaims {
   String? get name => _asString(raw['name']);
   String? get email => _asString(raw['email']);
   String? get picture => _asString(raw['picture']);
+
+  /// Non-standard `contact_id` claim issued by Antinvestor's IdP. Null
+  /// when the claim is missing or not a string.
+  String? get contactId => _asString(raw['contact_id']);
+
+  /// Non-standard `tenant_id` claim issued by Antinvestor's IdP.
+  String? get tenantId => _asString(raw['tenant_id']);
+
+  /// Non-standard `partition_id` claim issued by Antinvestor's IdP.
+  String? get partitionId => _asString(raw['partition_id']);
 
   List<String> get roles {
     final direct = raw['roles'];
@@ -29,5 +41,29 @@ class UserClaims {
     return const [];
   }
 
+  /// All non-standard (non-OIDC) claims. Use for bespoke per-app claims
+  /// the runtime doesn't surface as typed getters.
+  Map<String, dynamic> get customClaims {
+    return Map<String, dynamic>.fromEntries(
+      raw.entries.where((e) => !_standardOidcClaims.contains(e.key)),
+    );
+  }
+
   static String? _asString(Object? v) => v is String ? v : null;
 }
+
+/// RFC 8693 / OIDC Core standard claim names. Anything outside this set
+/// is treated as a "custom" claim by [UserClaims.customClaims].
+const Set<String> _standardOidcClaims = <String>{
+  // JWT registered / OIDC id-token claims.
+  'iss', 'sub', 'aud', 'exp', 'iat', 'nbf', 'jti', 'nonce',
+  'azp', 'auth_time', 'acr', 'amr',
+  // Profile claims.
+  'name', 'given_name', 'family_name', 'middle_name', 'nickname',
+  'preferred_username', 'profile', 'picture', 'website',
+  // Email / phone / address claims.
+  'email', 'email_verified',
+  'gender', 'birthdate', 'zoneinfo', 'locale',
+  'phone_number', 'phone_number_verified',
+  'address', 'updated_at',
+};

--- a/ui/runtime/lib/src/protocol/token_exchange.dart
+++ b/ui/runtime/lib/src/protocol/token_exchange.dart
@@ -61,6 +61,7 @@ class TokenExchange {
       'code': code,
       'redirect_uri': cfg.redirectUri,
       'code_verifier': verifier,
+      if (cfg.audiences.isNotEmpty) 'audience': cfg.audiences.join(','),
     };
     final res = await _postForm(cfg, ctx, form);
     if (res.statusCode < 200 || res.statusCode >= 300) {
@@ -92,6 +93,7 @@ class TokenExchange {
       'subject_token': subjectToken,
       'subject_token_type': 'urn:ietf:params:oauth:token-type:id_token',
       'subject_issuer': subjectIssuer,
+      if (cfg.audiences.isNotEmpty) 'audience': cfg.audiences.join(','),
     };
     final res = await _postForm(cfg, ctx, form);
     if (res.statusCode < 200 || res.statusCode >= 300) {

--- a/ui/runtime/lib/src/worker/token_worker.dart
+++ b/ui/runtime/lib/src/worker/token_worker.dart
@@ -234,6 +234,7 @@ class TokenWorker implements TokenProvider {
       'code_challenge_method': 'S256',
       'state': state,
       'nonce': nonce,
+      if (config.audiences.isNotEmpty) 'audience': config.audiences.join(','),
     };
     final sep = discovery.authorizationEndpoint.contains('?') ? '&' : '?';
     final qs = params.entries

--- a/ui/runtime/pubspec.yaml
+++ b/ui/runtime/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Auth runtime for Antinvestor Flutter apps. OAuth2 + PKCE, adaptive DPoP,
   rotating refresh tokens with reuse detection, Isolate-isolated tokens,
   hardware-backed storage, Riverpod providers, Material widgets.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/antinvestor/service-authentication
 homepage: https://github.com/antinvestor/service-authentication/tree/main/ui/runtime
 issue_tracker: https://github.com/antinvestor/service-authentication/issues

--- a/ui/runtime/test/auth_runtime_test.dart
+++ b/ui/runtime/test/auth_runtime_test.dart
@@ -376,7 +376,7 @@ void main() {
   test('version exposes authRuntimeVersion constant', () async {
     final rt = _Harness().build();
     expect(rt.version, authRuntimeVersion);
-    expect(rt.version, '0.2.0');
+    expect(rt.version, '0.3.0');
     await rt.dispose();
   });
 

--- a/ui/runtime/test/auth_runtime_test.dart
+++ b/ui/runtime/test/auth_runtime_test.dart
@@ -347,6 +347,32 @@ void main() {
     expect(() => rt.ensureAuthenticated(), throwsStateError);
   });
 
+  group('isAuthenticated (synchronous)', () {
+    test('returns false initially and true once authenticated', () async {
+      final h = _Harness(initialTokens: _tokens());
+      final rt = h.build();
+      // Construction kicks off init(); before that completes state is
+      // initializing or unauthenticated — never authenticated.
+      expect(rt.isAuthenticated, isFalse);
+
+      await rt.ensureAuthenticated();
+      expect(rt.state, AuthState.authenticated);
+      expect(rt.isAuthenticated, isTrue);
+      await rt.dispose();
+    });
+
+    test('returns false after logout', () async {
+      final h = _Harness(initialTokens: _tokens());
+      final rt = h.build();
+      await rt.ensureAuthenticated();
+      expect(rt.isAuthenticated, isTrue);
+
+      await rt.logout();
+      expect(rt.isAuthenticated, isFalse);
+      await rt.dispose();
+    });
+  });
+
   test('version exposes authRuntimeVersion constant', () async {
     final rt = _Harness().build();
     expect(rt.version, authRuntimeVersion);

--- a/ui/runtime/test/auth_runtime_test.dart
+++ b/ui/runtime/test/auth_runtime_test.dart
@@ -293,6 +293,38 @@ void main() {
     await rt.dispose();
   });
 
+  test('getUserClaims wraps getClaims in a typed UserClaims', () async {
+    final id = _makeJwt({
+      'sub': 'u-42',
+      'email': 'alice@example.com',
+      'contact_id': 'contact-abc',
+      'tenant_id': 'tenant-xyz',
+      'partition_id': 'partition-42',
+    });
+    final h = _Harness(initialTokens: _tokens(id: id));
+    final rt = h.build();
+    await rt.ensureAuthenticated();
+
+    final claims = await rt.getUserClaims();
+    expect(claims.sub, 'u-42');
+    expect(claims.email, 'alice@example.com');
+    expect(claims.contactId, 'contact-abc');
+    expect(claims.tenantId, 'tenant-xyz');
+    expect(claims.partitionId, 'partition-42');
+    await rt.dispose();
+  });
+
+  test('getUserClaims returns empty UserClaims when unauthenticated',
+      () async {
+    final h = _Harness();
+    final rt = h.build();
+    await Future<void>.delayed(Duration.zero);
+    final claims = await rt.getUserClaims();
+    expect(claims.sub, isNull);
+    expect(claims.contactId, isNull);
+    await rt.dispose();
+  });
+
   test('logout clears local state and transitions to unauthenticated',
       () async {
     final h = _Harness(initialTokens: _tokens());

--- a/ui/runtime/test/config/resolve_config_test.dart
+++ b/ui/runtime/test/config/resolve_config_test.dart
@@ -121,6 +121,57 @@ void main() {
     expect(a.hashCode, b.hashCode);
   });
 
+  group('redirectUri', () {
+    test(
+        'defaults to {scheme}://callback when only redirectScheme is provided',
+        () {
+      final cfg = resolveConfig(const AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: 'https://i',
+        apiBaseUrl: 'https://a',
+        redirectScheme: 'com.example.app',
+      ));
+      expect(cfg.redirectUri, 'com.example.app://callback');
+    });
+
+    test('explicit redirectUri takes precedence over redirectScheme', () {
+      final cfg = resolveConfig(const AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: 'https://i',
+        apiBaseUrl: 'https://a',
+        redirectScheme: 'com.example.app',
+        redirectUri: 'http://localhost:5173/auth',
+      ));
+      expect(cfg.redirectUri, 'http://localhost:5173/auth');
+    });
+
+    test('explicit redirectUri works when redirectScheme is empty', () {
+      final cfg = resolveConfig(const AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: 'https://i',
+        apiBaseUrl: 'https://a',
+        redirectScheme: '',
+        redirectUri: 'http://localhost:5173/auth',
+      ));
+      expect(cfg.redirectUri, 'http://localhost:5173/auth');
+    });
+
+    test(
+        'throws invalidConfig when neither redirectUri nor redirectScheme '
+        'is supplied', () {
+      expect(
+        () => resolveConfig(const AuthConfig(
+          clientId: 'c',
+          idpBaseUrl: 'https://i',
+          apiBaseUrl: 'https://a',
+          redirectScheme: '',
+        )),
+        throwsA(isA<AuthError>()
+            .having((e) => e.code, 'code', AuthErrorCode.invalidConfig)),
+      );
+    });
+  });
+
   group('audiences', () {
     test('defaults to empty list when omitted', () {
       final cfg = resolveConfig(const AuthConfig(

--- a/ui/runtime/test/config/resolve_config_test.dart
+++ b/ui/runtime/test/config/resolve_config_test.dart
@@ -120,4 +120,38 @@ void main() {
     expect(a, equals(b));
     expect(a.hashCode, b.hashCode);
   });
+
+  group('audiences', () {
+    test('defaults to empty list when omitted', () {
+      final cfg = resolveConfig(const AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: 'https://i',
+        apiBaseUrl: 'https://a',
+        redirectScheme: 'x',
+      ));
+      expect(cfg.audiences, isEmpty);
+    });
+
+    test('carries through when caller supplies them', () {
+      final cfg = resolveConfig(const AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: 'https://i',
+        apiBaseUrl: 'https://a',
+        redirectScheme: 'x',
+        audiences: ['svc-a', 'svc-b', 'svc-c'],
+      ));
+      expect(cfg.audiences, ['svc-a', 'svc-b', 'svc-c']);
+    });
+
+    test('resolved audiences list is immutable', () {
+      final cfg = resolveConfig(const AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: 'https://i',
+        apiBaseUrl: 'https://a',
+        redirectScheme: 'x',
+        audiences: ['svc-a'],
+      ));
+      expect(() => cfg.audiences.add('mutated'), throwsUnsupportedError);
+    });
+  });
 }

--- a/ui/runtime/test/models/user_claims_test.dart
+++ b/ui/runtime/test/models/user_claims_test.dart
@@ -40,4 +40,78 @@ void main() {
     });
     expect(c.roles, ['ok', 'good']);
   });
+
+  group('Antinvestor typed getters', () {
+    test('contactId / tenantId / partitionId surface the claim values', () {
+      const c = UserClaims({
+        'sub': 'u-1',
+        'contact_id': 'contact-abc',
+        'tenant_id': 'tenant-xyz',
+        'partition_id': 'partition-42',
+      });
+      expect(c.contactId, 'contact-abc');
+      expect(c.tenantId, 'tenant-xyz');
+      expect(c.partitionId, 'partition-42');
+    });
+
+    test('typed getters return null when claim missing or wrong type', () {
+      const c = UserClaims({
+        'contact_id': 123, // not a string
+      });
+      expect(c.contactId, isNull);
+      expect(c.tenantId, isNull);
+      expect(c.partitionId, isNull);
+    });
+  });
+
+  group('customClaims', () {
+    test('contains only non-OIDC-standard claims', () {
+      const c = UserClaims({
+        // Standard OIDC — must be excluded.
+        'iss': 'https://idp.example.com',
+        'sub': 'u-1',
+        'aud': 'client',
+        'exp': 9999999999,
+        'iat': 1234567890,
+        'nonce': 'n',
+        'email': 'a@b.c',
+        'email_verified': true,
+        'name': 'Alice',
+        'preferred_username': 'alice',
+        'picture': 'https://cdn/x.png',
+        'locale': 'en',
+        'updated_at': 1234567890,
+        // Non-standard — must be retained.
+        'contact_id': 'contact-abc',
+        'tenant_id': 'tenant-xyz',
+        'partition_id': 'partition-42',
+        'roles': <dynamic>['admin'],
+        'custom_flag': true,
+      });
+      final custom = c.customClaims;
+      expect(custom.keys, containsAll(<String>[
+        'contact_id',
+        'tenant_id',
+        'partition_id',
+        'roles',
+        'custom_flag',
+      ]));
+      // Standard keys are filtered out.
+      expect(custom.containsKey('iss'), isFalse);
+      expect(custom.containsKey('sub'), isFalse);
+      expect(custom.containsKey('email'), isFalse);
+      expect(custom.containsKey('email_verified'), isFalse);
+      expect(custom.containsKey('preferred_username'), isFalse);
+      expect(custom.containsKey('picture'), isFalse);
+      expect(custom.containsKey('updated_at'), isFalse);
+    });
+
+    test('customClaims is empty when only standard claims are present', () {
+      const c = UserClaims({
+        'sub': 'u-1',
+        'email': 'a@b.c',
+      });
+      expect(c.customClaims, isEmpty);
+    });
+  });
 }

--- a/ui/runtime/test/oauth/oauth_flow_test.dart
+++ b/ui/runtime/test/oauth/oauth_flow_test.dart
@@ -11,11 +11,12 @@ class _MockAppAuth extends Mock implements FlutterAppAuth {}
 
 class _FakeAuthorizationRequest extends Fake implements AuthorizationRequest {}
 
-ResolvedConfig _cfg() => resolveConfig(const AuthConfig(
+ResolvedConfig _cfg({String? redirectUri}) => resolveConfig(AuthConfig(
       clientId: 'c',
       idpBaseUrl: 'https://idp.example.com',
       apiBaseUrl: 'https://api.example.com',
       redirectScheme: 'com.example.app',
+      redirectUri: redirectUri,
     ));
 
 Future<OidcDiscovery> _fakeDiscovery(ResolvedConfig cfg) async =>
@@ -109,6 +110,28 @@ void main() {
         AuthErrorCode.oauthFailed,
       )),
     );
+  });
+
+  test(
+      'explicit redirectUri override is forwarded verbatim to flutter_appauth',
+      () async {
+    final appAuth = _MockAppAuth();
+    AuthorizationRequest? seen;
+    when(() => appAuth.authorize(any())).thenAnswer((inv) async {
+      seen = inv.positionalArguments.first as AuthorizationRequest;
+      return const AuthorizationResponse(
+        authorizationCode: 'c',
+        codeVerifier: 'v',
+      );
+    });
+
+    final flow = OAuthFlow(appAuth: appAuth, discoveryFn: _fakeDiscovery);
+    await flow.authorize(_cfg(redirectUri: 'http://localhost:5173/auth'));
+
+    expect(seen, isNotNull);
+    // Explicit redirect URI wins over the convention-driven
+    // `{scheme}://callback` fallback.
+    expect(seen!.redirectUrl, 'http://localhost:5173/auth');
   });
 
   test('missing code/verifier raises oauthFailed', () async {

--- a/ui/runtime/test/protocol/token_exchange_test.dart
+++ b/ui/runtime/test/protocol/token_exchange_test.dart
@@ -13,11 +13,13 @@ import 'package:http/testing.dart';
 
 const _timeout = Duration(seconds: 5);
 
-ResolvedConfig _cfg() => resolveConfig(const AuthConfig(
+ResolvedConfig _cfg({List<String>? audiences}) =>
+    resolveConfig(AuthConfig(
       clientId: 'c',
       idpBaseUrl: 'https://idp.example.com',
       apiBaseUrl: 'https://api.example.com',
       redirectScheme: 'com.example.app',
+      audiences: audiences,
     ));
 
 Map<String, dynamic> _discoveryDoc({bool dpop = false}) => <String, dynamic>{
@@ -153,6 +155,38 @@ void main() {
       expect(tokens.accessToken, 'at-1');
       expect(tokenCalls, 2);
       expect(ctx.clockOffsetMs, greaterThan(0));
+    });
+
+    test('includes audience=a,b,c when audiences configured', () async {
+      final cfg = _cfg(audiences: const ['svc-a', 'svc-b', 'svc-c']);
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        final form = Uri.splitQueryString(req.body);
+        expect(form['audience'], 'svc-a,svc-b,svc-c');
+        return http.Response(jsonEncode(_tokenResp()), 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      await exchange.exchangeCode(cfg, ctx, code: 'c', verifier: 'v');
+    });
+
+    test('omits audience when audiences is empty', () async {
+      final cfg = _cfg();
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        final form = Uri.splitQueryString(req.body);
+        expect(form.containsKey('audience'), isFalse);
+        return http.Response(jsonEncode(_tokenResp()), 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      await exchange.exchangeCode(cfg, ctx, code: 'c', verifier: 'v');
     });
 
     test('non-2xx final response raises tokenExchangeFailed', () async {
@@ -354,6 +388,27 @@ void main() {
         ),
         throwsA(isA<AuthError>()
             .having((e) => e.code, 'code', AuthErrorCode.tokenExchangeFailed)),
+      );
+    });
+
+    test('includes audience=a,b,c when audiences configured', () async {
+      final cfg = _cfg(audiences: const ['svc-a', 'svc-b']);
+      final client = MockClient((req) async {
+        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+          return http.Response(jsonEncode(_discoveryDoc()), 200);
+        }
+        final form = Uri.splitQueryString(req.body);
+        expect(form['audience'], 'svc-a,svc-b');
+        return http.Response(jsonEncode(_tokenResp()), 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final exchange = TokenExchange(client: client, timeout: _timeout);
+      await exchange.exchangeIdToken(
+        cfg,
+        ctx,
+        subjectToken: 'tok',
+        subjectIssuer: 'https://accounts.google.com',
       );
     });
   });

--- a/ui/runtime/test/support/fake_auth_runtime.dart
+++ b/ui/runtime/test/support/fake_auth_runtime.dart
@@ -117,6 +117,9 @@ class FakeAuthRuntime implements AuthRuntime {
   Future<Map<String, dynamic>> getClaims() async => _claims;
 
   @override
+  Future<UserClaims> getUserClaims() async => UserClaims(_claims);
+
+  @override
   Future<List<String>> getRoles() async => _roles;
 
   @override

--- a/ui/runtime/test/support/fake_auth_runtime.dart
+++ b/ui/runtime/test/support/fake_auth_runtime.dart
@@ -46,6 +46,9 @@ class FakeAuthRuntime implements AuthRuntime {
   AuthState get state => _state;
 
   @override
+  bool get isAuthenticated => _state == AuthState.authenticated;
+
+  @override
   Stream<AuthState> get authStateStream => _stateCtl.stream;
 
   @override

--- a/ui/runtime/test/worker/token_worker_test.dart
+++ b/ui/runtime/test/worker/token_worker_test.dart
@@ -319,6 +319,36 @@ void main() {
     expect(uri.queryParameters['nonce'], req.nonce);
     expect(uri.queryParameters['client_id'], 'c');
     expect(uri.queryParameters['redirect_uri'], 'com.example.app://callback');
+    // No audiences configured → no audience param is appended.
+    expect(uri.queryParameters.containsKey('audience'), isFalse);
+    await w.destroy();
+  });
+
+  test(
+      'prepareAuth appends audience=a,b,c when audiences configured', () async {
+    final config = resolveConfig(const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://idp.example.com',
+      apiBaseUrl: 'https://api.example.com',
+      redirectScheme: 'com.example.app',
+      audiences: ['svc-a', 'svc-b', 'svc-c'],
+    ));
+    final w = TokenWorker(
+      config: config,
+      keyManager: DefaultKeyManager(),
+      rootKeyStore: DefaultRootKeyStore(kv: InMemoryKeyValueStore()),
+      tokenStore: SecureTokenStore(kv: InMemoryKeyValueStore()),
+      discoveryClient: _FakeDiscoveryClient(),
+      tokenExchange: _FakeTokenExchange(),
+      apiProxy: _FakeApiProxy(),
+      refreshLock: RefreshLock(),
+      clock: _fixedNow,
+    );
+    await w.init();
+    final req = await w.prepareAuth();
+    expect(req.url, contains('audience=svc-a%2Csvc-b%2Csvc-c'));
+    final uri = Uri.parse(req.url);
+    expect(uri.queryParameters['audience'], 'svc-a,svc-b,svc-c');
     await w.destroy();
   });
 


### PR DESCRIPTION
## Summary

Purely additive v0.3 release driven by the consumer migration gap analysis in `docs/superpowers/specs/2026-04-20-auth-runtime-roadmap-design.md`. No breaking changes — existing v0.2 callers are unaffected.

Four additions:

- **`AuthConfig.audiences`** — optional `List<String>` forwarded to both the authorize endpoint (`audience=<comma-joined>`) and the RFC 8693 token-exchange grant. Unblocks `service-thesa/ui`, which needs Hydra to mint tokens whose `aud` claim lists all nine downstream services.
- **`AuthConfig.redirectUri`** — explicit override of the OAuth redirect URI; takes precedence over the existing `redirectScheme`. Enables desktop-loopback flows (`http://localhost:5173/auth`) used by `service-thesa/ui` (desktop) and `service-chat/ui` (desktop builds at `:5170`). Resolution order: explicit `redirectUri` > `{redirectScheme}://callback`. `ResolvedConfig.redirectUri` is now a non-nullable resolved field; at least one of the two must be non-empty.
- **`UserClaims.contactId` / `tenantId` / `partitionId` typed getters** plus a `customClaims` escape hatch that returns every non-standard (non-OIDC) claim. Removes the need for consumers (`service-chat/ui` reads `contact_id` across Antinvestor) to cast from a raw map. `AuthRuntime.getUserClaims()` wraps `getClaims()` in a typed `UserClaims`.
- **`AuthRuntime.isAuthenticated` synchronous getter** — equivalent to `state == AuthState.authenticated`. WorkManager-style background tasks can pre-check without paying for async warmup.

README gains three new sections — "Audiences (thesa pattern)", "Typed claim getters", "Background tasks (WorkManager)" — plus a warning against sharing runtime instances across isolates.

## Commit trail

1. `feat(auth-runtime): AuthConfig.audiences passthrough to authorize + token-exchange`
2. `feat(auth-runtime): AuthConfig.redirectUri explicit override for desktop loopback`
3. `feat(auth-runtime): UserClaims typed getters (contactId, tenantId, partitionId, customClaims)`
4. `feat(auth-runtime): AuthRuntime.isAuthenticated synchronous getter for background tasks`
5. `docs(auth-runtime): audiences + typed claims + background-task patterns`
6. `chore(auth-runtime): bump to v0.3.0`

## Stacked dependency

This PR is stacked on top of `feat/auth-runtime-v0.2-native-credentials` (PR #641), which is itself stacked on PR #640. Please review / merge in that order to keep the diff clean.

## Test plan

- [x] `flutter test` — 315 tests passing (baseline 295, +20 new for audiences, redirectUri, typed UserClaims, getUserClaims, isAuthenticated)
- [x] `flutter analyze` — clean throughout (0 issues)
- [x] `flutter pub publish --dry-run` — 0 warnings
- [ ] Downstream: exercise `service-thesa/ui` end-to-end with a 9-element audiences array against Hydra dev
- [ ] Downstream: exercise `service-chat/ui` background task harness using `isAuthenticated` pre-check
- [ ] Downstream: exercise a desktop build with `redirectUri: 'http://localhost:5173/auth'`