### PR TITLE
feat: wire frame v1.95.0 transparent tenancy interceptor

### DIFF
--- a/apps/audit/cmd/main.go
+++ b/apps/audit/cmd/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pitabwire/frame"
 	"github.com/pitabwire/frame/config"
 	"github.com/pitabwire/frame/datastore"
+	"github.com/pitabwire/frame/datastore/pool"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/frame/security/authorizer"
 	connectInterceptors "github.com/pitabwire/frame/security/interceptors/connect"
@@ -77,7 +78,7 @@ func main() {
 	auditSrv := handlers.NewAuditServer(ctx, svc, signer)
 
 	// Setup Connect RPC server with full interceptor chain
-	connectHandler := setupConnectServer(ctx, svc.SecurityManager(), auditSrv)
+	connectHandler := setupConnectServer(ctx, svc.SecurityManager(), auditDBPool, auditSrv)
 
 	// Register permission manifest for the audit service
 	sd := auditv1.File_audit_v1_audit_proto.Services().ByName("AuditService")
@@ -128,10 +129,11 @@ func loadOrGenerateSigner(ctx context.Context, hexKey string) (*business.ChainSi
 }
 
 // setupConnectServer creates the Connect RPC handler with the full interceptor chain:
-// Auth → TenancyAccess → FunctionAccess.
+// Auth → TenancyAccess → FunctionAccess → TenancyTx.
 func setupConnectServer(
 	ctx context.Context,
 	sm security.Manager,
+	dbPool pool.Pool,
 	implementation *handlers.AuditServer,
 ) http.Handler {
 	authenticator := sm.GetAuthenticator(ctx)
@@ -148,7 +150,16 @@ func setupConnectServer(
 	functionChecker := authorizer.NewFunctionChecker(auth, svcPerms.Namespace)
 	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
 
-	defaultInterceptorList, err := connectInterceptors.DefaultList(ctx, authenticator, tenancyAccessInterceptor, functionAccessInterceptor)
+	// Layer 3: TenancyTxInterceptor opens a request-scoped transaction
+	// after auth has populated the claims, publishes app.tenant_id +
+	// app.partition_id from the claims via set_config, and binds the
+	// transaction to the request context. Repository code then calls
+	// pool.DB(ctx, _) and gets the bound tx transparently; tenancy is
+	// enforced by Row-Level Security at the database layer.
+	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
+
+	defaultInterceptorList, err := connectInterceptors.DefaultList(ctx, authenticator,
+		tenancyAccessInterceptor, functionAccessInterceptor, tenancyTxInterceptor)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("failed to create default interceptors")
 	}

--- a/apps/default/cmd/main.go
+++ b/apps/default/cmd/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pitabwire/frame/config"
 	"github.com/pitabwire/frame/data"
 	"github.com/pitabwire/frame/datastore"
+	"github.com/pitabwire/frame/datastore/pool"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/frame/security/authorizer"
 	connectInterceptors "github.com/pitabwire/frame/security/interceptors/connect"
@@ -131,7 +132,7 @@ func main() {
 
 	// Setup Connect RPC handler for login history API
 	loginHistorySrv := loginhistory.NewLoginHistoryServer(loginEventRepo, loginRepo)
-	connectPath, connectHandler := setupConnectServer(ctx, sm, loginHistorySrv)
+	connectPath, connectHandler := setupConnectServer(ctx, sm, dbPool, loginHistorySrv)
 
 	// Combine auth routes and Connect RPC into a single handler.
 	// Frame's WithHTTPHandler uses plain assignment (not append), so only
@@ -257,12 +258,13 @@ func setupFilesClient(
 const namespaceTenancyAccess = "tenancy_access"
 
 // setupConnectServer creates the Connect RPC handler for login history
-// with the full interceptor chain: Auth -> TenancyAccess -> FunctionAccess.
+// with the full interceptor chain: Auth -> TenancyAccess -> FunctionAccess -> TenancyTx.
 // Returns the path prefix and handler so they can be registered on the
 // shared auth routes mux.
 func setupConnectServer(
 	ctx context.Context,
 	sm security.Manager,
+	dbPool pool.Pool,
 	implementation *loginhistory.LoginHistoryServer,
 ) (string, http.Handler) {
 	authenticator := sm.GetAuthenticator(ctx)
@@ -279,7 +281,16 @@ func setupConnectServer(
 	functionChecker := authorizer.NewFunctionChecker(auth, svcPerms.Namespace)
 	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
 
-	defaultInterceptorList, err := connectInterceptors.DefaultList(ctx, authenticator, tenancyAccessInterceptor, functionAccessInterceptor)
+	// Layer 3: TenancyTxInterceptor opens a request-scoped transaction
+	// after auth has populated the claims, publishes app.tenant_id +
+	// app.partition_id from the claims via set_config, and binds the
+	// transaction to the request context. Repository code then calls
+	// pool.DB(ctx, _) and gets the bound tx transparently; tenancy is
+	// enforced by Row-Level Security at the database layer.
+	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
+
+	defaultInterceptorList, err := connectInterceptors.DefaultList(ctx, authenticator,
+		tenancyAccessInterceptor, functionAccessInterceptor, tenancyTxInterceptor)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("failed to create default interceptors for login history")
 	}

--- a/apps/tenancy/cmd/main.go
+++ b/apps/tenancy/cmd/main.go
@@ -35,6 +35,8 @@ import (
 	"github.com/pitabwire/frame"
 	"github.com/pitabwire/frame/client"
 	"github.com/pitabwire/frame/config"
+	"github.com/pitabwire/frame/datastore"
+	"github.com/pitabwire/frame/datastore/pool"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/frame/security/authorizer"
 	connectInterceptors "github.com/pitabwire/frame/security/interceptors/connect"
@@ -105,7 +107,8 @@ func main() {
 	}
 
 	// Setup Connect server
-	connectHandler := setupConnectServer(ctx, sm, partSrv)
+	dbPool := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName)
+	connectHandler := setupConnectServer(ctx, sm, dbPool, partSrv)
 
 	// Register permission manifest for the tenancy service so the UI can
 	// discover available permissions for assignment.
@@ -145,6 +148,7 @@ func main() {
 func setupConnectServer(
 	ctx context.Context,
 	sm security.Manager,
+	dbPool pool.Pool,
 	implementation *handlers.TenancyServer,
 ) http.Handler {
 
@@ -162,7 +166,16 @@ func setupConnectServer(
 	functionChecker := authorizer.NewFunctionChecker(auth, svcPerms.Namespace)
 	functionAccessInterceptor := connectInterceptors.NewFunctionAccessInterceptor(functionChecker, procMap)
 
-	defaultInterceptorList, err := connectInterceptors.DefaultList(ctx, authenticator, tenancyAccessInterceptor, functionAccessInterceptor)
+	// Layer 3: TenancyTxInterceptor opens a request-scoped transaction
+	// after auth has populated the claims, publishes app.tenant_id +
+	// app.partition_id from the claims via set_config, and binds the
+	// transaction to the request context. Repository code then calls
+	// pool.DB(ctx, _) and gets the bound tx transparently; tenancy is
+	// enforced by Row-Level Security at the database layer.
+	tenancyTxInterceptor := connectInterceptors.NewTenancyTxInterceptor(dbPool)
+
+	defaultInterceptorList, err := connectInterceptors.DefaultList(ctx, authenticator,
+		tenancyAccessInterceptor, functionAccessInterceptor, tenancyTxInterceptor)
 	if err != nil {
 		util.Log(ctx).WithError(err).Fatal("failed to create default interceptors")
 	}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/moby/moby/api v1.54.2
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame v1.94.7
+	github.com/pitabwire/frame v1.95.0
 	github.com/pitabwire/util v0.9.0
 	github.com/rs/xid v1.6.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.0 h1:u9JhESo83i/GkZnhfTNuFMMWcNt7mnV1bGJ6FT4wXH8=
 github.com/panjf2000/ants/v2 v2.12.0/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.94.7 h1:q9nnI79OX7YpVEdchS12VE4ZE37Rx0CVNfaoFJrA64M=
-github.com/pitabwire/frame v1.94.7/go.mod h1:VgKY5c3wGtl4ij4iIwUB3EdSXPPyV0Xj+PacmRIN38s=
+github.com/pitabwire/frame v1.95.0 h1:DfQ85WyPaRnFDSlN/IWsjJc8zBIeciiUjxNVEbqW338=
+github.com/pitabwire/frame v1.95.0/go.mod h1:VgKY5c3wGtl4ij4iIwUB3EdSXPPyV0Xj+PacmRIN38s=
 github.com/pitabwire/natspubsub v0.8.3 h1:VFc73S+qBgxKDgD1ZW6Hz/wKu/8ao/uA1JG38a7MWfc=
 github.com/pitabwire/natspubsub v0.8.3/go.mod h1:W5FT+Am26dmKAKYtMsKQfEeqEUi7O16bpl0UTFlQEA0=
 github.com/pitabwire/util v0.9.0 h1:fnlTAuWKqAjc6GalO+a7hMeo6g3fAv5yjmaP237ChP4=


### PR DESCRIPTION
## Summary

- Bump `github.com/pitabwire/frame` to **v1.95.0**.
- Drop the local `replace github.com/pitabwire/frame => /home/j/code/pitabwire/frame` directive.
- Register `connectInterceptors.NewTenancyTxInterceptor(dbPool)` in each app's Connect interceptor chain.

The interceptor opens a request-scoped Postgres transaction populated with the resolved partition/tenant claims, so repository code no longer has to thread tenancy state manually (transparent multi-partition tenancy via RLS + session vars).

Frame release: https://github.com/pitabwire/frame/tree/v1.95.0

## Test plan

- [ ] CI green
- [ ] Connect handlers still serve requests under expected tenant scope