### PR TITLE
feat(ui/runtime): antinvestor_auth_runtime v0.3.1 — absolute URLs in fetch/upload

### DIFF
--- a/ui/runtime/CHANGELOG.md
+++ b/ui/runtime/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to `antinvestor_auth_runtime` are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.1 — 2026-04-20
+
+### Added
+- `runtime.fetch` / `runtime.upload` accept fully-qualified `https://...` URLs; when the path starts with `http://` or `https://`, the runtime uses it directly and skips `apiBaseUrl` prepending. Unblocks consumers that talk to multiple service domains with a single OAuth client.
+
 ## 0.3.0 — 2026-04-20
 
 ### Added

--- a/ui/runtime/README.md
+++ b/ui/runtime/README.md
@@ -254,6 +254,16 @@ Supported methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`.
 use `runtime.upload(path, fieldName:, filename:, contentType:, bytes:,
 length:)` — multipart form-data with automatic retry on 401.
 
+### Multi-domain usage
+
+`runtime.fetch(path)` concatenates `AuthConfig.apiBaseUrl + path` by default. Pass an absolute URL to bypass:
+
+```dart
+await runtime.fetch('https://files.example.com/v1/upload', method: 'POST', body: bytes);
+```
+
+Useful when an app talks to multiple service domains but shares a single OAuth client / token audience.
+
 ## Audiences (thesa pattern)
 
 Apps that front several downstream services need their access tokens to

--- a/ui/runtime/lib/src/auth_runtime.dart
+++ b/ui/runtime/lib/src/auth_runtime.dart
@@ -110,4 +110,4 @@ abstract class AuthRuntime {
 /// Version of the runtime. Callers include this in telemetry / bug
 /// reports. Kept as a bare constant for now; wired through
 /// `--dart-define=AUTH_RUNTIME_VERSION=...` in a follow-up task.
-const String authRuntimeVersion = '0.3.0';
+const String authRuntimeVersion = '0.3.1';

--- a/ui/runtime/lib/src/protocol/api_proxy.dart
+++ b/ui/runtime/lib/src/protocol/api_proxy.dart
@@ -57,7 +57,7 @@ class ApiProxy {
     Object? body,
     Duration? timeout,
   }) async {
-    final url = '${cfg.apiBaseUrl}$path';
+    final url = _resolveUrl(cfg.apiBaseUrl, path);
     final uri = Uri.parse(url);
     final effectiveTimeout = timeout ?? cfg.apiTimeout;
     final methodUpper = method.toUpperCase();
@@ -139,7 +139,7 @@ class ApiProxy {
     Map<String, String>? headers,
     Duration? timeout,
   }) async {
-    final url = '${cfg.apiBaseUrl}$path';
+    final url = _resolveUrl(cfg.apiBaseUrl, path);
     final uri = Uri.parse(url);
     final effectiveTimeout = timeout ?? cfg.uploadTimeout;
 
@@ -319,4 +319,17 @@ MediaType? _parseMediaType(String raw) {
   } catch (_) {
     return null;
   }
+}
+
+/// Resolves the target URL for an authenticated call.
+///
+/// When [path] is a fully-qualified `http://` or `https://` URL, it is
+/// used as-is. Otherwise [path] is concatenated onto [apiBaseUrl] as a
+/// relative suffix. This lets a single runtime (and its OAuth client /
+/// token audience) talk to multiple service domains.
+String _resolveUrl(String apiBaseUrl, String path) {
+  if (path.startsWith('https://') || path.startsWith('http://')) {
+    return path;
+  }
+  return '$apiBaseUrl$path';
 }

--- a/ui/runtime/pubspec.yaml
+++ b/ui/runtime/pubspec.yaml
@@ -3,7 +3,7 @@ description: >
   Auth runtime for Antinvestor Flutter apps. OAuth2 + PKCE, adaptive DPoP,
   rotating refresh tokens with reuse detection, Isolate-isolated tokens,
   hardware-backed storage, Riverpod providers, Material widgets.
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/antinvestor/service-authentication
 homepage: https://github.com/antinvestor/service-authentication/tree/main/ui/runtime
 issue_tracker: https://github.com/antinvestor/service-authentication/issues

--- a/ui/runtime/test/auth_runtime_test.dart
+++ b/ui/runtime/test/auth_runtime_test.dart
@@ -376,7 +376,7 @@ void main() {
   test('version exposes authRuntimeVersion constant', () async {
     final rt = _Harness().build();
     expect(rt.version, authRuntimeVersion);
-    expect(rt.version, '0.3.0');
+    expect(rt.version, '0.3.1');
     await rt.dispose();
   });
 

--- a/ui/runtime/test/protocol/api_proxy_test.dart
+++ b/ui/runtime/test/protocol/api_proxy_test.dart
@@ -284,4 +284,132 @@ void main() {
       expect(captured is http.MultipartRequest, isTrue);
     });
   });
+
+  group('absolute URLs', () {
+    test('fetch with https:// URL hits it exactly and skips apiBaseUrl',
+        () async {
+      final cfg = _cfg();
+      late http.Request captured;
+      final client = MockClient((req) async {
+        captured = req;
+        return http.Response('{"ok":true}', 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await proxy.fetch(
+        cfg,
+        ctx,
+        _TestTokenProvider(),
+        path: 'https://other.example.com/api/foo',
+        method: 'GET',
+      );
+      expect(captured.url.toString(), 'https://other.example.com/api/foo');
+      // apiBaseUrl must not be prepended.
+      expect(captured.url.toString(), isNot(contains('api.example.com')));
+    });
+
+    test('fetch with http:// URL is used directly', () async {
+      final cfg = _cfg();
+      late http.Request captured;
+      final client = MockClient((req) async {
+        captured = req;
+        return http.Response('{}', 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await proxy.fetch(
+        cfg,
+        ctx,
+        _TestTokenProvider(),
+        path: 'http://localhost:8080/v1/x',
+        method: 'GET',
+      );
+      expect(captured.url.toString(), 'http://localhost:8080/v1/x');
+    });
+
+    test('fetch with relative path still hits apiBaseUrl + path', () async {
+      final cfg = _cfg();
+      late http.Request captured;
+      final client = MockClient((req) async {
+        captured = req;
+        return http.Response('{}', 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await proxy.fetch(
+        cfg,
+        ctx,
+        _TestTokenProvider(),
+        path: '/relative/path',
+        method: 'GET',
+      );
+      expect(captured.url.toString(), 'https://api.example.com/relative/path');
+    });
+
+    test('upload with https:// URL hits the absolute URL', () async {
+      final cfg = _cfg();
+      late http.BaseRequest captured;
+      final client = MockClient.streaming((req, body) async {
+        captured = req;
+        return http.StreamedResponse(
+          Stream.value(utf8.encode('{}')),
+          200,
+        );
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await proxy.upload(
+        cfg,
+        ctx,
+        _TestTokenProvider(),
+        path: 'https://upload.example.com/files',
+        fieldName: 'file',
+        filename: 'a.bin',
+        contentType: 'application/octet-stream',
+        bytes: Stream.value(const [0x01, 0x02, 0x03]),
+        length: 3,
+      );
+      expect(captured.url.toString(), 'https://upload.example.com/files');
+      expect(captured.url.toString(), isNot(contains('api.example.com')));
+    });
+
+    test('DPoP proof htu matches the absolute URL actually used', () async {
+      final cfg = _cfg();
+      late http.Request captured;
+      final client = MockClient((req) async {
+        captured = req;
+        return http.Response('{}', 200);
+      });
+      final kp = generateDpopKeyPair();
+      final ctx = makeDpopContext(kp);
+      final proxy = ApiProxy(client: client);
+      await proxy.fetch(
+        cfg,
+        ctx,
+        _TestTokenProvider(type: TokenType.dpop),
+        path: 'https://other.example.com/api/foo',
+        method: 'POST',
+        body: '{}',
+      );
+      final proof = captured.headers['dpop'];
+      expect(proof, isNotNull);
+      final parts = proof!.split('.');
+      expect(parts.length, 3);
+      final payloadJson = utf8.decode(
+        base64Url.decode(_padBase64Url(parts[1])),
+      );
+      final payload = jsonDecode(payloadJson) as Map<String, dynamic>;
+      expect(payload['htu'], 'https://other.example.com/api/foo');
+      expect(payload['htm'], 'POST');
+    });
+  });
+}
+
+String _padBase64Url(String s) {
+  final pad = (4 - s.length % 4) % 4;
+  return s + ('=' * pad);
 }


### PR DESCRIPTION
Additive patch release. Enables multi-domain consumers (e.g. service-chat's per-service domains) to use a single runtime.