### PR TITLE
docs(auth-runtime): correct stale auth_gate comment

### DIFF
--- a/ui/runtime/lib/src/widgets/auth_gate.dart
+++ b/ui/runtime/lib/src/widgets/auth_gate.dart
@@ -13,9 +13,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 ///
 /// Defaults:
 /// - [loadingBuilder] → centered [CircularProgressIndicator]
-/// - [unauthenticatedBuilder] → centered [ElevatedButton] labelled "Sign
-///   in" that calls `authRuntimeProvider.read().ensureAuthenticated()`
-///   on tap. F-I.2 replaces this with the richer `SignInButton` widget.
+/// - [unauthenticatedBuilder] → centered [SignInButton], which handles
+///   the sign-in call and loading/error affordances. Apps can supply
+///   their own [unauthenticatedBuilder] (optionally wrapping
+///   [SignInButton]) for richer UX.
 /// - [errorBuilder] → centered error message + "Retry" button that
 ///   invalidates the state provider so the next frame re-subscribes.
 class AuthGate extends ConsumerWidget {


### PR DESCRIPTION
One-line comment fix in auth_gate.dart. No code change.