### PR TITLE
fix(tenancy): jwks_uri default to .identity.svc not .auth.svc

### DIFF
--- a/apps/tenancy/service/events/hydra_client_auth.go
+++ b/apps/tenancy/service/events/hydra_client_auth.go
@@ -25,7 +25,7 @@ import (
 // Internal service accounts use this for private_key_jwt authentication —
 // they sign assertions with a shared key from Hydra's JWK set and Hydra
 // verifies against its own published JWKS.
-const DefaultHydraPublicJWKSURI = "http://service-authentication-oauth2-hydra-public.auth.svc.cluster.local:4444/.well-known/jwks.json"
+const DefaultHydraPublicJWKSURI = "http://service-authentication-oauth2-hydra-public.identity.svc.cluster.local:4444/.well-known/jwks.json"
 
 func applyHydraClientAuthPayload(
 	payload map[string]any,


### PR DESCRIPTION
## Summary
- `DefaultHydraPublicJWKSURI` in `apps/tenancy/service/events/hydra_client_auth.go` was hardcoded to `service-authentication-oauth2-hydra-public.auth.svc.cluster.local`. Deployments that completed the namespace rename to `identity` had every newly-synced Hydra client written with an unreachable jwks_uri; Hydra's token verification returned 500 (`Unable to fetch JSON Web Keys`), and every service's `client_credentials` flow looped on retries (looked like the service kept re-authenticating every 10–20s instead of caching a token).

## Test plan
- [ ] CI on this branch
- [ ] After release, the hourly `synchronize-partitions` cron will rewrite jwks_uri on the existing Hydra clients; verify with `kubectl exec -n identity deploy/service-authentication-oauth2-hydra -c hydra -- hydra list oauth2-clients --endpoint http://127.0.0.1:4445 --format json | jq -r '.items[] | select(.jwks_uri//\"\"|test(\"auth.svc\")) | .client_id' | wc -l` returning 0.