### PR TITLE
chore(deps): bump pitabwire/frame to v1.94.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/moby/moby/api v1.54.1
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame v1.94.1
+	github.com/pitabwire/frame v1.94.2
 	github.com/pitabwire/util v0.8.0
 	github.com/rs/xid v1.6.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260327085200-c0e5fcbbbce1 h1:1Mk/k
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260327085200-c0e5fcbbbce1/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.0 h1:u9JhESo83i/GkZnhfTNuFMMWcNt7mnV1bGJ6FT4wXH8=
 github.com/panjf2000/ants/v2 v2.12.0/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.94.1 h1:m8HOy/jtbOzqkXLIRc25URSybxuOcKhD4gutJWP/An0=
-github.com/pitabwire/frame v1.94.1/go.mod h1:FX5rWg4t6nUC10634Wq7YqPBp40zkO4Vj8jfasd0uNo=
+github.com/pitabwire/frame v1.94.2 h1:msOLi+qpvfBAr8qfVYU4DbdSXaJDFhRnPxU8th6UgDc=
+github.com/pitabwire/frame v1.94.2/go.mod h1:FX5rWg4t6nUC10634Wq7YqPBp40zkO4Vj8jfasd0uNo=
 github.com/pitabwire/natspubsub v0.8.1 h1:1FjZ4wGbLWKFdH29rEErsq/B4ZL8ZsX6zyd1jLuaE1Q=
 github.com/pitabwire/natspubsub v0.8.1/go.mod h1:mAHWmEWQiq69YVgiqn6Ml4UlhFTGSJISm6byjw2GcBY=
 github.com/pitabwire/util v0.8.0 h1:LNKCTMmfurjk4ShG1peTuMFGsOAR5o5jIZ84lHNvwlU=


### PR DESCRIPTION
## Summary

Bumps pitabwire/frame from v1.94.1 to v1.94.2. Release notes:

- race-free subscriber.Stop() and Service.driver lifecycle — unblocks
  re-enabling -race in CI tests
- BaseModel.CreatedAt is derived from the xid embedded timestamp, so
  sort-by-id matches sort-by-created_at (prerequisite for the
  TimescaleDB hypertable work)
- datastore.BaseRepository gains WithBulkCreateConflictColumns(cols...)
  for targeting a specific unique index when needed

## Test plan

- [x] go build ./...
- [x] go test ./apps/default/service/hydra/... (passes)
- [x] go test ./apps/default/service/repository/... (passes)
- [ ] CI green before merge