### PR TITLE
chore: add Dockerfile multi-arch lint workflow

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -1,0 +1,25 @@
+# Copyright 2023-2026 Ant Investor Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Dockerfile Multi-Arch Lint
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  lint:
+    permissions:
+      contents: read
+    uses: antinvestor/common/.github/workflows/dockerfile-lint.yml@main


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dockerfile-lint.yml` that calls `antinvestor/common/.github/workflows/dockerfile-lint.yml@main` on every PR. The shared workflow runs `check-dockerfile-multiarch.sh` against `./apps/**/Dockerfile` to enforce the canonical multi-arch build pattern (BUILDPLATFORM pinning, declared TARGETOS/TARGETARCH args, GOOS/GOARCH passthrough).

## Test plan

- [ ] `dockerfile-lint` job passes (verified locally — all this repo's Dockerfiles already follow the canonical pattern).
- [ ] Existing CI (`test`, `lint`, `flutter`) continues to pass.

## Context

Part of a cross-repo rollout adding a CI lint guard for multi-arch Docker builds. See https://github.com/antinvestor/common/pull/4 for the reusable workflow and lint script.