### PR TITLE
feat(tenancy): register colony helm releases as service accounts

### DIFF
--- a/apps/audit/cmd/main.go
+++ b/apps/audit/cmd/main.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pitabwire/frame"
 	"github.com/pitabwire/frame/config"
 	"github.com/pitabwire/frame/datastore"
-	"github.com/pitabwire/frame/datastore/pool"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/frame/security/authorizer"
 	connectInterceptors "github.com/pitabwire/frame/security/interceptors/connect"
@@ -78,7 +77,7 @@ func main() {
 	auditSrv := handlers.NewAuditServer(ctx, svc, signer)
 
 	// Setup Connect RPC server with full interceptor chain
-	connectHandler := setupConnectServer(ctx, svc.SecurityManager(), auditDBPool, auditSrv)
+	connectHandler := setupConnectServer(ctx, svc.SecurityManager(), auditSrv)
 
 	// Register permission manifest for the audit service
 	sd := auditv1.File_audit_v1_audit_proto.Services().ByName("AuditService")
@@ -133,7 +132,6 @@ func loadOrGenerateSigner(ctx context.Context, hexKey string) (*business.ChainSi
 func setupConnectServer(
 	ctx context.Context,
 	sm security.Manager,
-	dbPool pool.Pool,
 	implementation *handlers.AuditServer,
 ) http.Handler {
 	authenticator := sm.GetAuthenticator(ctx)

--- a/apps/default/cmd/main.go
+++ b/apps/default/cmd/main.go
@@ -43,7 +43,6 @@ import (
 	"github.com/pitabwire/frame/config"
 	"github.com/pitabwire/frame/data"
 	"github.com/pitabwire/frame/datastore"
-	"github.com/pitabwire/frame/datastore/pool"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/frame/security/authorizer"
 	connectInterceptors "github.com/pitabwire/frame/security/interceptors/connect"
@@ -132,7 +131,7 @@ func main() {
 
 	// Setup Connect RPC handler for login history API
 	loginHistorySrv := loginhistory.NewLoginHistoryServer(loginEventRepo, loginRepo)
-	connectPath, connectHandler := setupConnectServer(ctx, sm, dbPool, loginHistorySrv)
+	connectPath, connectHandler := setupConnectServer(ctx, sm, loginHistorySrv)
 
 	// Combine auth routes and Connect RPC into a single handler.
 	// Frame's WithHTTPHandler uses plain assignment (not append), so only
@@ -264,7 +263,6 @@ const namespaceTenancyAccess = "tenancy_access"
 func setupConnectServer(
 	ctx context.Context,
 	sm security.Manager,
-	dbPool pool.Pool,
 	implementation *loginhistory.LoginHistoryServer,
 ) (string, http.Handler) {
 	authenticator := sm.GetAuthenticator(ctx)

--- a/apps/tenancy/cmd/main.go
+++ b/apps/tenancy/cmd/main.go
@@ -35,8 +35,6 @@ import (
 	"github.com/pitabwire/frame"
 	"github.com/pitabwire/frame/client"
 	"github.com/pitabwire/frame/config"
-	"github.com/pitabwire/frame/datastore"
-	"github.com/pitabwire/frame/datastore/pool"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/frame/security/authorizer"
 	connectInterceptors "github.com/pitabwire/frame/security/interceptors/connect"
@@ -107,8 +105,7 @@ func main() {
 	}
 
 	// Setup Connect server
-	dbPool := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName)
-	connectHandler := setupConnectServer(ctx, sm, dbPool, partSrv)
+	connectHandler := setupConnectServer(ctx, sm, partSrv)
 
 	// Register permission manifest for the tenancy service so the UI can
 	// discover available permissions for assignment.
@@ -148,7 +145,6 @@ func main() {
 func setupConnectServer(
 	ctx context.Context,
 	sm security.Manager,
-	dbPool pool.Pool,
 	implementation *handlers.TenancyServer,
 ) http.Handler {
 

--- a/apps/tenancy/migrations/0001/20260420_service_audit.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_audit.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-audit
+-- Audit log service. Records security and tenancy-relevant events
+-- (access changes, role assignments, partition mutations) for compliance.
+-- Needs tenancy for partition lookup and profile for actor resolution.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pag',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_audit',
+    'service-audit',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pb0',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pb0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pbg',
+    'service-audit',
+    'd86tt34pf2tddudk9pag',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_fintech_identity.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_fintech_identity.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-fintech-identity
+-- External fintech identity gateway. Public-facing identity API
+-- for fintech consumers. Bridges to internal identity service and
+-- needs profile/tenancy for scoping plus notification for KYC alerts.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pgg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_fintech_identity',
+    'service-fintech-identity',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_identity":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9ph0',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9ph0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9phg',
+    'service-fintech-identity',
+    'd86tt34pf2tddudk9pgg',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_identity":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_fintech_loans.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_fintech_loans.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-fintech-loans
+-- External fintech loans gateway. Public-facing loan API for
+-- fintech consumers. Bridges to internal loans service and needs
+-- profile/tenancy for scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pi0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_fintech_loans',
+    'service-fintech-loans',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_loans":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pig',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pig',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pj0',
+    'service-fintech-loans',
+    'd86tt34pf2tddudk9pi0',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_loans":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_geolocation.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_geolocation.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-geolocation
+-- Geolocation lookup service. Resolves IPs/coordinates to regions
+-- for device-context decisions. Needs profile, device, and notification
+-- to attach geo signals to user/device events.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pf0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_geolocation',
+    'service-geolocation',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
     '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pfg',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,12 +28,12 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pfg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pg0',
+    'service-geolocation',
+    'd86tt34pf2tddudk9pf0',
     'internal',
     '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'

--- a/apps/tenancy/migrations/0001/20260420_service_opportunities_api.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_opportunities_api.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: opportunities-api
+-- Opportunities public API. Surfaces opportunity listings/details
+-- to consumers and brokers the candidate-matching pipeline. Needs
+-- profile, file, redirect, and notification for downstream lookups.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pvg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-opportunities_api',
+    'opportunities-api',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_file":["*"],"service_notification":["*"],"service_profile":["*"],"service_redirect":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q00',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q00',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9q0g',
+    'opportunities-api',
+    'd86tt34pf2tddudk9pvg',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_file":["*"],"service_notification":["*"],"service_profile":["*"],"service_redirect":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_opportunities_crawler.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_opportunities_crawler.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: opportunities-crawler
+-- Opportunities crawler. Fetches and normalises external listings
+-- into the opportunities pipeline. Needs file for asset capture
+-- and tenancy/profile for scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9q10',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-opportunities_crawler',
+    'opportunities-crawler',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_file":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q1g',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q1g',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9q20',
+    'opportunities-crawler',
+    'd86tt34pf2tddudk9q10',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_file":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_opportunities_matching.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_opportunities_matching.sql
@@ -1,0 +1,41 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+-- Service account: opportunities-matching
+-- Opportunities candidate-matching worker. Scores and notifies
+-- candidates against opportunity listings. Needs notification for
+-- alerts, file/redirect for asset hand-offs, and payment for
+-- conversion-tied flows.
+
+INSERT INTO clients (
+    id, tenant_id, partition_id, name, client_id, client_secret,
+    type, grant_types, scopes, audiences,
+    token_endpoint_auth_method, service_account_id, properties
+) VALUES (
+    'd86tt34pf2tddudk9q2g',
+    'c2f4j7au6s7f91uqnojg',
+    'c2f4j7au6s7f91uqnokg',
+    'sa-opportunities_matching',
+    'opportunities-matching',
+    '',
+    'internal',
+    '{"types": ["client_credentials"]}',
+    'system_int openid',
+    '{"service_file":["*"],"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_redirect":["*"],"service_tenancy":["*"]}',
+    'private_key_jwt',
+    'd86tt34pf2tddudk9q30',
+    '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO service_accounts (
+    id, tenant_id, partition_id, profile_id,
+    client_id, client_ref, type, audiences, properties
+) VALUES (
+    'd86tt34pf2tddudk9q30',
+    'c2f4j7au6s7f91uqnojg',
+    'c2f4j7au6s7f91uqnokg',
+    'd86tt34pf2tddudk9q3g',
+    'opportunities-matching',
+    'd86tt34pf2tddudk9q2g',
+    'internal',
+    '{"service_file":["*"],"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_redirect":["*"],"service_tenancy":["*"]}',
+    '{}'
+) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_opportunities_materializer.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_opportunities_materializer.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: opportunities-materializer
+-- Opportunities materializer. Builds derived views and aggregates
+-- from raw opportunity events for downstream consumers. Operates
+-- behind the queue; needs tenancy for partition scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9q40',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-opportunities_materializer',
+    'opportunities-materializer',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q4g',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q4g',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9q50',
+    'opportunities-materializer',
+    'd86tt34pf2tddudk9q40',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_opportunities_worker.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_opportunities_worker.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: opportunities-worker
+-- Opportunities background worker. Processes queued jobs in the
+-- opportunities pipeline (enrichment, scheduling, retries).
+-- Operates behind the queue; needs tenancy for partition scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9q5g',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-opportunities_worker',
+    'opportunities-worker',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q60',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q60',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9q6g',
+    'opportunities-worker',
+    'd86tt34pf2tddudk9q5g',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_opportunities_writer.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_opportunities_writer.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: opportunities-writer
+-- Opportunities writer. Persists normalised opportunity records
+-- to the storage layer for the API and matcher to read. Operates
+-- behind the queue; needs tenancy for partition scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9q70',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-opportunities_writer',
+    'opportunities-writer',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q7g',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9q7g',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9q80',
+    'opportunities-writer',
+    'd86tt34pf2tddudk9q70',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_payment_airtel.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_payment_airtel.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-payment-airtel
+-- Airtel Money payment provider integration. Bridges the payment
+-- service to Airtel's mobile money API. Needs payment service for
+-- status callbacks and profile/tenancy for scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pl0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_payment_airtel',
+    'service-payment-airtel',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9plg',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9plg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pm0',
+    'service-payment-airtel',
+    'd86tt34pf2tddudk9pl0',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_payment_mpesa.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_payment_mpesa.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-payment-mpesa
+-- M-Pesa (Safaricom Daraja) payment provider integration. Bridges
+-- the payment service to Safaricom's mobile money API for STK push
+-- and B2C/C2B flows. Needs payment service for status callbacks.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pmg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_payment_mpesa',
+    'service-payment-mpesa',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pn0',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pn0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9png',
+    'service-payment-mpesa',
+    'd86tt34pf2tddudk9pmg',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_payment_mtn.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_payment_mtn.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-payment-mtn
+-- MTN Mobile Money payment provider integration. Bridges the
+-- payment service to MTN's mobile money API across markets. Needs
+-- payment service for status callbacks.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9po0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_payment_mtn',
+    'service-payment-mtn',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pog',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pog',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pp0',
+    'service-payment-mtn',
+    'd86tt34pf2tddudk9po0',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_payment_polar.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_payment_polar.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-payment-polar
+-- Polar payment provider integration. Bridges the payment service
+-- to Polar's checkout/billing API for digital-product flows. Needs
+-- payment service for status callbacks.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9ppg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_payment_polar',
+    'service-payment-polar',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pq0',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pq0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pqg',
+    'service-payment-polar',
+    'd86tt34pf2tddudk9ppg',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_payment_stripe.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_payment_stripe.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-payment-stripe
+-- Stripe payment provider integration. Bridges the payment service
+-- to Stripe for card and SEPA flows. Needs payment service for
+-- status callbacks and notification for receipt delivery.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pr0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_payment_stripe',
+    'service-payment-stripe',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9prg',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9prg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9ps0',
+    'service-payment-stripe',
+    'd86tt34pf2tddudk9pr0',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_profile_dek.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_profile_dek.sql
@@ -1,26 +1,27 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-profile-dek
+-- Profile DEK (Data Encryption Key) worker. Runs alongside the
+-- main profile service to manage field-level encryption keys.
+-- Needs notification for key-rotation events, device for trusted
+-- key delivery, and tenancy for partition scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pjg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_profile_dek',
+    'service-profile-dek',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_device":["*"],"service_notification":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pk0',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +29,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pk0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pkg',
+    'service-profile-dek',
+    'd86tt34pf2tddudk9pjg',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_device":["*"],"service_notification":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_redirect.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_redirect.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-redirect
+-- Short URL and link redirector. Handles tracked redirects and
+-- click attribution for files/storage hand-offs. Needs profile
+-- and tenancy for owner/partition scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pdg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_redirect',
+    'service-redirect',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pe0',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pe0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9peg',
+    'service-redirect',
+    'd86tt34pf2tddudk9pdg',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_stawi_jobs_api.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_stawi_jobs_api.sql
@@ -19,7 +19,7 @@ INSERT INTO clients (
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '["*"]',
+    '{}',
     'private_key_jwt',
     'c2f4j7au6s7f91uqnqig',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
@@ -36,6 +36,6 @@ INSERT INTO service_accounts (
     'stawi-jobs-api',
     'c2f4j7au6s7f91uqnqhg',
     'internal',
-    '["*"]',
+    '{}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_stawi_jobs_candidates.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_stawi_jobs_candidates.sql
@@ -21,7 +21,7 @@ INSERT INTO clients (
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '["*"]',
+    '{"service_billing":["*"],"service_file":["*"],"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_redirect":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
     'c2f4j7au6s7f91uqnqeg',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
@@ -38,6 +38,6 @@ INSERT INTO service_accounts (
     'stawi-jobs-candidates',
     'c2f4j7au6s7f91uqnqdg',
     'internal',
-    '["*"]',
+    '{"service_billing":["*"],"service_file":["*"],"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_redirect":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_stawi_jobs_crawler.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_stawi_jobs_crawler.sql
@@ -20,7 +20,7 @@ INSERT INTO clients (
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '["*"]',
+    '{}',
     'private_key_jwt',
     'c2f4j7au6s7f91uqnqgg',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
@@ -37,6 +37,6 @@ INSERT INTO service_accounts (
     'stawi-jobs-crawler',
     'c2f4j7au6s7f91uqnqfg',
     'internal',
-    '["*"]',
+    '{}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_stawi_jobs_scheduler.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_stawi_jobs_scheduler.sql
@@ -19,7 +19,7 @@ INSERT INTO clients (
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '["*"]',
+    '{}',
     'private_key_jwt',
     'c2f4j7au6s7f91uqnqkg',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
@@ -36,6 +36,6 @@ INSERT INTO service_accounts (
     'stawi-jobs-scheduler',
     'c2f4j7au6s7f91uqnqjg',
     'internal',
-    '["*"]',
+    '{}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_thesa.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_thesa.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: service-thesa
+-- Thesa platform gateway. Public-facing endpoint that fronts
+-- internal services for the thesa product surface. Needs profile
+-- and tenancy for request scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pc0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-service_thesa',
+    'service-thesa',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pcg',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pcg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pd0',
+    'service-thesa',
+    'd86tt34pf2tddudk9pc0',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_trustage_formstore.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_trustage_formstore.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: trustage-formstore
+-- Trustage form-storage worker. Persists and retrieves dynamic
+-- form submissions for the trustage product. Needs profile and
+-- tenancy for participant scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9psg',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-trustage_formstore',
+    'trustage-formstore',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pt0',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pt0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9ptg',
+    'trustage-formstore',
+    'd86tt34pf2tddudk9psg',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260420_service_trustage_queuestore.sql
+++ b/apps/tenancy/migrations/0001/20260420_service_trustage_queuestore.sql
@@ -1,26 +1,26 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Service account: service-device
--- Device registry and management. Tracks user devices for push
--- notifications and MFA. Needs profile for owner lookup,
--- notification for device alerts, and tenancy for scoping.
+-- Service account: trustage-queuestore
+-- Trustage queue-storage worker. Persists queued events/messages
+-- for the trustage product. Needs profile and tenancy for
+-- participant scoping.
 
 INSERT INTO clients (
     id, tenant_id, partition_id, name, client_id, client_secret,
     type, grant_types, scopes, audiences,
     token_endpoint_auth_method, service_account_id, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pu0',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'sa-service_device',
-    'service-devices',
+    'sa-trustage_queuestore',
+    'trustage-queuestore',
     '',
     'internal',
     '{"types": ["client_credentials"]}',
     'system_int openid',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     'private_key_jwt',
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pug',
     '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -28,13 +28,13 @@ INSERT INTO service_accounts (
     id, tenant_id, partition_id, profile_id,
     client_id, client_ref, type, audiences, properties
 ) VALUES (
-    'c2f4j7au6s7f91uqnp0g',
+    'd86tt34pf2tddudk9pug',
     'c2f4j7au6s7f91uqnojg',
     'c2f4j7au6s7f91uqnokg',
-    'd75qclkpf2t1uum8ij60',
-    'service-devices',
-    'c2f4j7au6s7f91uqnovg',
+    'd86tt34pf2tddudk9pv0',
+    'trustage-queuestore',
+    'd86tt34pf2tddudk9pu0',
     'internal',
-    '{"service_device":["*"],"service_notification":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{"service_profile":["*"],"service_tenancy":["*"]}',
     '{}'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/IDS.md
+++ b/apps/tenancy/migrations/IDS.md
@@ -41,6 +41,7 @@ configuration.
 | 9bsv0s0hijjg02qk7l1g | 9bsv0s0hijjg02z5lbjg | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_stawi.sql |
 | 9bsv0s0hijjg02qks6i0 | 9bsv0s0hijjg09bzz6dg | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_stawi.sql |
 | 9bsv0s0hid5g02qkl7gjg | 9bsv0s0hijjg02z5lr4g | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_stawi_dev.sql |
+| d7j42dspf2tfev9jfh40 | 9bsv0s0hijjg02z5lr4g | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_stawi_dev.sql |
 | 9bsv0s0hijjb83qksr20 | 9bsv0s0hijjghdbz96dg | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_stawi_dev.sql |
 | d6q1aekpf2taeg5iovpg | d6q1aekpf2taeg5iovp0 | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
 | d6q1aekpf2taeg5iovr0 | d6q1aekpf2taeg5iovqg | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
@@ -124,6 +125,26 @@ configuration.
 | c2f4j7au6s7f91uqnqgg | d75qclkpf2t1uum8iji0 | c2f4j7au6s7f91uqnqfg | apps/tenancy/migrations/0001/20260420_service_stawi_jobs_crawler.sql |
 | c2f4j7au6s7f91uqnqkg | d75qclkpf2t1uum8ijj0 | c2f4j7au6s7f91uqnqjg | apps/tenancy/migrations/0001/20260420_service_stawi_jobs_scheduler.sql |
 | c2f4j7au6s7f91uqnqeg | d75qclkpf2t1uum8ijhg | c2f4j7au6s7f91uqnqdg | apps/tenancy/migrations/0001/20260420_service_stawi_jobs_candidates.sql |
+| d86tt34pf2tddudk9pb0 | d86tt34pf2tddudk9pbg | d86tt34pf2tddudk9pag | apps/tenancy/migrations/0001/20260420_service_audit.sql |
+| d86tt34pf2tddudk9pcg | d86tt34pf2tddudk9pd0 | d86tt34pf2tddudk9pc0 | apps/tenancy/migrations/0001/20260420_service_thesa.sql |
+| d86tt34pf2tddudk9pe0 | d86tt34pf2tddudk9peg | d86tt34pf2tddudk9pdg | apps/tenancy/migrations/0001/20260420_service_redirect.sql |
+| d86tt34pf2tddudk9pfg | d86tt34pf2tddudk9pg0 | d86tt34pf2tddudk9pf0 | apps/tenancy/migrations/0001/20260420_service_geolocation.sql |
+| d86tt34pf2tddudk9ph0 | d86tt34pf2tddudk9phg | d86tt34pf2tddudk9pgg | apps/tenancy/migrations/0001/20260420_service_fintech_identity.sql |
+| d86tt34pf2tddudk9pig | d86tt34pf2tddudk9pj0 | d86tt34pf2tddudk9pi0 | apps/tenancy/migrations/0001/20260420_service_fintech_loans.sql |
+| d86tt34pf2tddudk9pk0 | d86tt34pf2tddudk9pkg | d86tt34pf2tddudk9pjg | apps/tenancy/migrations/0001/20260420_service_profile_dek.sql |
+| d86tt34pf2tddudk9plg | d86tt34pf2tddudk9pm0 | d86tt34pf2tddudk9pl0 | apps/tenancy/migrations/0001/20260420_service_payment_airtel.sql |
+| d86tt34pf2tddudk9pn0 | d86tt34pf2tddudk9png | d86tt34pf2tddudk9pmg | apps/tenancy/migrations/0001/20260420_service_payment_mpesa.sql |
+| d86tt34pf2tddudk9pog | d86tt34pf2tddudk9pp0 | d86tt34pf2tddudk9po0 | apps/tenancy/migrations/0001/20260420_service_payment_mtn.sql |
+| d86tt34pf2tddudk9pq0 | d86tt34pf2tddudk9pqg | d86tt34pf2tddudk9ppg | apps/tenancy/migrations/0001/20260420_service_payment_polar.sql |
+| d86tt34pf2tddudk9prg | d86tt34pf2tddudk9ps0 | d86tt34pf2tddudk9pr0 | apps/tenancy/migrations/0001/20260420_service_payment_stripe.sql |
+| d86tt34pf2tddudk9pt0 | d86tt34pf2tddudk9ptg | d86tt34pf2tddudk9psg | apps/tenancy/migrations/0001/20260420_service_trustage_formstore.sql |
+| d86tt34pf2tddudk9pug | d86tt34pf2tddudk9pv0 | d86tt34pf2tddudk9pu0 | apps/tenancy/migrations/0001/20260420_service_trustage_queuestore.sql |
+| d86tt34pf2tddudk9q00 | d86tt34pf2tddudk9q0g | d86tt34pf2tddudk9pvg | apps/tenancy/migrations/0001/20260420_service_opportunities_api.sql |
+| d86tt34pf2tddudk9q1g | d86tt34pf2tddudk9q20 | d86tt34pf2tddudk9q10 | apps/tenancy/migrations/0001/20260420_service_opportunities_crawler.sql |
+| d86tt34pf2tddudk9q30 | d86tt34pf2tddudk9q3g | d86tt34pf2tddudk9q2g | apps/tenancy/migrations/0001/20260420_service_opportunities_matching.sql |
+| d86tt34pf2tddudk9q4g | d86tt34pf2tddudk9q50 | d86tt34pf2tddudk9q40 | apps/tenancy/migrations/0001/20260420_service_opportunities_materializer.sql |
+| d86tt34pf2tddudk9q60 | d86tt34pf2tddudk9q6g | d86tt34pf2tddudk9q5g | apps/tenancy/migrations/0001/20260420_service_opportunities_worker.sql |
+| d86tt34pf2tddudk9q7g | d86tt34pf2tddudk9q80 | d86tt34pf2tddudk9q70 | apps/tenancy/migrations/0001/20260420_service_opportunities_writer.sql |
 
 ## Partition roles
 | xid | role | partition | file |
@@ -158,3 +179,21 @@ configuration.
 | d7gi6lkpf2t67dlsqri0 | owner  | d7gi6lkpf2t67dlsqrhg | apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql |
 | d7gi6lkpf2t67dlsqrig | admin  | d7gi6lkpf2t67dlsqrhg | apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql |
 | d7gi6ncpf2t7oh5akfqg | member | d7gi6lkpf2t67dlsqrhg | apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql |
+| d7j42dspf2tfev9jfgt0 | admin  | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
+| d7j42dspf2tfev9jfgtg | member | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
+| d7j42dspf2tfev9jfgu0 | admin  | d7b4qekpf2tshigkrv60 | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
+| d7j42dspf2tfev9jfgug | member | d7b4qekpf2tshigkrv60 | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
+| d7j42dspf2tfev9jfgv0 | owner  | d6q1aekpf2taeg5iovpg | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
+| d7j42dspf2tfev9jfgvg | admin  | d6q1aekpf2taeg5iovpg | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
+| d7j42dspf2tfev9jfh00 | member | d6q1aekpf2taeg5iovpg | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
+| d7j42dspf2tfev9jfh0g | owner  | d6q1aekpf2taeg5iovr0 | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
+| d7j42dspf2tfev9jfh10 | admin  | d6q1aekpf2taeg5iovr0 | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
+| d7j42dspf2tfev9jfh1g | member | d6q1aekpf2taeg5iovr0 | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
+| d7j42dspf2tfev9jfh20 | admin  | 9bsv0s0hijjg02qk7l1g | apps/tenancy/migrations/0001/20260420_partition_stawi_chat.sql |
+| d7j42dspf2tfev9jfh2g | member | 9bsv0s0hijjg02qk7l1g | apps/tenancy/migrations/0001/20260420_partition_stawi_chat.sql |
+| d7j42dspf2tfev9jfh30 | admin  | 9bsv0s0hijjg02qks6i0 | apps/tenancy/migrations/0001/20260420_partition_stawi_chat.sql |
+| d7j42dspf2tfev9jfh3g | member | 9bsv0s0hijjg02qks6i0 | apps/tenancy/migrations/0001/20260420_partition_stawi_chat.sql |
+| d7j42dspf2tfev9jfh4g | admin  | d7j42dspf2tfev9jfh40 | apps/tenancy/migrations/0001/20260420_partition_stawi_dev.sql |
+| d7j42dspf2tfev9jfh50 | member | d7j42dspf2tfev9jfh40 | apps/tenancy/migrations/0001/20260420_partition_stawi_dev.sql |
+| d7j42dspf2tfev9jfh5g | admin  | 9bsv0s0hijjb83qksr20 | apps/tenancy/migrations/0001/20260420_partition_stawi_dev.sql |
+| d7j42dspf2tfev9jfh60 | member | 9bsv0s0hijjb83qksr20 | apps/tenancy/migrations/0001/20260420_partition_stawi_dev.sql |

--- a/apps/tenancy/service/business/business_integration_test.go
+++ b/apps/tenancy/service/business/business_integration_test.go
@@ -208,9 +208,17 @@ func (s *BusinessTestSuite) TestListTenantByEnvironment() {
 		Environment: tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_STAGING,
 	})
 	s.Require().NoError(err)
-	s.Len(tenants, 1)
-	s.Equal(stagingTenant.GetID(), tenants[0].GetId())
-	s.Equal(tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_STAGING, tenants[0].GetEnvironment())
+	// Seed migrations include staging tenants (Stawi Development, etc.), so
+	// assert the just-created tenant is in the result and every returned
+	// tenant has the requested environment, not an exact count.
+	var found *tenancyv1.TenantObject
+	for _, t := range tenants {
+		s.Equal(tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_STAGING, t.GetEnvironment())
+		if t.GetId() == stagingTenant.GetID() {
+			found = t
+		}
+	}
+	s.Require().NotNil(found, "created staging tenant should be in the listing")
 }
 
 // ========================
@@ -375,8 +383,18 @@ func (s *BusinessTestSuite) TestListPartition() {
 
 	partitions, err := deps.PartitionBusiness.ListPartition(ctx, &tenancyv1.ListPartitionRequest{})
 	s.Require().NoError(err)
-	s.GreaterOrEqual(len(partitions), 1)
-	s.Equal(partition.GetID(), partitions[0].GetId())
+	s.Require().NotEmpty(partitions)
+	// Seed migrations create partitions for Thesa/Stawi/Ant Investor that
+	// share the listing with the test-created partition, so assert
+	// presence rather than position.
+	var found bool
+	for _, p := range partitions {
+		if p.GetId() == partition.GetID() {
+			found = true
+			break
+		}
+	}
+	s.True(found, "created partition should appear in the listing")
 }
 
 func (s *BusinessTestSuite) TestGetPartitionParents() {


### PR DESCRIPTION
## Summary

Audit of HelmReleases using the colony chart in `antinvestor-deployments` found that 20 deployed services have no matching service-account migration in `apps/tenancy/migrations/0001`, plus one mismatch where the migration's `client_id` does not match the deployed release name (so the running pod cannot authenticate via `client_credentials`).

The colony chart sets `OAUTH2_SERVICE_CLIENT_ID` to `.Release.Name` by default, so every deployed release needs a row in `clients` and `service_accounts` keyed by that exact name.

## Changes

**Fix:**
- `service-device` migration → `client_id` from `service-device` to `service-devices` to match the actual helm release in `profile/devices`.

**New migrations (20):**
- Core/utility: `service-audit`, `service-thesa`, `service-redirect`, `service-geolocation`, `service-profile-dek`
- Fintech surfaces: `service-fintech-identity`, `service-fintech-loans`
- Payment providers: `service-payment-airtel`, `service-payment-mpesa`, `service-payment-mtn`, `service-payment-polar`, `service-payment-stripe`
- Trustage workers: `trustage-formstore`, `trustage-queuestore`
- Opportunities pipeline: `opportunities-{api,crawler,matching,materializer,worker,writer}`

Each migration follows the existing pattern (paired `clients` + `service_accounts` row, `private_key_jwt` auth, `system_int openid` scopes). Audiences mirror what each release lists in its HelmRelease; queue-only workers get a minimal `service_tenancy` audience. Fresh xid IDs (`d86tt34pf2tddudk9*`) are used so there is no collision with the existing `c2f4j7au6s7f91uqn*` range.

## Test plan
- [x] `go build ./apps/tenancy/...` passes
- [x] `go test ./apps/tenancy/service/repository/ -run TestServiceAccount` passes (35s integration with testcontainers — exercises migrations end-to-end)
- [ ] CI green