### PR TITLE
feat(hypertable): composite PK on login_events and audit_entries

### DIFF
--- a/apps/audit/migrations/0001/20260420_audit_entries_composite_pk.sql
+++ b/apps/audit/migrations/0001/20260420_audit_entries_composite_pk.sql
@@ -1,0 +1,11 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+--
+-- Licensed under the Apache License, Version 2.0 (the "License").
+
+-- audit_entries is promoted to a TimescaleDB hypertable. The time-partition
+-- column must be part of every UNIQUE/PRIMARY constraint, so replace the
+-- BaseModel-default PK (id) with a composite (id, created_at). Audit rows
+-- are immutable by policy, so the composite PK matches real write patterns.
+
+ALTER TABLE audit_entries DROP CONSTRAINT IF EXISTS audit_entries_pkey;
+ALTER TABLE audit_entries ADD PRIMARY KEY (id, created_at);

--- a/apps/default/migrations/0001/20260420_login_events_composite_pk.sql
+++ b/apps/default/migrations/0001/20260420_login_events_composite_pk.sql
@@ -1,0 +1,13 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+--
+-- Licensed under the Apache License, Version 2.0 (the "License").
+
+-- login_events is promoted to a TimescaleDB hypertable (see
+-- apps/default/service/models/hypertables.go). TimescaleDB requires the
+-- time-partition column to participate in every UNIQUE/PRIMARY constraint,
+-- so we replace the BaseModel-default PK (id) with a composite (id, created_at).
+-- Reads and writes through GORM continue to work because BeforeCreate sets
+-- both columns and xid-generated ids remain globally unique.
+
+ALTER TABLE login_events DROP CONSTRAINT IF EXISTS login_events_pkey;
+ALTER TABLE login_events ADD PRIMARY KEY (id, created_at);

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/moby/moby/api v1.54.2
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame v1.94.4
+	github.com/pitabwire/frame v1.94.6
 	github.com/pitabwire/util v0.8.0
 	github.com/rs/xid v1.6.0
 	github.com/stretchr/testify v1.11.1
@@ -88,7 +88,7 @@ require (
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/go-archive v0.2.0 // indirect
-	github.com/moby/moby/client v0.4.0 // indirect
+	github.com/moby/moby/client v0.4.1 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/moby/sys/user v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,8 @@ github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8
 github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
 github.com/moby/moby/api v1.54.2 h1:wiat9QAhnDQjA7wk1kh/TqHz2I1uUA7M7t9SAl/JNXg=
 github.com/moby/moby/api v1.54.2/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
-github.com/moby/moby/client v0.4.0 h1:S+2XegzHQrrvTCvF6s5HFzcrywWQmuVnhOXe2kiWjIw=
-github.com/moby/moby/client v0.4.0/go.mod h1:QWPbvWchQbxBNdaLSpoKpCdf5E+WxFAgNHogCWDoa7g=
+github.com/moby/moby/client v0.4.1 h1:DMQgisVoMkmMs7fp3ROSdiBnoAu8+vo3GggFl06M/wY=
+github.com/moby/moby/client v0.4.1/go.mod h1:z52C9O2POPOsnxZAy//WtKcQ32P+jT/NGeXu/7nfjGQ=
 github.com/moby/patternmatcher v0.6.1 h1:qlhtafmr6kgMIJjKJMDmMWq7WLkKIo23hsrpR3x084U=
 github.com/moby/patternmatcher v0.6.1/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
@@ -220,8 +220,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.0 h1:u9JhESo83i/GkZnhfTNuFMMWcNt7mnV1bGJ6FT4wXH8=
 github.com/panjf2000/ants/v2 v2.12.0/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.94.4 h1:4KgbhY44nUOk3l7BYYd9qZlq7vBxOGP5YBS7VzQUYQU=
-github.com/pitabwire/frame v1.94.4/go.mod h1:ZK/YaGUEpltB71XFf8dCAfXLRKY5QcAO9Mnya+B/ra8=
+github.com/pitabwire/frame v1.94.6 h1:CJJdo6+jvL53yp5HaEhrGsaAE48BVmpBD1PRXzRmt3g=
+github.com/pitabwire/frame v1.94.6/go.mod h1:5tyetk1wosnb/KW+54IHKcogm1VIKmdurYW1JjcSqaA=
 github.com/pitabwire/natspubsub v0.8.2 h1:kzNas93jIsFLiHHJm24j7c0XBLsR9zkuVLqvnhE0Si8=
 github.com/pitabwire/natspubsub v0.8.2/go.mod h1:jKluv8iY22EEn2oRjqU/rURBOj+56SJmeOd5+AxknSQ=
 github.com/pitabwire/util v0.8.0 h1:LNKCTMmfurjk4ShG1peTuMFGsOAR5o5jIZ84lHNvwlU=


### PR DESCRIPTION
## Summary

TimescaleDB requires the time-partition column to participate in every
UNIQUE/PRIMARY constraint on a hypertable. Adds post-AutoMigrate SQL to
swap the default \`PRIMARY KEY (id)\` for composite \`PRIMARY KEY (id, created_at)\`
on both hypertable-registered tables in this repo:

- \`apps/default/migrations/0001/20260420_login_events_composite_pk.sql\`
- \`apps/audit/migrations/0001/20260420_audit_entries_composite_pk.sql\`

Prepares both tables for the TimescaleDB conversion performed by
common/timescale.Ensure at service startup.

## Test plan

- [x] go build ./...
- [x] go test ./apps/default/service/repository/...
- [ ] CI green before merge