### PR TITLE
feat(auth): native Google/Apple credential token-exchange facade

### DIFF
--- a/apps/default/cmd/main.go
+++ b/apps/default/cmd/main.go
@@ -125,8 +125,9 @@ func main() {
 
 	loginRepo := repository.NewLoginRepository(ctx, dbPool, workManager)
 	loginEventRepo := repository.NewLoginEventRepository(ctx, dbPool, workManager)
+	externalIdentityRepo := repository.NewExternalIdentityRepository(ctx, dbPool, workManager)
 
-	srv := handlers.NewAuthServer(ctx, sm, &cfg, cacheManager, loginRepo, loginEventRepo, profileCli, deviceCli, partitionCli, notificationCli, localizationMan)
+	srv := handlers.NewAuthServer(ctx, sm, &cfg, cacheManager, loginRepo, loginEventRepo, externalIdentityRepo, profileCli, deviceCli, partitionCli, notificationCli, localizationMan)
 	srv.SetEventsManager(svc.EventsManager())
 
 	// Setup Connect RPC handler for login history API

--- a/apps/default/config/config.go
+++ b/apps/default/config/config.go
@@ -93,6 +93,17 @@ type AuthenticationConfig struct {
 	// underlying AES key.
 	FedCMIdPSessionCookieKey string `envDefault:"fedcm_idp_session_v1" env:"FEDCM_IDP_SESSION_COOKIE_KEY"`
 
+	// NativeCredentialExchangeEnabled gates the mobile Google/Apple ID-token
+	// exchange facade. Individual OAuth clients must still opt in through their
+	// tenancy properties.
+	NativeCredentialExchangeEnabled bool `envDefault:"false" env:"NATIVE_CREDENTIAL_EXCHANGE_ENABLED"`
+
+	// Oauth2HydraPublicInternalURL is the Hydra public URL used by the token
+	// facade when the externally advertised issuer routes /oauth2/token to the
+	// authentication service. When empty, FedCMHydraPublicURL/Oauth2ServiceURI is
+	// used.
+	Oauth2HydraPublicInternalURL string `envDefault:"" env:"OAUTH2_HYDRA_PUBLIC_INTERNAL_URL"`
+
 	// PostHog product analytics. The same phc_* project key is used by both
 	// the Go server SDK and the browser SDK — that is by design in PostHog,
 	// the project key is public. Set PostHogAPIKey to the empty string in

--- a/apps/default/migrations/0001/20260604_external_identities.sql
+++ b/apps/default/migrations/0001/20260604_external_identities.sql
@@ -1,0 +1,40 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+--
+-- Licensed under the Apache License, Version 2.0 (the "License").
+
+CREATE TABLE IF NOT EXISTS external_identities (
+    id varchar(50) NOT NULL,
+    tenant_id varchar(50),
+    partition_id varchar(50),
+    access_id varchar(50),
+    created_at timestamptz,
+    modified_at timestamptz,
+    created_by varchar(50),
+    modified_by varchar(50),
+    version bigint DEFAULT 0,
+    deleted_at timestamptz,
+    profile_id varchar(50) NOT NULL,
+    provider varchar(32) NOT NULL,
+    provider_subject varchar(255) NOT NULL,
+    email_at_link varchar(255),
+    email_verified boolean,
+    last_seen_at timestamptz,
+    properties jsonb,
+    PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_external_identity_provider_subject
+    ON external_identities (provider, provider_subject)
+    WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_external_identities_profile_id
+    ON external_identities (profile_id);
+
+CREATE INDEX IF NOT EXISTS idx_external_identities_email_at_link
+    ON external_identities (email_at_link);
+
+CREATE INDEX IF NOT EXISTS idx_external_identities_email_verified
+    ON external_identities (email_verified);
+
+CREATE INDEX IF NOT EXISTS idx_external_identities_last_seen_at
+    ON external_identities (last_seen_at);

--- a/apps/default/service/handlers/fedcm_assertion.go
+++ b/apps/default/service/handlers/fedcm_assertion.go
@@ -177,14 +177,14 @@ func (h *AuthServer) FedCMIdAssertionEndpoint(w http.ResponseWriter, r *http.Req
 	}
 
 	// Stash access/refresh tokens for the follow-up /fedcm/token-exchange call.
-	h.stashFedCMExchange(ctx, result.IDToken, body.ClientID, result)
+	h.stashFedCMExchange(ctx, result.IDToken, body.ClientID, origin, result)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	return json.NewEncoder(w).Encode(map[string]string{"token": result.IDToken})
 }
 
-func (h *AuthServer) stashFedCMExchange(ctx context.Context, idToken, clientID string, r *fedcm.HeadlessResult) {
+func (h *AuthServer) stashFedCMExchange(ctx context.Context, idToken, clientID, origin string, r *fedcm.HeadlessResult) {
 	if h.cacheMan == nil || idToken == "" {
 		return
 	}
@@ -198,6 +198,7 @@ func (h *AuthServer) stashFedCMExchange(ctx context.Context, idToken, clientID s
 		"refresh_token": r.RefreshToken,
 		"expires_in":    r.ExpiresIn,
 		"client_id":     clientID,
+		"origin":        origin,
 	})
 	if merr != nil {
 		log.WithError(merr).Warn("fedcm exchange marshal failed")
@@ -218,7 +219,11 @@ func (h *AuthServer) stashFedCMExchange(ctx context.Context, idToken, clientID s
 // id-assertion token payloads. Mirrors the pattern used by the revocation KV
 // in fedcm_wiring.go (GetRawCache + NewGenericCache).
 func (h *AuthServer) fedcmExchangeCache() (cache.Cache[string, string], error) {
-	rCache, ok := h.cacheMan.GetRawCache("defaultCache")
+	cacheName := "defaultCache"
+	if h.config != nil && strings.TrimSpace(h.config.CacheName) != "" {
+		cacheName = h.config.CacheName
+	}
+	rCache, ok := h.cacheMan.GetRawCache(cacheName)
 	if !ok {
 		return nil, errFedCMCacheUnavailable
 	}

--- a/apps/default/service/handlers/fedcm_token_exchange.go
+++ b/apps/default/service/handlers/fedcm_token_exchange.go
@@ -22,7 +22,8 @@ import (
 )
 
 type fedcmTokenExchangeRequest struct {
-	IDToken string `json:"id_token"`
+	IDToken  string `json:"id_token"`
+	ClientID string `json:"client_id,omitempty"`
 }
 
 type fedcmTokenExchangeResponse struct {
@@ -68,9 +69,22 @@ func (h *AuthServer) FedCMTokenExchangeEndpoint(w http.ResponseWriter, r *http.R
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
 		ExpiresIn    int    `json:"expires_in"`
+		ClientID     string `json:"client_id"`
+		Origin       string `json:"origin"`
 	}
 	if err := json.Unmarshal([]byte(raw), &stash); err != nil {
 		return writeFedCMError(w, http.StatusInternalServerError, "server_error")
+	}
+	if body.ClientID != "" && stash.ClientID != "" && body.ClientID != stash.ClientID {
+		return writeFedCMError(w, http.StatusUnauthorized, "invalid_token")
+	}
+	// The id-assertion endpoint always records the RP origin (it rejects
+	// requests without an Origin header), so a stashed origin must match the
+	// caller's. A missing/blank request Origin no longer bypasses the check —
+	// only legacy entries written before origin capture (stash.Origin == "")
+	// fall through, which eases rollout.
+	if stash.Origin != "" && r.Header.Get("Origin") != stash.Origin {
+		return writeFedCMError(w, http.StatusUnauthorized, "invalid_token")
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/apps/default/service/handlers/fedcm_token_exchange_internal_test.go
+++ b/apps/default/service/handlers/fedcm_token_exchange_internal_test.go
@@ -1,0 +1,121 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	authconfig "github.com/antinvestor/service-authentication/apps/default/config"
+	"github.com/pitabwire/frame/cache"
+	"github.com/stretchr/testify/require"
+)
+
+func newExchangeTestServer(t *testing.T) *AuthServer {
+	t.Helper()
+	cacheMan := cache.NewManager()
+	cacheMan.AddCache("auth-cache", cache.NewInMemoryCache())
+	return &AuthServer{
+		config:   &authconfig.AuthenticationConfig{CacheName: "auth-cache"},
+		cacheMan: cacheMan,
+	}
+}
+
+const testRPOrigin = "https://rp.example.com"
+
+func stashExchangeEntry(t *testing.T, h *AuthServer, idToken, clientID string) {
+	t.Helper()
+	c, err := h.fedcmExchangeCache()
+	require.NoError(t, err)
+	sum := sha256.Sum256([]byte(idToken))
+	key := "fedcm:exchange:" + hex.EncodeToString(sum[:])
+	payload, err := json.Marshal(map[string]any{
+		"access_token":  "at",
+		"refresh_token": "rt",
+		"expires_in":    300,
+		"client_id":     clientID,
+		"origin":        testRPOrigin,
+	})
+	require.NoError(t, err)
+	require.NoError(t, c.Set(context.Background(), key, string(payload), time.Minute))
+}
+
+func exchangeRequest(idToken, clientID, origin string) *http.Request {
+	body, _ := json.Marshal(fedcmTokenExchangeRequest{IDToken: idToken, ClientID: clientID})
+	req := httptest.NewRequest(http.MethodPost, "/fedcm/token-exchange", strings.NewReader(string(body)))
+	if origin != "" {
+		req.Header.Set("Origin", origin)
+	}
+	return req
+}
+
+func TestFedCMTokenExchangeOriginMatch(t *testing.T) {
+	h := newExchangeTestServer(t)
+	stashExchangeEntry(t, h, "id-token-1", "client-a")
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.FedCMTokenExchangeEndpoint(rec, exchangeRequest("id-token-1", "client-a", testRPOrigin)))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "\"access_token\":\"at\"")
+}
+
+func TestFedCMTokenExchangeRejectsMismatchedOrigin(t *testing.T) {
+	h := newExchangeTestServer(t)
+	stashExchangeEntry(t, h, "id-token-2", "client-a")
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.FedCMTokenExchangeEndpoint(rec, exchangeRequest("id-token-2", "client-a", "https://evil.example.com")))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestFedCMTokenExchangeRejectsMissingOriginWhenStashed(t *testing.T) {
+	// A stashed origin must be presented back. Omitting the Origin header no
+	// longer bypasses the binding.
+	h := newExchangeTestServer(t)
+	stashExchangeEntry(t, h, "id-token-3", "client-a")
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.FedCMTokenExchangeEndpoint(rec, exchangeRequest("id-token-3", "client-a", "")))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestFedCMTokenExchangeRejectsMismatchedClientID(t *testing.T) {
+	h := newExchangeTestServer(t)
+	stashExchangeEntry(t, h, "id-token-4", "client-stashed")
+
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.FedCMTokenExchangeEndpoint(rec, exchangeRequest("id-token-4", "client-b", testRPOrigin)))
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+func TestFedCMTokenExchangeIsOneShot(t *testing.T) {
+	h := newExchangeTestServer(t)
+	stashExchangeEntry(t, h, "id-token-5", "client-a")
+
+	rec1 := httptest.NewRecorder()
+	require.NoError(t, h.FedCMTokenExchangeEndpoint(rec1, exchangeRequest("id-token-5", "client-a", testRPOrigin)))
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	rec2 := httptest.NewRecorder()
+	require.NoError(t, h.FedCMTokenExchangeEndpoint(rec2, exchangeRequest("id-token-5", "client-a", testRPOrigin)))
+	require.Equal(t, http.StatusUnauthorized, rec2.Code)
+}

--- a/apps/default/service/handlers/fedcm_wiring.go
+++ b/apps/default/service/handlers/fedcm_wiring.go
@@ -35,6 +35,9 @@ func hydraPublicURL(cfg *aconfig.AuthenticationConfig) string {
 	if cfg == nil {
 		return ""
 	}
+	if cfg.Oauth2HydraPublicInternalURL != "" {
+		return cfg.Oauth2HydraPublicInternalURL
+	}
 	if cfg.FedCMHydraPublicURL != "" {
 		return cfg.FedCMHydraPublicURL
 	}

--- a/apps/default/service/handlers/init_server.go
+++ b/apps/default/service/handlers/init_server.go
@@ -38,6 +38,7 @@ import (
 	"github.com/antinvestor/service-authentication/apps/default/service/handlers/providers"
 	"github.com/antinvestor/service-authentication/apps/default/service/hydra"
 	"github.com/antinvestor/service-authentication/apps/default/service/models"
+	"github.com/antinvestor/service-authentication/apps/default/service/nativecredentials"
 	"github.com/antinvestor/service-authentication/apps/default/service/repository"
 	"github.com/antinvestor/service-authentication/apps/default/service/telemetry"
 	"github.com/antinvestor/service-authentication/apps/default/utils"
@@ -77,8 +78,9 @@ type AuthServer struct {
 	iCache cache.Cache[string, models.LoginEvent]
 
 	// Repository dependencies
-	loginRepo      repository.LoginRepository
-	loginEventRepo repository.LoginEventRepository
+	loginRepo            repository.LoginRepository
+	loginEventRepo       repository.LoginEventRepository
+	externalIdentityRepo repository.ExternalIdentityRepository
 
 	// Login options enabled
 	loginOptions map[string]any
@@ -99,6 +101,14 @@ type AuthServer struct {
 	fedcmRevocation *fedcm.RevocationStore
 	fedcmDriver     *fedcm.HeadlessDriver
 	fedcmWellKnown  *FedCMWellKnownHandler
+
+	nativeVerifier *nativecredentials.Verifier
+
+	// tokenFacadeClient reaches Hydra for the public /oauth2/token and
+	// discovery facades. It carries a bounded timeout and is built with a
+	// background context so it does NOT attach the service OAuth2 token
+	// source — proxied requests are forwarded with the caller's own auth.
+	tokenFacadeClient *http.Client
 
 	// Product analytics. Always non-nil — telemetry.New returns a noop
 	// client when POSTHOG_API_KEY is empty — so handlers can call
@@ -123,7 +133,7 @@ func NewAuthServer(ctx context.Context,
 	securityMan security.Manager,
 	authConfig *aconfig.AuthenticationConfig,
 	cacheMan cache.Manager,
-	loginRepository repository.LoginRepository, loginEventRepository repository.LoginEventRepository,
+	loginRepository repository.LoginRepository, loginEventRepository repository.LoginEventRepository, externalIdentityRepository repository.ExternalIdentityRepository,
 	profileCli profilev1connect.ProfileServiceClient,
 	deviceCli devicev1connect.DeviceServiceClient,
 	partitionCli tenancyv1connect.TenancyServiceClient,
@@ -158,8 +168,9 @@ func NewAuthServer(ctx context.Context,
 		notificationCli: notificationCli,
 
 		// Initialise repositories
-		loginRepo:      loginRepository,
-		loginEventRepo: loginEventRepository,
+		loginRepo:            loginRepository,
+		loginEventRepo:       loginEventRepository,
+		externalIdentityRepo: externalIdentityRepository,
 
 		defaultHydraCli: hydraCli,
 
@@ -187,6 +198,13 @@ func NewAuthServer(ctx context.Context,
 		InternalCallbackURL: publicOrigin + "/_internal/fedcm-callback",
 		Now:                 time.Now,
 	}
+	h.nativeVerifier = nativecredentials.NewVerifier()
+
+	// Bounded-timeout client for the token/discovery facades. Background
+	// context (like hydraHTTPCli above) keeps the service OAuth2 token source
+	// off proxied requests.
+	facadeHTTPOpts := append([]client.HTTPOption{client.WithHTTPTimeout(facadeUpstreamTimeout)}, httpOpts...)
+	h.tokenFacadeClient = client.NewHTTPClient(context.Background(), facadeHTTPOpts...)
 
 	h.analytics = telemetry.New(ctx, authConfig.PostHogAPIKey, authConfig.PostHogHost)
 

--- a/apps/default/service/handlers/oauth_token_facade.go
+++ b/apps/default/service/handlers/oauth_token_facade.go
@@ -1,0 +1,723 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	profilev1 "buf.build/gen/go/antinvestor/profile/protocolbuffers/go/profile/v1"
+	tenancyv1 "buf.build/gen/go/antinvestor/tenancy/protocolbuffers/go/tenancy/v1"
+	"connectrpc.com/connect"
+	"github.com/antinvestor/service-authentication/apps/default/service/fedcm"
+	"github.com/antinvestor/service-authentication/apps/default/service/models"
+	"github.com/antinvestor/service-authentication/apps/default/service/nativecredentials"
+	"github.com/pitabwire/frame"
+	"github.com/pitabwire/frame/client"
+	"github.com/pitabwire/frame/data"
+	"github.com/pitabwire/util"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+const nativeTokenExchangeGrant = "urn:ietf:params:oauth:grant-type:token-exchange"
+const idTokenSubjectTokenType = "urn:ietf:params:oauth:token-type:id_token"
+
+// facadeUpstreamTimeout bounds every facade call to Hydra (discovery + token).
+// The native exchange is a session-bootstrap path, not a hot path, so a slow
+// Hydra must not hold the request open indefinitely.
+const facadeUpstreamTimeout = 15 * time.Second
+
+// facadeUpstreamClient returns the bounded-timeout client used to reach Hydra.
+// It is always set by NewAuthServer in production; the fallback only matters
+// for unit tests that construct AuthServer directly.
+func (h *AuthServer) facadeUpstreamClient() *http.Client {
+	if h.tokenFacadeClient != nil {
+		return h.tokenFacadeClient
+	}
+	return client.NewHTTPClient(context.Background(), client.WithHTTPTimeout(facadeUpstreamTimeout))
+}
+
+// hydraUpstreamBase resolves the Hydra public base URL the facade proxies to.
+// It fails closed when the URL is unset or points back at this facade's own
+// origin, which would otherwise cause unbounded request recursion (the issuer
+// origin routes /oauth2/token to the facade, the facade proxies to the same
+// origin, and so on).
+func (h *AuthServer) hydraUpstreamBase(r *http.Request) (string, error) {
+	base := strings.TrimRight(hydraPublicURL(h.config), "/")
+	if base == "" {
+		return "", fmt.Errorf("hydra public URL is not configured")
+	}
+	if sameHTTPHost(base, h.externalTokenEndpoint(r)) {
+		return "", fmt.Errorf("hydra public URL points back at the token facade")
+	}
+	return base, nil
+}
+
+// sameHTTPHost reports whether two URLs share a host (case-insensitive),
+// ignoring scheme and path. Used to detect the self-referential proxy loop.
+func sameHTTPHost(a, b string) bool {
+	ua, err1 := url.Parse(a)
+	ub, err2 := url.Parse(b)
+	if err1 != nil || err2 != nil || ua.Host == "" || ub.Host == "" {
+		return false
+	}
+	return strings.EqualFold(ua.Host, ub.Host)
+}
+
+type nativeClientConfig struct {
+	Enabled        bool
+	GoogleAudience string
+	AppleAudience  string
+}
+
+type nativeExchangeError struct {
+	status      int
+	code        string
+	description string
+}
+
+func (e *nativeExchangeError) Error() string {
+	if e.description != "" {
+		return e.description
+	}
+	return e.code
+}
+
+// OpenIDConfigurationFacadeEndpoint proxies Hydra's discovery document and
+// rewrites token_endpoint to this authentication-service facade.
+func (h *AuthServer) OpenIDConfigurationFacadeEndpoint(w http.ResponseWriter, r *http.Request) error {
+	base, err := h.hydraUpstreamBase(r)
+	if err != nil {
+		util.Log(r.Context()).WithError(err).Error("hydra discovery facade misconfigured")
+		return h.writeOAuthError(w, http.StatusInternalServerError, "server_error", "token endpoint is misconfigured")
+	}
+	discoveryURL := base + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, discoveryURL, nil)
+	if err != nil {
+		return h.writeOAuthError(w, http.StatusInternalServerError, "server_error", "could not construct discovery request")
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := h.facadeUpstreamClient().Do(req)
+	if err != nil {
+		util.Log(r.Context()).WithError(err).Error("hydra discovery proxy transport failed")
+		return h.writeOAuthError(w, http.StatusBadGateway, "server_error", "hydra discovery endpoint is unavailable")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1024*1024))
+	if err != nil {
+		return h.writeOAuthError(w, http.StatusBadGateway, "server_error", "could not read hydra discovery response")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
+		w.WriteHeader(resp.StatusCode)
+		_, err = w.Write(raw)
+		return err
+	}
+
+	var doc map[string]any
+	if err = json.Unmarshal(raw, &doc); err != nil {
+		return h.writeOAuthError(w, http.StatusBadGateway, "server_error", "hydra discovery response is invalid")
+	}
+	doc["token_endpoint"] = h.externalTokenEndpoint(r)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusOK)
+	return json.NewEncoder(w).Encode(doc)
+}
+
+// OAuthTokenFacadeEndpoint serves the public /oauth2/token facade. It handles
+// native provider ID-token exchange and proxies all ordinary grants to Hydra.
+func (h *AuthServer) OAuthTokenFacadeEndpoint(w http.ResponseWriter, r *http.Request) error {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		return h.writeOAuthError(w, http.StatusMethodNotAllowed, "invalid_request", "method not allowed")
+	}
+	if r.Body == nil {
+		return h.writeOAuthError(w, http.StatusBadRequest, "invalid_request", "request body is required")
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, 2*1024*1024))
+	if err != nil {
+		return h.writeOAuthError(w, http.StatusBadRequest, "invalid_request", "could not read request body")
+	}
+	form, err := url.ParseQuery(string(body))
+	if err != nil {
+		return h.writeOAuthError(w, http.StatusBadRequest, "invalid_request", "invalid form body")
+	}
+
+	if form.Get("grant_type") != nativeTokenExchangeGrant {
+		return h.proxyTokenRequestToHydra(w, r, body)
+	}
+
+	tokenResponse, exchangeErr := h.handleNativeTokenExchange(r.Context(), r, form)
+	if exchangeErr != nil {
+		return h.writeOAuthError(w, exchangeErr.status, exchangeErr.code, exchangeErr.description)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(tokenResponse)
+	return err
+}
+
+func (h *AuthServer) proxyTokenRequestToHydra(w http.ResponseWriter, r *http.Request, body []byte) error {
+	base, err := h.hydraUpstreamBase(r)
+	if err != nil {
+		util.Log(r.Context()).WithError(err).Error("hydra token facade misconfigured")
+		return h.writeOAuthError(w, http.StatusInternalServerError, "server_error", "token endpoint is misconfigured")
+	}
+	tokenURL := base + "/oauth2/token"
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, tokenURL, bytes.NewReader(body))
+	if err != nil {
+		return h.writeOAuthError(w, http.StatusInternalServerError, "server_error", "could not construct upstream token request")
+	}
+	copyTokenProxyHeaders(req.Header, r.Header)
+
+	resp, err := h.facadeUpstreamClient().Do(req)
+	if err != nil {
+		util.Log(r.Context()).WithError(err).Error("hydra token proxy transport failed")
+		return h.writeOAuthError(w, http.StatusBadGateway, "server_error", "hydra token endpoint is unavailable")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	for key, values := range resp.Header {
+		if shouldProxyResponseHeader(key) {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+	}
+	if w.Header().Get("Cache-Control") == "" {
+		w.Header().Set("Cache-Control", "no-store")
+	}
+	if w.Header().Get("Pragma") == "" {
+		w.Header().Set("Pragma", "no-cache")
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, err = io.Copy(w, resp.Body)
+	return err
+}
+
+func copyTokenProxyHeaders(dst, src http.Header) {
+	for _, key := range []string{"Content-Type", "Accept", "Authorization", "DPoP", "DPoP-Nonce", "User-Agent"} {
+		if value := src.Get(key); value != "" {
+			dst.Set(key, value)
+		}
+	}
+}
+
+func shouldProxyResponseHeader(key string) bool {
+	switch strings.ToLower(key) {
+	case "content-type", "cache-control", "pragma", "www-authenticate", "dpop-nonce":
+		return true
+	default:
+		return false
+	}
+}
+
+// handleNativeTokenExchange validates a provider ID token and mints a Hydra
+// session for the resolved profile. It is double-gated: the deployment-wide
+// NativeCredentialExchangeEnabled flag (default false) AND a per-client
+// native_auth_enabled property must both be set.
+//
+// NOTE: this path does not enforce a step-up MFA challenge — possession of a
+// fresh, verified Google/Apple ID token is treated as the authentication
+// factor. Tenancies that require MFA must not enable native auth on their
+// clients until an MFA gate is wired in.
+func (h *AuthServer) handleNativeTokenExchange(ctx context.Context, r *http.Request, form url.Values) ([]byte, *nativeExchangeError) {
+	if !h.config.NativeCredentialExchangeEnabled {
+		return nil, oauthErr(http.StatusBadRequest, "invalid_grant", "native credential exchange is disabled")
+	}
+	if form.Get("subject_token_type") != idTokenSubjectTokenType {
+		return nil, oauthErr(http.StatusBadRequest, "invalid_request", "subject_token_type must be id_token")
+	}
+	clientID := strings.TrimSpace(form.Get("client_id"))
+	if clientID == "" {
+		return nil, oauthErr(http.StatusBadRequest, "invalid_request", "client_id is required")
+	}
+
+	clientCfg, hydraClient, err := h.resolveNativeClientConfig(ctx, clientID)
+	if err != nil {
+		return nil, oauthErr(http.StatusBadRequest, "invalid_client", err.Error())
+	}
+	if !clientCfg.Enabled {
+		return nil, oauthErr(http.StatusBadRequest, "invalid_grant", "native auth is not enabled for this client")
+	}
+
+	issuer := strings.TrimSpace(form.Get("subject_issuer"))
+	audience := clientCfg.audienceForIssuer(issuer)
+	if audience == "" {
+		return nil, oauthErr(http.StatusBadRequest, "invalid_grant", "subject issuer is not enabled for this client")
+	}
+
+	rate := h.CheckLoginRateLimit(ctx, nativeRateLimitKey(clientID, issuer, clientIP(r)))
+	if !rate.Allowed {
+		util.Log(ctx).WithField("client_id", clientID).WithField("subject_issuer", issuer).
+			Warn("native credential exchange rate limited")
+		return nil, oauthErr(http.StatusTooManyRequests, "rate_limited", "too many native credential exchange attempts")
+	}
+
+	identity, err := h.nativeVerifier.VerifyIDToken(ctx, issuer, audience, form.Get("subject_token"))
+	if err != nil {
+		return nil, oauthErr(http.StatusBadRequest, "invalid_grant", err.Error())
+	}
+	replayed, replayErr := h.rejectNativeReplay(ctx, identity)
+	if replayErr != nil {
+		return nil, oauthErr(http.StatusInternalServerError, "server_error", "replay cache unavailable")
+	}
+	if replayed {
+		return nil, oauthErr(http.StatusBadRequest, "invalid_grant", "subject token has already been used")
+	}
+
+	profileID, contactID, err := h.resolveNativeProfile(ctx, identity)
+	if err != nil {
+		return nil, oauthErr(http.StatusBadRequest, "invalid_grant", err.Error())
+	}
+
+	accessObj, err := h.getOrCreateTenancyAccessByClientID(ctx, clientID, profileID)
+	if err != nil {
+		return nil, oauthErr(http.StatusForbidden, "access_denied", "profile is not allowed for this client")
+	}
+	partition := accessObj.GetPartition()
+	if partition == nil {
+		return nil, oauthErr(http.StatusInternalServerError, "server_error", "access partition is missing")
+	}
+	if err = h.linkExternalIdentity(ctx, identity, profileID, accessObj.GetId(), partition.GetTenantId(), partition.GetId()); err != nil {
+		return nil, oauthErr(http.StatusInternalServerError, "server_error", "could not link external identity")
+	}
+
+	loginEvent, err := h.createNativeLoginEvent(
+		ctx, r, form, clientID, profileID, contactID, accessObj.GetId(), partition.GetTenantId(), partition.GetId(), identity,
+	)
+	if err != nil {
+		return nil, oauthErr(http.StatusInternalServerError, "server_error", err.Error())
+	}
+
+	deviceObj, err := h.processDeviceSession(ctx, profileID, r.UserAgent())
+	if err != nil && deviceObj == nil {
+		return nil, oauthErr(http.StatusInternalServerError, "server_error", "could not resolve device session")
+	}
+	deviceID := ""
+	if deviceObj != nil {
+		deviceID = deviceObj.GetId()
+		loginEvent.DeviceID = deviceID
+	}
+	if _, err = h.loginEventRepo.Update(ctx, loginEvent, "device_id"); err != nil {
+		return nil, oauthErr(http.StatusInternalServerError, "server_error", "could not persist login event context")
+	}
+
+	defaultRole := partitionDefaultRole(partition)
+	roles := h.fetchAccessRoleNames(ctx, loginEvent.AccessID, defaultRole)
+	if len(roles) == 0 {
+		roles = []string{"user"}
+	}
+	claims := BuildUserTokenClaims(loginEvent, profileID, deviceID, roles)
+	scopes := tokenScopes(hydraClient.GetScope())
+	nonce := strings.TrimSpace(form.Get("nonce"))
+
+	result, err := h.fedcmDriver.Run(ctx, fedcm.HeadlessRequest{
+		ClientID:     clientID,
+		ClientSecret: hydraClient.GetClientSecret(),
+		SubjectID:    profileID,
+		Nonce:        nonce,
+		Scopes:       scopes,
+		Claims:       claims,
+		ACR:          "native",
+		AMR:          []string{identity.Provider},
+		DeviceID:     deviceID,
+	})
+	if err != nil {
+		util.Log(ctx).WithError(err).WithField("client_id", clientID).Error("native headless hydra flow failed")
+		return nil, oauthErr(http.StatusBadGateway, "server_error", "hydra token issuance failed")
+	}
+
+	h.ResetLoginRateLimit(ctx, nativeRateLimitKey(clientID, issuer, clientIP(r)))
+	util.Log(ctx).
+		WithField("client_id", clientID).
+		WithField("provider", identity.Provider).
+		WithField("profile_id", profileID).
+		WithField("login_event_id", loginEvent.GetID()).
+		Info("native credential exchange succeeded")
+	payload, err := json.Marshal(map[string]any{
+		"access_token":  result.AccessToken,
+		"refresh_token": result.RefreshToken,
+		"id_token":      result.IDToken,
+		"token_type":    "Bearer",
+		"expires_in":    result.ExpiresIn,
+	})
+	if err != nil {
+		return nil, oauthErr(http.StatusInternalServerError, "server_error", "could not encode token response")
+	}
+	return payload, nil
+}
+
+func (c nativeClientConfig) audienceForIssuer(issuer string) string {
+	switch strings.TrimRight(strings.TrimSpace(issuer), "/") {
+	case nativecredentials.GoogleIssuer, nativecredentials.GoogleIssuerShort:
+		return c.GoogleAudience
+	case nativecredentials.AppleIssuer:
+		return c.AppleAudience
+	default:
+		return ""
+	}
+}
+
+func (h *AuthServer) resolveNativeClientConfig(ctx context.Context, clientID string) (*nativeClientConfig, anyHydraClient, error) {
+	hydraClient, err := h.defaultHydraCli.GetOAuth2Client(ctx, clientID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("hydra client lookup failed: %w", err)
+	}
+
+	props := map[string]any{}
+	clientResp, clientErr := h.partitionCli.GetClient(ctx, connect.NewRequest(&tenancyv1.GetClientRequest{ClientId: clientID}))
+	if clientErr == nil && clientResp.Msg.GetData() != nil && clientResp.Msg.GetData().GetProperties() != nil {
+		props = clientResp.Msg.GetData().GetProperties().AsMap()
+	} else if partition, perr := h.resolvePartitionByClientID(ctx, clientID); perr == nil && partition.GetProperties() != nil {
+		props = partition.GetProperties().AsMap()
+	}
+
+	// Audiences are intentionally NOT defaulted to the platform-wide
+	// AuthProviderGoogleClientID/AuthProviderAppleClientID. A shared default
+	// would let an ID token minted for one app bootstrap a session on any other
+	// native-enabled client. Each client must declare its own provider audience.
+	return &nativeClientConfig{
+		Enabled:        boolProperty(props, "native_auth_enabled"),
+		GoogleAudience: stringProperty(props, "native_google_server_client_id", ""),
+		AppleAudience:  stringProperty(props, "native_apple_client_id", ""),
+	}, hydraClient, nil
+}
+
+type anyHydraClient interface {
+	GetClientSecret() string
+	GetScope() string
+}
+
+func boolProperty(props map[string]any, key string) bool {
+	v, ok := props[key]
+	if !ok {
+		return false
+	}
+	switch typed := v.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(typed, "true") || typed == "1"
+	default:
+		return false
+	}
+}
+
+func stringProperty(props map[string]any, key string, fallback string) string {
+	v, ok := props[key]
+	if !ok {
+		return strings.TrimSpace(fallback)
+	}
+	if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+		return strings.TrimSpace(s)
+	}
+	return strings.TrimSpace(fallback)
+}
+
+func tokenScopes(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return []string{"openid", "profile", "email", "offline_access"}
+	}
+	return strings.Fields(raw)
+}
+
+func (h *AuthServer) rejectNativeReplay(ctx context.Context, identity *nativecredentials.Identity) (bool, error) {
+	if identity == nil {
+		return false, fmt.Errorf("identity is required")
+	}
+	if identity.TokenHash == "" {
+		return false, fmt.Errorf("token hash is required")
+	}
+	if h.cacheMan == nil {
+		return false, fmt.Errorf("cache manager is unavailable")
+	}
+	rawCache, ok := h.cacheMan.GetRawCache(h.config.CacheName)
+	if !ok {
+		return false, fmt.Errorf("cache %q is unavailable", h.config.CacheName)
+	}
+	key := "native:replay:" + identity.Provider + ":" + identity.TokenHash
+	count, err := rawCache.Increment(ctx, key, 1)
+	if err != nil {
+		return false, err
+	}
+	if count > 1 {
+		return true, nil
+	}
+	if err = rawCache.Expire(ctx, key, 6*time.Minute); err != nil {
+		_ = rawCache.Delete(ctx, key)
+		return false, err
+	}
+	return false, nil
+}
+
+func (h *AuthServer) resolveNativeProfile(ctx context.Context, identity *nativecredentials.Identity) (profileID, contactID string, err error) {
+	if identity == nil {
+		return "", "", fmt.Errorf("identity is required")
+	}
+	existingIdentity, err := h.externalIdentityRepo.GetByProviderSubject(ctx, identity.Provider, identity.Subject)
+	if err != nil {
+		return "", "", fmt.Errorf("external identity lookup failed: %w", err)
+	}
+	if existingIdentity != nil && existingIdentity.ProfileID != "" {
+		profileID = existingIdentity.ProfileID
+		contactID, err = h.findContactIDForProfile(ctx, profileID, identity.Email)
+		if err != nil {
+			return "", "", err
+		}
+		return profileID, contactID, nil
+	}
+	if identity.Email == "" {
+		return "", "", fmt.Errorf("%s did not provide an email and is not linked", identity.Provider)
+	}
+	if !identity.EmailVerified {
+		return "", "", fmt.Errorf("%s email is not verified", identity.Provider)
+	}
+
+	result, lookupErr := h.profileCli.GetByContact(ctx, connect.NewRequest(&profilev1.GetByContactRequest{Contact: identity.Email}))
+	if lookupErr != nil && !frame.ErrorIsNotFound(lookupErr) {
+		return "", "", fmt.Errorf("profile lookup failed: %w", lookupErr)
+	}
+	if lookupErr == nil && result != nil && result.Msg.GetData() != nil {
+		profile := result.Msg.GetData()
+		if profile.GetType() == profilev1.ProfileType_BOT {
+			return "", "", fmt.Errorf("bot accounts cannot log in through native credentials")
+		}
+		return profile.GetId(), contactIDFromProfile(profile, identity.Email), nil
+	}
+
+	displayName := identity.Name
+	if displayName == "" {
+		displayName = strings.TrimSpace(strings.Join([]string{identity.GivenName, identity.FamilyName}, " "))
+	}
+	properties, _ := structpb.NewStruct(map[string]any{
+		KeyProfileName: displayName,
+		"src":          identity.Provider,
+	})
+	createResult, createErr := h.profileCli.Create(ctx, connect.NewRequest(&profilev1.CreateRequest{
+		Type:       profilev1.ProfileType_PERSON,
+		Contact:    identity.Email,
+		Properties: properties,
+	}))
+	if createErr != nil {
+		return "", "", fmt.Errorf("profile creation failed: %w", createErr)
+	}
+	profile := createResult.Msg.GetData()
+	if profile == nil || profile.GetId() == "" {
+		return "", "", fmt.Errorf("profile creation returned invalid response")
+	}
+	return profile.GetId(), contactIDFromProfile(profile, identity.Email), nil
+}
+
+func (h *AuthServer) findContactIDForProfile(ctx context.Context, profileID, contact string) (string, error) {
+	req := &profilev1.GetByIdRequest{}
+	req.SetId(profileID)
+	resp, err := h.profileCli.GetById(ctx, connect.NewRequest(req))
+	if err != nil {
+		return "", err
+	}
+	profile := resp.Msg.GetData()
+	if profile == nil {
+		return "", fmt.Errorf("linked profile is missing")
+	}
+	if profile.GetType() == profilev1.ProfileType_BOT {
+		return "", fmt.Errorf("bot accounts cannot log in through native credentials")
+	}
+	return contactIDFromProfile(profile, contact), nil
+}
+
+func contactIDFromProfile(profile *profilev1.ProfileObject, contact string) string {
+	if profile == nil {
+		return ""
+	}
+	for _, c := range profile.GetContacts() {
+		if strings.EqualFold(strings.TrimSpace(c.GetDetail()), strings.TrimSpace(contact)) {
+			return c.GetId()
+		}
+	}
+	return ""
+}
+
+func (h *AuthServer) linkExternalIdentity(ctx context.Context, identity *nativecredentials.Identity, profileID, accessID, tenantID, partitionID string) error {
+	existing, err := h.externalIdentityRepo.GetByProviderSubject(ctx, identity.Provider, identity.Subject)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		if existing.ProfileID != profileID {
+			return fmt.Errorf("external identity is already linked to another profile")
+		}
+		return h.touchExternalIdentity(ctx, existing, identity, accessID, tenantID, partitionID)
+	}
+
+	record := &models.ExternalIdentity{
+		ProfileID:       profileID,
+		Provider:        identity.Provider,
+		ProviderSubject: identity.Subject,
+		EmailAtLink:     identity.Email,
+		EmailVerified:   identity.EmailVerified,
+		LastSeenAt:      time.Now(),
+		Properties: data.JSONMap{
+			"issuer":                identity.Issuer,
+			"provider_subject_hash": identity.SubjectHash,
+		},
+	}
+	record.AccessID = accessID
+	record.TenantID = tenantID
+	record.PartitionID = partitionID
+	record.GenID(ctx)
+	if err = h.externalIdentityRepo.Create(ctx, record); err != nil {
+		if !data.ErrorIsDuplicateKey(err) {
+			return err
+		}
+		existing, lookupErr := h.externalIdentityRepo.GetByProviderSubject(ctx, identity.Provider, identity.Subject)
+		if lookupErr != nil {
+			return lookupErr
+		}
+		if existing == nil || existing.ProfileID != profileID {
+			return err
+		}
+		return h.touchExternalIdentity(ctx, existing, identity, accessID, tenantID, partitionID)
+	}
+	return err
+}
+
+// touchExternalIdentity refreshes the mutable columns of an already-linked
+// identity on each successful native login, including the tenant/partition of
+// the access used this time so the record reflects the latest workspace.
+func (h *AuthServer) touchExternalIdentity(
+	ctx context.Context, existing *models.ExternalIdentity,
+	identity *nativecredentials.Identity, accessID, tenantID, partitionID string,
+) error {
+	existing.LastSeenAt = time.Now()
+	existing.EmailAtLink = identity.Email
+	existing.EmailVerified = identity.EmailVerified
+	existing.AccessID = accessID
+	existing.TenantID = tenantID
+	existing.PartitionID = partitionID
+	_, err := h.externalIdentityRepo.Update(ctx, existing,
+		"last_seen_at", "email_at_link", "email_verified", "access_id", "tenant_id", "partition_id")
+	return err
+}
+
+func (h *AuthServer) createNativeLoginEvent(
+	ctx context.Context, r *http.Request, form url.Values,
+	clientID, profileID, contactID, accessID, tenantID, partitionID string,
+	identity *nativecredentials.Identity,
+) (*models.LoginEvent, error) {
+	loginRecord, err := h.getOrCreateLoginRecord(ctx, profileID, clientID, identity.Provider)
+	if err != nil {
+		return nil, fmt.Errorf("resolve login record: %w", err)
+	}
+	loginEvent := &models.LoginEvent{
+		ClientID:  clientID,
+		LoginID:   loginRecord.GetID(),
+		ProfileID: profileID,
+		ContactID: contactID,
+		Client:    r.UserAgent(),
+		IP:        clientIP(r),
+		AccessID:  accessID,
+		Properties: data.JSONMap{
+			loginEventPropertyLoginSource: string(models.LoginSource(identity.Provider)),
+			"native_provider":             identity.Provider,
+			"native_issuer":               identity.Issuer,
+			"native_subject_hash":         identity.SubjectHash,
+			"native_email":                identity.Email,
+			"native_email_verified":       identity.EmailVerified,
+			"platform":                    strings.TrimSpace(form.Get("platform")),
+			"installation_id":             strings.TrimSpace(form.Get("installation_id")),
+			"device_name":                 strings.TrimSpace(form.Get("device_name")),
+		},
+	}
+	loginEvent.TenantID = tenantID
+	loginEvent.PartitionID = partitionID
+	loginEvent.GenID(ctx)
+	if err = h.loginEventRepo.Create(ctx, loginEvent); err != nil {
+		return nil, fmt.Errorf("create login event: %w", err)
+	}
+	return loginEvent, nil
+}
+
+func oauthErr(status int, code, description string) *nativeExchangeError {
+	return &nativeExchangeError{status: status, code: code, description: description}
+}
+
+func (h *AuthServer) writeOAuthError(w http.ResponseWriter, status int, code, description string) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(status)
+	return json.NewEncoder(w).Encode(map[string]string{
+		"error":             code,
+		"error_description": description,
+	})
+}
+
+func clientIP(r *http.Request) string {
+	for _, header := range []string{"X-Forwarded-For", "X-Real-IP"} {
+		if value := strings.TrimSpace(r.Header.Get(header)); value != "" {
+			first := strings.TrimSpace(strings.Split(value, ",")[0])
+			if first != "" {
+				return first
+			}
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}
+
+func nativeRateLimitKey(clientID, issuer, ip string) string {
+	return clientID + ":" + issuer + ":" + ip
+}
+
+func (h *AuthServer) externalTokenEndpoint(r *http.Request) string {
+	if h != nil && h.config != nil {
+		if origin := strings.TrimRight(strings.TrimSpace(h.config.FedCMPublicOrigin), "/"); origin != "" {
+			if parsed, err := url.Parse(origin); err == nil && parsed.Scheme != "" && parsed.Host != "" {
+				return origin + "/oauth2/token"
+			}
+		}
+	}
+	scheme := "https"
+	if r.Header.Get("X-Forwarded-Proto") != "" {
+		scheme = strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-Proto"), ",")[0])
+	} else if r.TLS == nil {
+		scheme = "http"
+	}
+	host := r.Host
+	if forwardedHost := strings.TrimSpace(r.Header.Get("X-Forwarded-Host")); forwardedHost != "" {
+		host = strings.TrimSpace(strings.Split(forwardedHost, ",")[0])
+	}
+	return scheme + "://" + host + "/oauth2/token"
+}

--- a/apps/default/service/handlers/oauth_token_facade_endpoints_internal_test.go
+++ b/apps/default/service/handlers/oauth_token_facade_endpoints_internal_test.go
@@ -1,0 +1,227 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	authconfig "github.com/antinvestor/service-authentication/apps/default/config"
+	"github.com/antinvestor/service-authentication/apps/default/service/nativecredentials"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAudienceForIssuer(t *testing.T) {
+	cfg := nativeClientConfig{GoogleAudience: "g-aud", AppleAudience: "a-aud"}
+	cases := []struct {
+		issuer string
+		want   string
+	}{
+		{nativecredentials.GoogleIssuer, "g-aud"},
+		{nativecredentials.GoogleIssuer + "/", "g-aud"},
+		{nativecredentials.GoogleIssuerShort, "g-aud"},
+		{" " + nativecredentials.AppleIssuer + " ", "a-aud"},
+		{"https://evil.example.com", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		require.Equalf(t, tc.want, cfg.audienceForIssuer(tc.issuer), "issuer %q", tc.issuer)
+	}
+}
+
+func TestAudienceForIssuerUnsetReturnsEmpty(t *testing.T) {
+	// A client that did not configure an audience must not accept any token —
+	// no fallback to a shared platform-wide client ID.
+	cfg := nativeClientConfig{}
+	require.Empty(t, cfg.audienceForIssuer(nativecredentials.GoogleIssuer))
+	require.Empty(t, cfg.audienceForIssuer(nativecredentials.AppleIssuer))
+}
+
+func TestBoolProperty(t *testing.T) {
+	require.True(t, boolProperty(map[string]any{"k": true}, "k"))
+	require.True(t, boolProperty(map[string]any{"k": "true"}, "k"))
+	require.True(t, boolProperty(map[string]any{"k": "TRUE"}, "k"))
+	require.True(t, boolProperty(map[string]any{"k": "1"}, "k"))
+	require.False(t, boolProperty(map[string]any{"k": "false"}, "k"))
+	require.False(t, boolProperty(map[string]any{"k": 1}, "k"))
+	require.False(t, boolProperty(map[string]any{}, "k"))
+}
+
+func TestStringProperty(t *testing.T) {
+	require.Equal(t, "v", stringProperty(map[string]any{"k": "v"}, "k", "fb"))
+	require.Equal(t, "fb", stringProperty(map[string]any{"k": "  "}, "k", "fb"))
+	require.Equal(t, "fb", stringProperty(map[string]any{}, "k", "fb"))
+	require.Equal(t, "", stringProperty(map[string]any{}, "k", ""))
+	require.Equal(t, "v", stringProperty(map[string]any{"k": " v "}, "k", "fb"))
+}
+
+func TestTokenScopesDefaults(t *testing.T) {
+	require.Equal(t, []string{"openid", "profile", "email", "offline_access"}, tokenScopes(""))
+	require.Equal(t, []string{"openid", "profile", "email", "offline_access"}, tokenScopes("   "))
+	require.Equal(t, []string{"openid", "email"}, tokenScopes("openid email"))
+}
+
+func TestClientIPPrefersForwardedHeaders(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/oauth2/token", nil)
+	r.RemoteAddr = "10.0.0.9:5555"
+	require.Equal(t, "10.0.0.9", clientIP(r))
+
+	r.Header.Set("X-Real-IP", "203.0.113.7")
+	require.Equal(t, "203.0.113.7", clientIP(r))
+
+	r.Header.Set("X-Forwarded-For", "198.51.100.4, 70.41.3.18")
+	require.Equal(t, "198.51.100.4", clientIP(r))
+}
+
+func TestSameHTTPHost(t *testing.T) {
+	require.True(t, sameHTTPHost("https://Accounts.Example.com/oauth2/token", "https://accounts.example.com"))
+	require.False(t, sameHTTPHost("https://hydra-internal:4444", "https://accounts.example.com/oauth2/token"))
+	require.False(t, sameHTTPHost("", "https://accounts.example.com"))
+	require.False(t, sameHTTPHost("https://a.example.com", "::::not-a-url"))
+}
+
+func TestHydraUpstreamBaseRejectsSelfReference(t *testing.T) {
+	h := &AuthServer{config: &authconfig.AuthenticationConfig{
+		FedCMPublicOrigin:            "https://accounts.example.com",
+		Oauth2HydraPublicInternalURL: "https://accounts.example.com",
+	}}
+	r := httptest.NewRequest(http.MethodPost, "/oauth2/token", nil)
+	_, err := h.hydraUpstreamBase(r)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "points back")
+}
+
+func TestHydraUpstreamBaseRejectsUnset(t *testing.T) {
+	h := &AuthServer{config: &authconfig.AuthenticationConfig{}}
+	r := httptest.NewRequest(http.MethodPost, "/oauth2/token", nil)
+	_, err := h.hydraUpstreamBase(r)
+	require.Error(t, err)
+}
+
+func TestHydraUpstreamBaseAllowsDistinctHost(t *testing.T) {
+	h := &AuthServer{config: &authconfig.AuthenticationConfig{
+		FedCMPublicOrigin:            "https://accounts.example.com",
+		Oauth2HydraPublicInternalURL: "https://hydra-internal:4444",
+	}}
+	r := httptest.NewRequest(http.MethodPost, "/oauth2/token", nil)
+	base, err := h.hydraUpstreamBase(r)
+	require.NoError(t, err)
+	require.Equal(t, "https://hydra-internal:4444", base)
+}
+
+func TestOpenIDConfigurationFacadeRewritesTokenEndpoint(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/.well-known/openid-configuration", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 "https://hydra.internal",
+			"token_endpoint":         "https://hydra.internal/oauth2/token",
+			"authorization_endpoint": "https://hydra.internal/oauth2/auth",
+		})
+	}))
+	defer upstream.Close()
+
+	h := &AuthServer{
+		config: &authconfig.AuthenticationConfig{
+			FedCMPublicOrigin:            "https://accounts.example.com",
+			Oauth2HydraPublicInternalURL: upstream.URL,
+		},
+		tokenFacadeClient: upstream.Client(),
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	require.NoError(t, h.OpenIDConfigurationFacadeEndpoint(rec, req))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &doc))
+	require.Equal(t, "https://accounts.example.com/oauth2/token", doc["token_endpoint"])
+	// Unrelated fields are passed through untouched.
+	require.Equal(t, "https://hydra.internal/oauth2/auth", doc["authorization_endpoint"])
+}
+
+func TestOpenIDConfigurationFacadeFailsOnSelfReference(t *testing.T) {
+	h := &AuthServer{config: &authconfig.AuthenticationConfig{
+		FedCMPublicOrigin:            "https://accounts.example.com",
+		Oauth2HydraPublicInternalURL: "https://accounts.example.com",
+	}}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	require.NoError(t, h.OpenIDConfigurationFacadeEndpoint(rec, req))
+	require.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestOAuthTokenFacadeProxiesOrdinaryGrants(t *testing.T) {
+	var gotBody string
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/oauth2/token", r.URL.Path)
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"at","token_type":"bearer"}`))
+	}))
+	defer upstream.Close()
+
+	h := &AuthServer{
+		config: &authconfig.AuthenticationConfig{
+			FedCMPublicOrigin:            "https://accounts.example.com",
+			Oauth2HydraPublicInternalURL: upstream.URL,
+		},
+		tokenFacadeClient: upstream.Client(),
+	}
+
+	form := "grant_type=client_credentials&client_id=svc&client_secret=shh"
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/token", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic abc")
+	rec := httptest.NewRecorder()
+
+	require.NoError(t, h.OAuthTokenFacadeEndpoint(rec, req))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, form, gotBody)
+	require.Equal(t, "Basic abc", gotAuth)
+	require.Contains(t, rec.Body.String(), "access_token")
+	require.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+}
+
+func TestOAuthTokenFacadeNativeGrantDisabledByDefault(t *testing.T) {
+	h := &AuthServer{config: &authconfig.AuthenticationConfig{}}
+	form := "grant_type=" + nativeTokenExchangeGrant
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/token", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	require.NoError(t, h.OAuthTokenFacadeEndpoint(rec, req))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, "invalid_grant", body["error"])
+}
+
+func TestOAuthTokenFacadeRejectsNonPost(t *testing.T) {
+	h := &AuthServer{config: &authconfig.AuthenticationConfig{}}
+	req := httptest.NewRequest(http.MethodGet, "/oauth2/token", nil)
+	rec := httptest.NewRecorder()
+	require.NoError(t, h.OAuthTokenFacadeEndpoint(rec, req))
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}

--- a/apps/default/service/handlers/oauth_token_facade_internal_test.go
+++ b/apps/default/service/handlers/oauth_token_facade_internal_test.go
@@ -1,0 +1,77 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	authconfig "github.com/antinvestor/service-authentication/apps/default/config"
+	"github.com/antinvestor/service-authentication/apps/default/service/nativecredentials"
+	"github.com/pitabwire/frame/cache"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExternalTokenEndpointPrefersConfiguredPublicOrigin(t *testing.T) {
+	h := &AuthServer{config: &authconfig.AuthenticationConfig{FedCMPublicOrigin: "https://accounts.example.com/"}}
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	req.Host = "attacker.example"
+	req.Header.Set("X-Forwarded-Host", "evil.example")
+	req.Header.Set("X-Forwarded-Proto", "http")
+
+	require.Equal(t, "https://accounts.example.com/oauth2/token", h.externalTokenEndpoint(req))
+}
+
+func TestRejectNativeReplayFailsClosedWithoutCache(t *testing.T) {
+	h := &AuthServer{config: &authconfig.AuthenticationConfig{CacheName: "auth-cache"}}
+	identity := &nativecredentials.Identity{Provider: nativecredentials.ProviderGoogle, TokenHash: "abc123"}
+
+	replayed, err := h.rejectNativeReplay(context.Background(), identity)
+	require.False(t, replayed)
+	require.Error(t, err)
+}
+
+func TestRejectNativeReplayRejectsSecondUse(t *testing.T) {
+	cacheMan := cache.NewManager()
+	cacheMan.AddCache("auth-cache", cache.NewInMemoryCache())
+	h := &AuthServer{
+		config:   &authconfig.AuthenticationConfig{CacheName: "auth-cache"},
+		cacheMan: cacheMan,
+	}
+	identity := &nativecredentials.Identity{Provider: nativecredentials.ProviderGoogle, TokenHash: "abc123"}
+
+	replayed, err := h.rejectNativeReplay(context.Background(), identity)
+	require.NoError(t, err)
+	require.False(t, replayed)
+
+	replayed, err = h.rejectNativeReplay(context.Background(), identity)
+	require.NoError(t, err)
+	require.True(t, replayed)
+}
+
+func TestFedCMExchangeCacheUsesConfiguredCacheName(t *testing.T) {
+	cacheMan := cache.NewManager()
+	cacheMan.AddCache("auth-cache", cache.NewInMemoryCache())
+	h := &AuthServer{
+		config:   &authconfig.AuthenticationConfig{CacheName: "auth-cache"},
+		cacheMan: cacheMan,
+	}
+
+	c, err := h.fedcmExchangeCache()
+	require.NoError(t, err)
+	require.NotNil(t, c)
+}

--- a/apps/default/service/handlers/routing.go
+++ b/apps/default/service/handlers/routing.go
@@ -94,6 +94,16 @@ func (h *AuthServer) SetupRouterV1(ctx context.Context) *http.ServeMux {
 	// Public routes (no auth, no CSRF)
 	h.addHandler(router, h.ErrorEndpoint, "/error", "ErrorEndpoint")
 	h.addHandler(router, h.SwaggerEndpoint, "/swagger.json", "SwaggerEndpoint")
+	router.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		if err := h.OpenIDConfigurationFacadeEndpoint(w, r); err != nil {
+			h.writeAPIError(r.Context(), w, err, "OpenIDConfigurationFacade")
+		}
+	})
+	router.HandleFunc("POST /oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		if err := h.OAuthTokenFacadeEndpoint(w, r); err != nil {
+			h.writeAPIError(r.Context(), w, err, "OAuthTokenFacade")
+		}
+	})
 
 	// Custom root handler that handles both static files and index
 	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/apps/default/service/models/models.go
+++ b/apps/default/service/models/models.go
@@ -56,6 +56,17 @@ type LoginEvent struct {
 	Status           int `gorm:"index"`
 }
 
+type ExternalIdentity struct {
+	data.BaseModel
+	ProfileID       string       `gorm:"type:varchar(50);not null;index"`
+	Provider        string       `gorm:"type:varchar(32);not null;uniqueIndex:idx_external_identity_provider_subject"`
+	ProviderSubject string       `gorm:"type:varchar(255);not null;uniqueIndex:idx_external_identity_provider_subject"`
+	EmailAtLink     string       `gorm:"type:varchar(255);index"`
+	EmailVerified   bool         `gorm:"index"`
+	LastSeenAt      time.Time    `gorm:"index"`
+	Properties      data.JSONMap `gorm:"type:jsonb"`
+}
+
 func (l LoginEvent) GetTenantID() string {
 	return l.TenantID
 }

--- a/apps/default/service/nativecredentials/verifier.go
+++ b/apps/default/service/nativecredentials/verifier.go
@@ -1,0 +1,211 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nativecredentials
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+)
+
+const (
+	ProviderGoogle = "google"
+	ProviderApple  = "apple"
+
+	GoogleIssuer      = "https://accounts.google.com"
+	GoogleIssuerShort = "accounts.google.com"
+	AppleIssuer       = "https://appleid.apple.com"
+)
+
+type Identity struct {
+	Provider      string
+	Issuer        string
+	Subject       string
+	SubjectHash   string
+	Email         string
+	EmailVerified bool
+	Name          string
+	GivenName     string
+	FamilyName    string
+	Picture       string
+	IssuedAt      time.Time
+	ExpiresAt     time.Time
+	RawClaims     map[string]any
+	TokenHash     string
+}
+
+type Verifier struct {
+	mu        sync.Mutex
+	providers map[string]*oidc.Provider
+	now       func() time.Time
+}
+
+func NewVerifier() *Verifier {
+	return &Verifier{
+		providers: make(map[string]*oidc.Provider),
+		now:       time.Now,
+	}
+}
+
+func (v *Verifier) VerifyIDToken(ctx context.Context, issuer, audience, rawToken string) (*Identity, error) {
+	issuer = canonicalIssuer(issuer)
+	if issuer == "" {
+		return nil, fmt.Errorf("subject_issuer is required")
+	}
+	if audience == "" {
+		return nil, fmt.Errorf("provider audience is not configured")
+	}
+	if rawToken == "" {
+		return nil, fmt.Errorf("subject_token is required")
+	}
+
+	providerName, discoveryIssuer, err := providerForIssuer(issuer)
+	if err != nil {
+		return nil, err
+	}
+
+	p, err := v.oidcProvider(ctx, discoveryIssuer)
+	if err != nil {
+		return nil, err
+	}
+
+	idToken, err := p.Verifier(&oidc.Config{ClientID: audience}).Verify(ctx, rawToken)
+	if err != nil {
+		return nil, fmt.Errorf("%s: id_token verification failed: %w", providerName, err)
+	}
+
+	if providerName == ProviderGoogle && idToken.Issuer != GoogleIssuer && idToken.Issuer != GoogleIssuerShort {
+		return nil, fmt.Errorf("google: unexpected issuer %q", idToken.Issuer)
+	}
+	if providerName == ProviderApple && idToken.Issuer != AppleIssuer {
+		return nil, fmt.Errorf("apple: unexpected issuer %q", idToken.Issuer)
+	}
+
+	var claims map[string]any
+	if err = idToken.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("%s: parse id_token claims: %w", providerName, err)
+	}
+
+	identity := identityFromClaims(providerName, idToken, claims, rawToken)
+	if identity.Subject == "" {
+		return nil, fmt.Errorf("%s: subject claim is missing", providerName)
+	}
+	if identity.IssuedAt.IsZero() {
+		return nil, fmt.Errorf("%s: issued-at claim is missing", providerName)
+	}
+	if v.now().After(identity.IssuedAt.Add(5*time.Minute + 30*time.Second)) {
+		return nil, fmt.Errorf("%s: id_token is too old for native exchange", providerName)
+	}
+	if identity.Email == "" && identity.Provider == ProviderGoogle {
+		return nil, fmt.Errorf("google: email claim is required")
+	}
+	if identity.Provider == ProviderGoogle && !identity.EmailVerified {
+		return nil, fmt.Errorf("google: email is not verified")
+	}
+
+	return identity, nil
+}
+
+func (v *Verifier) oidcProvider(ctx context.Context, issuer string) (*oidc.Provider, error) {
+	v.mu.Lock()
+	p := v.providers[issuer]
+	v.mu.Unlock()
+	if p != nil {
+		return p, nil
+	}
+
+	created, err := oidc.NewProvider(ctx, issuer)
+	if err != nil {
+		return nil, fmt.Errorf("discover OIDC issuer %s: %w", issuer, err)
+	}
+
+	v.mu.Lock()
+	if existing := v.providers[issuer]; existing != nil {
+		v.mu.Unlock()
+		return existing, nil
+	}
+	v.providers[issuer] = created
+	v.mu.Unlock()
+	return created, nil
+}
+
+func providerForIssuer(issuer string) (provider, discoveryIssuer string, err error) {
+	switch issuer {
+	case GoogleIssuer, GoogleIssuerShort:
+		return ProviderGoogle, GoogleIssuer, nil
+	case AppleIssuer:
+		return ProviderApple, AppleIssuer, nil
+	default:
+		return "", "", fmt.Errorf("unsupported subject_issuer %q", issuer)
+	}
+}
+
+func canonicalIssuer(issuer string) string {
+	issuer = strings.TrimSpace(issuer)
+	if strings.EqualFold(issuer, GoogleIssuerShort) {
+		return GoogleIssuerShort
+	}
+	return strings.TrimRight(issuer, "/")
+}
+
+func identityFromClaims(provider string, token *oidc.IDToken, claims map[string]any, rawToken string) *Identity {
+	email, _ := claims["email"].(string)
+	name, _ := claims["name"].(string)
+	givenName, _ := claims["given_name"].(string)
+	familyName, _ := claims["family_name"].(string)
+	picture, _ := claims["picture"].(string)
+	emailVerified := boolClaim(claims["email_verified"])
+
+	subjectHash := ""
+	if token.Subject != "" {
+		sum := sha256.Sum256([]byte(provider + ":" + token.Subject))
+		subjectHash = hex.EncodeToString(sum[:])
+	}
+	tokenSum := sha256.Sum256([]byte(rawToken))
+
+	return &Identity{
+		Provider:      provider,
+		Issuer:        token.Issuer,
+		Subject:       token.Subject,
+		SubjectHash:   subjectHash,
+		Email:         email,
+		EmailVerified: emailVerified,
+		Name:          name,
+		GivenName:     givenName,
+		FamilyName:    familyName,
+		Picture:       picture,
+		IssuedAt:      token.IssuedAt,
+		ExpiresAt:     token.Expiry,
+		RawClaims:     claims,
+		TokenHash:     hex.EncodeToString(tokenSum[:]),
+	}
+}
+
+func boolClaim(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		return strings.EqualFold(t, "true")
+	default:
+		return false
+	}
+}

--- a/apps/default/service/nativecredentials/verifier_test.go
+++ b/apps/default/service/nativecredentials/verifier_test.go
@@ -1,0 +1,124 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nativecredentials
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalIssuer(t *testing.T) {
+	cases := map[string]string{
+		"  https://accounts.google.com/ ": GoogleIssuer,
+		"accounts.google.com":             GoogleIssuerShort,
+		"ACCOUNTS.GOOGLE.COM":             GoogleIssuerShort,
+		"https://appleid.apple.com/":      AppleIssuer,
+		"":                                "",
+		"https://other.example.com//":     "https://other.example.com",
+	}
+	for in, want := range cases {
+		require.Equalf(t, want, canonicalIssuer(in), "input %q", in)
+	}
+}
+
+func TestProviderForIssuer(t *testing.T) {
+	p, disc, err := providerForIssuer(GoogleIssuer)
+	require.NoError(t, err)
+	require.Equal(t, ProviderGoogle, p)
+	require.Equal(t, GoogleIssuer, disc)
+
+	p, disc, err = providerForIssuer(GoogleIssuerShort)
+	require.NoError(t, err)
+	require.Equal(t, ProviderGoogle, p)
+	require.Equal(t, GoogleIssuer, disc)
+
+	p, disc, err = providerForIssuer(AppleIssuer)
+	require.NoError(t, err)
+	require.Equal(t, ProviderApple, p)
+	require.Equal(t, AppleIssuer, disc)
+
+	_, _, err = providerForIssuer("https://evil.example.com")
+	require.Error(t, err)
+}
+
+func TestBoolClaim(t *testing.T) {
+	require.True(t, boolClaim(true))
+	require.True(t, boolClaim("true"))
+	require.True(t, boolClaim("TRUE"))
+	require.False(t, boolClaim("1"))
+	require.False(t, boolClaim(false))
+	require.False(t, boolClaim(nil))
+	require.False(t, boolClaim(1))
+}
+
+func TestIdentityFromClaims(t *testing.T) {
+	issuedAt := time.Date(2026, 6, 4, 12, 0, 0, 0, time.UTC)
+	token := &oidc.IDToken{
+		Issuer:   GoogleIssuer,
+		Subject:  "sub-123",
+		IssuedAt: issuedAt,
+		Expiry:   issuedAt.Add(time.Hour),
+	}
+	claims := map[string]any{
+		"email":          "user@example.com",
+		"email_verified": true,
+		"name":           "Test User",
+		"given_name":     "Test",
+		"family_name":    "User",
+		"picture":        "https://img.example.com/a.png",
+	}
+
+	id := identityFromClaims(ProviderGoogle, token, claims, "raw-token")
+	require.Equal(t, ProviderGoogle, id.Provider)
+	require.Equal(t, "sub-123", id.Subject)
+	require.Equal(t, "user@example.com", id.Email)
+	require.True(t, id.EmailVerified)
+	require.Equal(t, "Test User", id.Name)
+	require.Equal(t, issuedAt, id.IssuedAt)
+
+	wantSubjectHash := sha256.Sum256([]byte(ProviderGoogle + ":sub-123"))
+	require.Equal(t, hex.EncodeToString(wantSubjectHash[:]), id.SubjectHash)
+
+	wantTokenHash := sha256.Sum256([]byte("raw-token"))
+	require.Equal(t, hex.EncodeToString(wantTokenHash[:]), id.TokenHash)
+}
+
+func TestIdentityFromClaimsEmptySubjectHasNoHash(t *testing.T) {
+	id := identityFromClaims(ProviderApple, &oidc.IDToken{Issuer: AppleIssuer}, map[string]any{}, "raw")
+	require.Empty(t, id.SubjectHash)
+	require.False(t, id.EmailVerified)
+}
+
+func TestVerifyIDTokenInputValidation(t *testing.T) {
+	v := NewVerifier()
+	ctx := t.Context()
+
+	_, err := v.VerifyIDToken(ctx, "", "aud", "tok")
+	require.ErrorContains(t, err, "subject_issuer is required")
+
+	_, err = v.VerifyIDToken(ctx, GoogleIssuer, "", "tok")
+	require.ErrorContains(t, err, "audience is not configured")
+
+	_, err = v.VerifyIDToken(ctx, GoogleIssuer, "aud", "")
+	require.ErrorContains(t, err, "subject_token is required")
+
+	_, err = v.VerifyIDToken(ctx, "https://evil.example.com", "aud", "tok")
+	require.ErrorContains(t, err, "unsupported subject_issuer")
+}

--- a/apps/default/service/repository/external_identity.go
+++ b/apps/default/service/repository/external_identity.go
@@ -1,0 +1,51 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository
+
+import (
+	"context"
+
+	"github.com/antinvestor/service-authentication/apps/default/service/models"
+	"github.com/pitabwire/frame/data"
+	"github.com/pitabwire/frame/datastore"
+	"github.com/pitabwire/frame/datastore/pool"
+	"github.com/pitabwire/frame/workerpool"
+)
+
+type externalIdentityRepository struct {
+	datastore.BaseRepository[*models.ExternalIdentity]
+}
+
+func NewExternalIdentityRepository(ctx context.Context, dbPool pool.Pool, workMan workerpool.Manager) ExternalIdentityRepository {
+	return &externalIdentityRepository{
+		BaseRepository: datastore.NewBaseRepository[*models.ExternalIdentity](
+			ctx, dbPool, workMan, func() *models.ExternalIdentity { return &models.ExternalIdentity{} },
+		),
+	}
+}
+
+func (r *externalIdentityRepository) GetByProviderSubject(ctx context.Context, provider, providerSubject string) (*models.ExternalIdentity, error) {
+	var identity models.ExternalIdentity
+	err := r.Pool().DB(ctx, true).
+		Where("provider = ? AND provider_subject = ?", provider, providerSubject).
+		First(&identity).Error
+	if err != nil {
+		if data.ErrorIsNoRows(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &identity, nil
+}

--- a/apps/default/service/repository/interfaces.go
+++ b/apps/default/service/repository/interfaces.go
@@ -39,6 +39,13 @@ type LoginEventRepository interface {
 	GetByOauth2SessionID(ctx context.Context, oauth2SessionID string) (*models.LoginEvent, error)
 }
 
+// ExternalIdentityRepository handles database operations for provider-scoped
+// external identities such as Google and Apple subject identifiers.
+type ExternalIdentityRepository interface {
+	datastore.BaseRepository[*models.ExternalIdentity]
+	GetByProviderSubject(ctx context.Context, provider, providerSubject string) (*models.ExternalIdentity, error)
+}
+
 // SessionRepository handles database operations for Session entities
 type SessionRepository interface {
 	datastore.BaseRepository[*models.Session]

--- a/apps/default/service/repository/migrate.go
+++ b/apps/default/service/repository/migrate.go
@@ -30,5 +30,5 @@ func Migrate(ctx context.Context, dbManager datastore.Manager, migrationPath str
 	}
 
 	return dbManager.Migrate(ctx, pool, migrationPath,
-		&models.Login{}, &models.LoginEvent{})
+		&models.Login{}, &models.LoginEvent{}, &models.ExternalIdentity{})
 }

--- a/apps/default/tests/base_testsuite.go
+++ b/apps/default/tests/base_testsuite.go
@@ -51,8 +51,9 @@ import (
 )
 
 type DepsBuilder struct {
-	LoginRepo      repository.LoginRepository
-	LoginEventRepo repository.LoginEventRepository
+	LoginRepo            repository.LoginRepository
+	LoginEventRepo       repository.LoginEventRepository
+	ExternalIdentityRepo repository.ExternalIdentityRepository
 
 	ProfileCli      profilev1connect.ProfileServiceClient
 	DeviceCli       devicev1connect.DeviceServiceClient
@@ -66,8 +67,9 @@ func BuildRepos(ctx context.Context, svc *frame.Service) (*DepsBuilder, error) {
 	cfg, _ := svc.Config().(*aconfig.AuthenticationConfig)
 
 	depBuilder := &DepsBuilder{
-		LoginRepo:      repository.NewLoginRepository(ctx, dbPool, workMan),
-		LoginEventRepo: repository.NewLoginEventRepository(ctx, dbPool, workMan),
+		LoginRepo:            repository.NewLoginRepository(ctx, dbPool, workMan),
+		LoginEventRepo:       repository.NewLoginEventRepository(ctx, dbPool, workMan),
+		ExternalIdentityRepo: repository.NewExternalIdentityRepository(ctx, dbPool, workMan),
 	}
 
 	var err error
@@ -283,7 +285,7 @@ func (bs *BaseTestSuite) CreateService(
 
 	authServer := handlers.NewAuthServer(ctx, svc.SecurityManager(), &cfg,
 		svc.CacheManager(), depsBuilder.LoginRepo, depsBuilder.LoginEventRepo,
-		depsBuilder.ProfileCli, depsBuilder.DeviceCli, depsBuilder.PartitionCli, depsBuilder.NotificationCli, nil)
+		depsBuilder.ExternalIdentityRepo, depsBuilder.ProfileCli, depsBuilder.DeviceCli, depsBuilder.PartitionCli, depsBuilder.NotificationCli, nil)
 
 	authServiceHandlers := authServer.SetupRouterV1(ctx)
 

--- a/apps/tenancy/service/events/events_test.go
+++ b/apps/tenancy/service/events/events_test.go
@@ -474,7 +474,12 @@ func (suite *EventsTestSuite) TestPreparePayload_WithRedirectURIs() {
 
 	uris, ok := payload["redirect_uris"].([]string)
 	require.True(t, ok)
-	assert.Len(t, uris, 2)
+	// authorization_code clients also get the first-party FedCM callback URI
+	// appended by ensureFedCMCallbackRedirectURI.
+	assert.Len(t, uris, 3)
+	assert.Contains(t, uris, "https://example.com/cb")
+	assert.Contains(t, uris, "https://other.com/cb")
+	assert.Contains(t, uris[len(uris)-1], "/_internal/fedcm-callback")
 }
 
 // --- ServiceAccountSyncEvent ---

--- a/apps/tenancy/service/events/fedcm_callback.go
+++ b/apps/tenancy/service/events/fedcm_callback.go
@@ -1,0 +1,50 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"os"
+	"strings"
+)
+
+const defaultFedCMPublicOrigin = "https://accounts.stawi.org"
+
+func ensureFedCMCallbackRedirectURI(redirectURIs, grantTypes []string) []string {
+	if !containsString(grantTypes, "authorization_code") {
+		return redirectURIs
+	}
+	callback := fedCMCallbackRedirectURI()
+	if callback == "" || containsString(redirectURIs, callback) {
+		return redirectURIs
+	}
+	return append(redirectURIs, callback)
+}
+
+func fedCMCallbackRedirectURI() string {
+	origin := strings.TrimRight(strings.TrimSpace(os.Getenv("FEDCM_PUBLIC_ORIGIN")), "/")
+	if origin == "" {
+		origin = defaultFedCMPublicOrigin
+	}
+	return origin + "/_internal/fedcm-callback"
+}
+
+func containsString(values []string, needle string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/apps/tenancy/service/events/fedcm_callback_test.go
+++ b/apps/tenancy/service/events/fedcm_callback_test.go
@@ -1,0 +1,66 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package events
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureFedCMCallbackRedirectURI(t *testing.T) {
+	t.Setenv("FEDCM_PUBLIC_ORIGIN", "https://accounts.example.com")
+	const callback = "https://accounts.example.com/_internal/fedcm-callback"
+
+	t.Run("appends for authorization_code clients", func(t *testing.T) {
+		got := ensureFedCMCallbackRedirectURI(
+			[]string{"https://app.example.com/cb"},
+			[]string{"authorization_code", "refresh_token"},
+		)
+		require.Equal(t, []string{"https://app.example.com/cb", callback}, got)
+	})
+
+	t.Run("skips non authorization_code clients", func(t *testing.T) {
+		in := []string{"https://app.example.com/cb"}
+		got := ensureFedCMCallbackRedirectURI(in, []string{"client_credentials"})
+		require.Equal(t, in, got)
+	})
+
+	t.Run("does not duplicate when already present", func(t *testing.T) {
+		in := []string{callback}
+		got := ensureFedCMCallbackRedirectURI(in, []string{"authorization_code"})
+		require.Equal(t, in, got)
+		require.Len(t, got, 1)
+	})
+
+	t.Run("matches case-insensitively without duplicating", func(t *testing.T) {
+		in := []string{"AUTHORIZATION_CODE-callback-placeholder", callback}
+		got := ensureFedCMCallbackRedirectURI(in, []string{"AUTHORIZATION_CODE"})
+		require.Len(t, got, 2)
+	})
+}
+
+func TestEnsureFedCMCallbackRedirectURIDefaultOrigin(t *testing.T) {
+	t.Setenv("FEDCM_PUBLIC_ORIGIN", "")
+	got := ensureFedCMCallbackRedirectURI(nil, []string{"authorization_code"})
+	require.Equal(t, []string{defaultFedCMPublicOrigin + "/_internal/fedcm-callback"}, got)
+}
+
+func TestContainsString(t *testing.T) {
+	require.True(t, containsString([]string{"a", "b"}, "b"))
+	require.True(t, containsString([]string{" Authorization_Code "}, "authorization_code"))
+	require.False(t, containsString([]string{"a"}, "c"))
+	require.False(t, containsString(nil, "x"))
+}

--- a/apps/tenancy/service/events/sync_client.go
+++ b/apps/tenancy/service/events/sync_client.go
@@ -200,6 +200,7 @@ func buildClientHydraPayload(cl *models.Client, profileID string) map[string]any
 	}
 
 	redirectURIs := getStringSlice(cl.RedirectURIs, "uris")
+	redirectURIs = ensureFedCMCallbackRedirectURI(redirectURIs, grantTypes)
 	audienceList := authz.AudienceNamespaces(cl.Audiences)
 
 	scopes := cl.Scopes

--- a/apps/tenancy/service/events/sync_partition.go
+++ b/apps/tenancy/service/events/sync_partition.go
@@ -211,6 +211,7 @@ func preparePayload(clientID string, partition *models.Partition) (map[string]an
 	if gt := extractStringList(partition.Properties, "grant_types"); len(gt) > 0 {
 		grantTypes = gt
 	}
+	uriList = ensureFedCMCallbackRedirectURI(uriList, grantTypes)
 
 	responseTypes := []string{"token", "id_token", "code", "token id_token", "token code id_token"}
 	if rt := extractStringList(partition.Properties, "response_types"); len(rt) > 0 {

--- a/docs/auth-runtime-native-credentials.md
+++ b/docs/auth-runtime-native-credentials.md
@@ -4,60 +4,92 @@
 who need to make the Flutter `antinvestor_auth_runtime` v0.2+ native
 sign-in path work end-to-end.
 
-**Scope:** what the Ory Hydra (or equivalent) IdP must accept for the
-Flutter runtime to exchange Apple / Google ID tokens into Antinvestor
-sessions via RFC 8693.
+**Scope:** what the Ory Hydra-backed authentication deployment must accept for
+the Flutter runtime to exchange Apple / Google ID tokens into Antinvestor
+sessions.
 
 **Status:** this is a **future enablement**. The Flutter runtime already
-ships the client side in v0.2. The Go service may need additional
-changes before it can honour the token-exchange grant end-to-end —
-track progress under `TODO track in Jira/issue` (replace with the
-actual issue ID once filed).
+ships the client side in v0.2. The Go service needs a token endpoint facade
+before it can honour the native exchange end-to-end.
 
 ---
 
 ## 1. Prerequisites
 
-- Ory Hydra ≥ **v2.2** (first release with token-exchange grant
-  support), or an equivalent OAuth 2.0 authorization server.
+- Ory Hydra remains the issuer of Antinvestor access, refresh, and ID tokens.
+- A public auth-service facade fronts `/oauth2/token` for the issuer origin.
+  The facade handles the native provider-token exchange and proxies ordinary
+  OAuth grants to Hydra.
 - OAuth clients are already provisioned for the mobile apps
   (`antinvestor-mobile`, `antinvestor-chat-mobile`,
   `antinvestor-fintech-mobile`, …) with the `authorization_code` and
   `refresh_token` grants enabled.
 - Ability to update client registrations via Hydra's admin API or
   equivalent tenancy config.
-- A trusted-issuer registry the auth service consults during
-  token-exchange: either a first-class Hydra feature or a thin shim in
-  front of `/oauth2/token`.
+- A trusted-issuer registry the auth service consults during native exchange.
 
-## 2. Enable the token-exchange grant
+## 2. Token endpoint facade
 
-The mobile OAuth client's `grant_types` must include:
+The Flutter runtime posts this form grant to the discovered `token_endpoint`:
 
 ```
 urn:ietf:params:oauth:grant-type:token-exchange
 ```
 
-Example (Hydra admin API):
+In the current architecture, the discovered endpoint must be the auth-service
+facade, not Hydra directly. The facade must:
 
-```http
-PATCH /admin/clients/{client_id}
-Content-Type: application/json
+- accept `application/x-www-form-urlencoded` token requests,
+- proxy `authorization_code`, `refresh_token`, and `client_credentials`
+  requests to Hydra without changing request semantics,
+- handle only
+  `urn:ietf:params:oauth:grant-type:token-exchange` inside the auth service,
+- verify the Google or Apple ID token,
+- resolve/link the Antinvestor profile,
+- create the normal login event/device/access context,
+- run any required MFA gate,
+- drive Hydra through a headless `authorization_code` flow, and
+- return Hydra's token response unchanged.
 
-[
-  {
-    "op": "add",
-    "path": "/grant_types/-",
-    "value": "urn:ietf:params:oauth:grant-type:token-exchange"
-  }
-]
-```
+Do not add the RFC 8693 grant to Hydra client `grant_types` as a hard
+requirement in facade mode. Hydra receives a normal authorization-code exchange
+after the auth service validates the provider identity proof. If a future
+deployed Hydra version is explicitly verified to support RFC 8693 directly,
+that can be revisited as a separate architecture decision.
 
 The client also needs `offline_access` in its allowed scopes so the
 exchanged session can be rotated via refresh tokens (already required
 for the v0.1 authorization-code path).
 
-## 3. Register Apple as a trusted subject issuer
+The facade needs a separate internal Hydra public URL for its upstream token
+and authorization calls. Do not point it at the public issuer origin when that
+origin routes `/oauth2/token` back to the facade.
+
+## 3. Performance expectations
+
+The native exchange is a session bootstrap path, not a per-request path. It
+should run only when the runtime cannot use an existing Antinvestor session and
+has a fresh Google or Apple ID token.
+
+Per successful native login, expect provider-token verification, profile/device
+resolution, and a headless Hydra authorization-code flow. This is mostly
+internal HTTP and database work, not heavy CPU work. Keep it fast by:
+
+- caching provider JWKS,
+- using pooled HTTP clients,
+- using the internal Hydra public URL,
+- setting short timeouts,
+- rate limiting before expensive verification and Hydra work,
+- reusing refresh tokens for normal session renewal, and
+- tracing each leg so slow provider verification and slow Hydra calls can be
+  distinguished.
+
+Target server-side latency after the provider ID token is available:
+
+- P50 under 300 ms.
+- P95 under 1.5 s in staging under normal load.
+
+## 4. Register Apple as a trusted subject issuer
 
 | Field            | Value                                                       |
 |------------------|-------------------------------------------------------------|
@@ -84,7 +116,7 @@ trusted_issuers:
 At exchange time, validate `subject_token.aud` matches the expected
 Services ID for the requesting `client_id`.
 
-## 4. Register Google as a trusted subject issuer
+## 5. Register Google as a trusted subject issuer
 
 | Field            | Value                                                       |
 |------------------|-------------------------------------------------------------|
@@ -105,7 +137,7 @@ trusted_issuers:
       antinvestor-chat-mobile: 456.apps.googleusercontent.com
 ```
 
-## 5. Claim-mapping rules
+## 6. Claim-mapping rules
 
 When the exchange succeeds, the IdP mints a fresh Antinvestor session
 backed by the subject token's claims:
@@ -126,7 +158,7 @@ on the very first sign-in, and only if the app requested the `name`
 scope. Subsequent sign-ins return `sub` and `email` only. Persist the
 name on first sight; do not overwrite with nulls on repeat exchanges.
 
-## 6. Security hardening
+## 7. Security hardening
 
 - **Freshness:** reject `subject_token` whose `iat` is older than
   **5 minutes** (plus a small clock-skew tolerance, e.g. ±30 s). Apple
@@ -154,7 +186,7 @@ name on first sight; do not overwrite with nulls on repeat exchanges.
   Apple tokens) in a short-lived cache (≥ token freshness window) and
   reject duplicates.
 
-## 7. Rate limiting
+## 8. Rate limiting
 
 Add a per-client, per-IP rate limit on the token-exchange endpoint.
 Suggested budget: **30 requests per minute per client** — more than
@@ -164,12 +196,15 @@ credential-stuffing attempts that bypass `/oauth2/auth`.
 Log 429s and feed them into the existing auth-service dashboards
 alongside `/oauth2/token` errors.
 
-## 8. Testing checklist
+## 9. Testing checklist
 
 Before cutting over a production tenancy:
 
-- [ ] Client listed in `grant_types` includes
-      `urn:ietf:params:oauth:grant-type:token-exchange`.
+- [ ] Public discovery advertises the auth-service facade as `token_endpoint`.
+- [ ] Facade proxies `authorization_code`, `refresh_token`, and
+      `client_credentials` grants to Hydra unchanged.
+- [ ] Facade uses a non-recursive internal Hydra public URL.
+- [ ] Mobile client has `authorization_code` and `refresh_token` grants.
 - [ ] Apple trusted issuer registered with correct Services ID per
       consuming app.
 - [ ] Google trusted issuer registered with correct server client ID
@@ -196,4 +231,7 @@ Before cutting over a production tenancy:
 - RFC 8693 — OAuth 2.0 Token Exchange: <https://www.rfc-editor.org/rfc/rfc8693>
 - Apple — Sign in with Apple REST API: <https://developer.apple.com/documentation/sign_in_with_apple>
 - Google — Authenticating with a backend server: <https://developers.google.com/identity/sign-in/android/backend-auth>
-- Ory Hydra — Token Exchange (when released): <https://www.ory.sh/docs/hydra>
+- Ory Hydra production deployment and public/admin endpoint split:
+  <https://www.ory.com/docs/hydra/self-hosted/production>
+- Ory Hydra custom login and consent flow:
+  <https://www.ory.com/docs/hydra/guides/custom-ui-oauth2>

--- a/docs/mobile-web-one-tap-and-mfa-implementation-plan.md
+++ b/docs/mobile-web-one-tap-and-mfa-implementation-plan.md
@@ -1,0 +1,825 @@
+# Mobile/Web One Tap and MFA Implementation Plan
+
+## Goal
+
+Make authentication feel immediate for end users while keeping Hydra as the
+only issuer of Antinvestor access, refresh, and ID tokens.
+
+The user-facing target is:
+
+1. Returning mobile users open the app and are signed in automatically when a
+   safe platform credential is available.
+2. New mobile users see the platform-native Google or Apple sheet before any
+   browser flow.
+3. Flutter web users reach the current hosted login page, where first-party
+   FedCM and Google One Tap/FedCM are attempted before contact-code login.
+4. Users can enable account-level MFA from an account security screen.
+5. MFA does not add friction on every login: a verified trusted device can
+   skip repeated MFA until risk or expiry requires step-up.
+
+## Assumptions
+
+- "One Tap" is Google terminology. Android uses Google Sign-In through
+  Credential Manager / `google_sign_in`; web uses Google Identity Services
+  with FedCM. Apple uses Sign in with Apple through the native Apple sheet,
+  which requires an explicit user action.
+- Google and Apple ID tokens are identity proofs only. They are never accepted
+  as Antinvestor API bearer tokens.
+- The public OAuth issuer remains the same user-facing origin. Hydra remains
+  the authoritative issuer, but the auth service may front `/oauth2/token` to
+  handle native credential token exchange and proxy all other grants to Hydra.
+- Account-managed MFA is separate from the existing contact-code login flow.
+  The current contact OTP path can remain as login bootstrap/recovery, but the
+  new primary MFA methods are passkeys/WebAuthn and TOTP.
+
+## Current State
+
+Already present:
+
+- Flutter runtime native providers:
+  - `ui/runtime/lib/src/credentials/google_credential_provider.dart`
+  - `ui/runtime/lib/src/credentials/apple_credential_provider.dart`
+- Runtime native credential exchange call:
+  - `ui/runtime/lib/src/protocol/token_exchange.dart`
+  - posts RFC 8693 `urn:ietf:params:oauth:grant-type:token-exchange`
+- Login page Google FedCM completion:
+  - `apps/default/service/handlers/login_step_2_google_fedcm.go`
+- First-party FedCM IdP and one-shot token stash:
+  - `apps/default/service/handlers/fedcm_assertion.go`
+  - `apps/default/service/handlers/fedcm_token_exchange.go`
+- Shared user token claims:
+  - `apps/default/service/handlers/login_step_4_consent.go`
+  - `BuildUserTokenClaims`
+
+Missing:
+
+- Backend handling for provider ID token to Hydra token exchange.
+- Provider-scoped external identity linking (`google:<sub>`, `apple:<sub>`).
+- Mobile-native device enrollment without relying on browser cookies.
+- Account-level MFA factor enrollment, verification, recovery, and trusted
+  device policy.
+- Flutter/runtime account security UI and typed APIs for MFA settings.
+
+## Hydra Compatibility Audit
+
+The existing browser login paths already fit Hydra's login/consent contract:
+
+- Google FedCM on `/s/login` completes through `completeProviderLogin`, then
+  calls `AcceptLoginRequest`; consent and token issuance remain Hydra-owned.
+- First-party FedCM already runs a server-side authorization-code flow with the
+  `fedcm.HeadlessDriver` and exchanges the code at Hydra's `/oauth2/token`.
+- Hydra client provisioning already defaults partition clients to
+  `authorization_code` plus `refresh_token`, and current seeds include the
+  internal FedCM callback redirect URI.
+
+The mobile-native path is not yet Hydra-compatible as implemented:
+
+- `TokenExchange.exchangeIdToken` posts the RFC 8693 grant to the discovered
+  `token_endpoint`.
+- `SetupRouterV1` does not currently register `/oauth2/token` in the auth
+  service, so discovery/gateway routing would send the native exchange directly
+  to Hydra.
+- The auth service docs already mark native credential backend support as
+  future enablement.
+
+Required Hydra-safe decisions:
+
+- Keep Hydra as the only token issuer, but put an auth-service facade in front
+  of the public `/oauth2/token` endpoint.
+- Publish discovery metadata whose `token_endpoint` points at that facade.
+- The facade must proxy ordinary grants to Hydra unchanged and handle only the
+  native provider-token exchange itself.
+- The facade's internal Hydra URL must be a separate private/public Hydra
+  service URL, not the external issuer URL, or proxying and headless exchanges
+  can loop back into the facade.
+- Do not require Hydra to support
+  `urn:ietf:params:oauth:grant-type:token-exchange` for this rollout unless a
+  specific deployed Hydra version is verified to accept it. Use the tenancy
+  `native_auth_enabled` property as the auth-service policy gate.
+- Enforce the internal FedCM callback redirect URI for every user-facing
+  authorization-code client during client sync, not only in seed migrations.
+- Keep `offline_access` and `refresh_token` enabled for mobile clients so the
+  returned Hydra refresh token works with the existing runtime refresh path.
+- Before production, harden `/fedcm/token-exchange` to bind the one-shot stash
+  to the requesting origin/client and a verifier, matching the earlier FedCM
+  design instead of relying only on `hash(id_token)`.
+- Native exchange and first-party FedCM should create or reuse a durable
+  `LoginEvent` and call `BuildUserTokenClaims` rather than hand-building token
+  extras. This keeps refresh-token webhook enrichment and browser-issued token
+  shape identical.
+- MFA must complete before `AcceptLoginRequest` or the headless Hydra token
+  issuance. A token already minted by Hydra cannot be made "MFA complete" after
+  the fact.
+
+## Architecture
+
+### Interaction Plane
+
+- Flutter runtime signs users in through this waterfall:
+  1. Existing stored Antinvestor session.
+  2. Native silent provider attempts.
+  3. Native interactive provider attempts.
+  4. OAuth browser fallback.
+- Hosted web login page signs users in through this waterfall:
+  1. Hydra skip/remembered login.
+  2. First-party FedCM from `idp_session`.
+  3. Google One Tap/FedCM.
+  4. Sign in with Apple button.
+  5. Contact-code fallback.
+- Account security UI exposes:
+  - MFA status.
+  - Add passkey.
+  - Add authenticator app.
+  - View/regenerate recovery codes.
+  - Remove factor after step-up.
+  - Trusted devices.
+
+### Control Plane
+
+Provider and MFA policy is resolved per OAuth client:
+
+- `native_auth_enabled`
+- `native_google_server_client_id`
+- `native_apple_client_id`
+- `mfa_policy`: `optional`, `required`, or `risk_based`
+- `mfa_trusted_device_ttl_days`
+- `mfa_required_for_roles`
+
+Store these on tenancy client or partition properties so rollout is per
+application without hard-coding client IDs in the auth service.
+
+### Execution Plane
+
+- Add a token endpoint facade in the auth service:
+  - `POST /oauth2/token`
+  - For `authorization_code`, `refresh_token`, and `client_credentials`, proxy
+    the request to Hydra unchanged.
+  - For `urn:ietf:params:oauth:grant-type:token-exchange`, verify the external
+    subject token, run the same profile/login-event/claim path as browser
+    login, drive Hydra headlessly, and return Hydra's token response.
+  - The public OIDC discovery document must advertise this facade as
+    `token_endpoint`; the facade must call a separately configured internal
+    Hydra public URL for proxying and headless authorization-code exchange.
+- Add an MFA gate called before:
+  - `AcceptLoginRequest` in web/provider/contact flows.
+  - headless Hydra issuance in native token exchange.
+  - first-party FedCM assertion issuance.
+
+### Data Plane
+
+New auth-service-owned tables:
+
+- `external_identities`
+  - `id`
+  - `tenant_id`
+  - `partition_id`
+  - `profile_id`
+  - `provider` (`google`, `apple`)
+  - `provider_subject`
+  - `email_at_link`
+  - `email_verified`
+  - `last_seen_at`
+  - unique `(provider, provider_subject)`
+
+- `mfa_factors`
+  - `id`
+  - `profile_id`
+  - `kind` (`webauthn`, `totp`)
+  - `display_name`
+  - `status` (`pending`, `active`, `revoked`)
+  - `secret_ciphertext` for TOTP only
+  - `webauthn_credential_id`
+  - `webauthn_public_key`
+  - `webauthn_sign_count`
+  - `webauthn_transports`
+  - `backup_eligible`
+  - `last_used_at`
+  - `created_by_login_event_id`
+
+- `mfa_recovery_codes`
+  - `id`
+  - `profile_id`
+  - `code_hash`
+  - `used_at`
+
+- `mfa_challenges`
+  - `id`
+  - `profile_id`
+  - `login_event_id`
+  - `client_id`
+  - `purpose` (`login`, `settings_step_up`, `factor_enrollment`)
+  - `allowed_methods`
+  - `expires_at`
+  - `consumed_at`
+  - `attempt_count`
+
+- `trusted_devices`
+  - `id`
+  - `profile_id`
+  - `client_id`
+  - `device_id`
+  - `mfa_factor_id`
+  - `trusted_until`
+  - `last_used_at`
+  - unique `(profile_id, client_id, device_id)`
+
+Existing `login_events.properties` records:
+
+- `native_provider`
+- `native_issuer`
+- `native_subject_hash`
+- `mfa_required`
+- `mfa_verified`
+- `mfa_method`
+- `mfa_factor_id`
+- `trusted_device_used`
+
+## Performance and Capacity Model
+
+The headless Hydra authorization-code flow is not CPU-heavy, but it is more
+round-trip and database intensive than a direct token grant. It must only run
+when a new Antinvestor session is created from a Google, Apple, or first-party
+FedCM identity proof. It must not run for normal API calls, access-token
+refresh, or app-start checks when a valid Antinvestor session already exists.
+
+Expected backend work per successful native exchange:
+
+1. Verify the provider ID token.
+2. Resolve or link the external identity and profile.
+3. Resolve device, tenancy access, and roles.
+4. Create or update a `LoginEvent`.
+5. Start Hydra `/oauth2/auth`.
+6. Accept Hydra login through the admin API.
+7. Accept Hydra consent through the admin API.
+8. Exchange the authorization code at Hydra `/oauth2/token`.
+
+Operational targets:
+
+- Cached JWKS verification should be local CPU plus cache lookup; remote JWKS
+  fetches happen only on cache miss or key rotation.
+- Internal Hydra calls should use pooled HTTP clients, short timeouts, and the
+  internal Hydra public URL.
+- Target P50 server-side exchange latency: under 300 ms after the provider ID
+  token is already available.
+- Target P95 server-side exchange latency: under 1.5 s in staging under normal
+  load.
+- A failed Hydra leg should return a clear OAuth error and fall back to browser
+  OAuth on mobile unless policy requires blocking, such as `mfa_required`.
+- Refresh-token calls stay on the normal Hydra refresh path and should not
+  re-run provider verification or headless login.
+
+Concurrency controls:
+
+- Use the existing cache-backed FedCM lock pattern for first-party FedCM:
+  `fedcm:lock:<profile_id>:<client_id>`.
+- Add an equivalent short-lived native-exchange lock:
+  `native:exchange:<provider>:<provider_subject_hash>:<client_id>`.
+- Lock TTL should be short, around 5-10 seconds, and lock contention should
+  return a retryable error.
+- Replay cache must reject reused provider tokens independently of locks.
+- Rate limit per `client_id`, provider, and source IP before expensive JWKS,
+  profile, and Hydra work.
+
+Observability targets:
+
+- Trace one parent span around the facade request.
+- Add child spans for provider verification, profile linking, device/access
+  resolution, MFA policy, Hydra authorize, accept login, accept consent, and
+  Hydra token exchange.
+- Emit counters for success, policy block, provider-token failure, Hydra
+  failure, MFA-required, replay, and rate-limit outcomes.
+- Dashboards should break down latency by provider, platform, and client ID.
+
+## Implementation To-do Checklist
+
+### Backend Foundation
+
+- [ ] Add auth-service `POST /oauth2/token` facade route.
+- [ ] Add discovery/gateway routing so public discovery advertises the facade
+      as `token_endpoint`.
+- [x] Configure a separate internal Hydra public URL for facade upstream calls.
+- [x] Proxy `authorization_code`, `refresh_token`, and `client_credentials`
+      grants to Hydra without changing the request body or authentication
+      semantics.
+- [ ] Add integration tests that prove normal OAuth grants still work through
+      the facade.
+
+### Native Provider Exchange
+
+- [x] Add `nativecredentials` package with issuer registry, JWKS cache, ID
+      token verifier, replay cache, profile linker, and exchange coordinator.
+- [x] Add `external_identities` model, repository, and migration.
+- [x] Add per-client properties for `native_auth_enabled`,
+      `native_google_server_client_id`, and `native_apple_client_id`.
+- [x] Verify Google `iss`, `aud`, `exp`, `iat`, signature, and replay state.
+- [x] Verify Apple `iss`, `aud`, `exp`, `iat`, signature, and replay state.
+- [x] Resolve or create profile only from verified provider identity.
+- [x] Link external identity using provider-scoped subject keys.
+- [x] Create or reuse a durable `LoginEvent` before Hydra issuance.
+- [x] Resolve access and roles with the same helpers used by browser consent.
+- [x] Call `BuildUserTokenClaims` for every native-issued token.
+- [x] Drive Hydra through the existing headless authorization-code driver.
+- [x] Return Hydra's token response unchanged.
+
+### Hydra Client Provisioning
+
+- [x] Ensure every user-facing authorization-code client includes the internal
+      callback URI `<FEDCM_PUBLIC_ORIGIN>/_internal/fedcm-callback`.
+- [ ] Ensure mobile clients have `authorization_code`, `refresh_token`, `code`,
+      and `offline_access`.
+- [ ] Add startup or sync-time validation for missing callback URI, missing
+      refresh grant, missing scope, and missing native provider audience.
+- [ ] Do not require Hydra client `grant_types` to include RFC 8693 in facade
+      mode.
+
+### Flutter Runtime and Mobile UX
+
+- [x] Extend native ID-token exchange form with `installation_id`, `platform`,
+      and `device_name`.
+- [ ] Add a high-level `NativeCredentialConfig` helper for Google/Apple setup.
+- [ ] Attempt stored Antinvestor session first.
+- [ ] Attempt silent Google only when no valid Antinvestor session exists.
+- [ ] Attempt interactive Google or Apple only after user sign-in intent.
+- [ ] Treat cancel/unavailable/no-session as normal fallback, not visible
+      errors.
+- [ ] Add typed handling for `mfa_required`.
+- [ ] Keep browser OAuth fallback available for all native provider failures
+      except explicit policy blocks.
+
+### Web One Tap and FedCM
+
+- [ ] Keep `/s/login` as the Flutter web credential broker.
+- [ ] Keep Google FedCM completion on the hosted login page.
+- [ ] Add Apple web button when Apple provider config is present.
+- [x] Harden `/fedcm/token-exchange` with origin/client/verifier binding.
+- [ ] Rework first-party FedCM token extras to use `BuildUserTokenClaims`.
+- [ ] Ensure first-party FedCM creates or reuses a durable `LoginEvent`.
+
+### MFA
+
+- [ ] Add MFA factor, challenge, recovery-code, and trusted-device models.
+- [ ] Add repositories and migrations.
+- [ ] Add RPCs for MFA status, enrollment, removal, recovery codes, and trusted
+      device management.
+- [ ] Add browser MFA challenge endpoints before Hydra login acceptance.
+- [ ] Add native MFA challenge creation before headless Hydra issuance.
+- [ ] Add runtime `completeMfaChallenge`.
+- [ ] Set Hydra `acr` and `amr` only after MFA has actually completed.
+- [ ] Add trusted-device policy with expiry, revocation, and audit events.
+
+### Verification and Rollout
+
+- [ ] Add unit tests for provider verification, replay, identity linking, MFA
+      policy, and trusted-device expiry.
+- [ ] Add Hydra integration tests for facade proxying, native exchange, MFA
+      challenge/resume, refresh preservation, and normal login regressions.
+- [ ] Add Flutter tests for native provider waterfall and MFA-required state.
+- [ ] Add staging smoke tests on Android, iOS, Chrome desktop/mobile, and
+      Safari fallback.
+- [ ] Roll out behind `native_auth_enabled=false` by default.
+- [ ] Enable one staging client, then one production client at a time.
+- [ ] Turn on required MFA only after recovery and support flows are proven.
+
+## Implementation Phases
+
+### Phase 1: Native Credential Token Exchange Backend
+
+Add:
+
+- `apps/default/service/handlers/oauth_token_facade.go`
+- `apps/default/service/nativecredentials/`
+  - `exchange.go`
+  - `issuer_registry.go`
+  - `id_token_verifier.go`
+  - `profile_linker.go`
+  - `device_context.go`
+- `apps/default/service/models/external_identity.go`
+- `apps/default/service/repository/external_identity.go`
+- migration for `external_identities`
+- gateway/discovery change so public `/.well-known/openid-configuration`
+  advertises the auth-service facade as `token_endpoint`
+- config:
+  - `OAUTH2_HYDRA_PUBLIC_INTERNAL_URL` for facade-to-Hydra proxying
+  - `NATIVE_CREDENTIAL_EXCHANGE_ENABLED`
+  - per-client `native_auth_enabled` policy property
+
+Do not add the RFC 8693 grant to Hydra client `grant_types` as a hard
+requirement in facade mode. The auth service authorizes the native grant before
+Hydra sees it; Hydra receives only the headless `authorization_code` exchange.
+
+Request accepted by the facade:
+
+```http
+POST /oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+client_id=<antinvestor-client-id>
+subject_token=<google-or-apple-id-token>
+subject_token_type=urn:ietf:params:oauth:token-type:id_token
+subject_issuer=https://accounts.google.com
+audience=<optional downstream audience>
+installation_id=<runtime installation id>
+platform=android|ios|web
+device_name=<optional human label>
+```
+
+Validation:
+
+- `client_id` resolves to an active tenancy client.
+- Native auth is enabled for that client.
+- `subject_issuer` is allow-listed for that client.
+- ID token signature validates against issuer JWKS.
+- `iss`, `aud`, `exp`, and `iat` are valid.
+- Token freshness window is 5 minutes plus skew.
+- Google accepts `https://accounts.google.com` and `accounts.google.com`.
+- Apple accepts `https://appleid.apple.com`.
+- Nonce was already checked in the runtime, but the server also rejects
+  missing nonce when the provider should return one.
+- Replay cache rejects duplicate `(issuer, subject, iat, jwt-id-or-hash)`.
+- Per-client/per-IP rate limit is enforced.
+
+Exchange:
+
+1. Resolve provider identity by `(provider, sub)`.
+2. If found, use linked `profile_id`.
+3. If not found and verified email/contact exists, resolve or create profile.
+4. Link `(provider, sub)` to the profile.
+5. Enroll or update the mobile device using `installation_id` and user agent.
+6. Create a `LoginEvent` with source `google` or `apple`.
+7. Resolve tenancy access and roles using existing helpers.
+8. Run MFA gate.
+9. If MFA is satisfied, run the existing headless Hydra driver with
+   `BuildUserTokenClaims`.
+10. Return Hydra's token response unchanged.
+
+Hydra client prerequisites:
+
+- `authorization_code` and `refresh_token` grant types.
+- `code` response type.
+- `openid profile email offline_access` scopes, with additional application
+  scopes as needed.
+- Internal callback URI:
+  `<FEDCM_PUBLIC_ORIGIN>/_internal/fedcm-callback`.
+- Client secret retrievable by the auth service for confidential clients.
+
+Acceptance criteria:
+
+- Android Google native sign-in returns Antinvestor access/refresh/ID tokens.
+- iOS Sign in with Apple returns Antinvestor access/refresh/ID tokens.
+- Returned access token contains normal `tenant_id`, `partition_id`,
+  `access_id`, `profile_id`, `device_id`, `session_id`, and `roles`.
+- Refresh works through existing refresh grant.
+- Logout/revocation works through existing runtime code.
+- A forged, stale, wrong-audience, or replayed provider token is rejected.
+
+### Phase 2: Flutter Runtime Mobile UX
+
+Keep `createAuthRuntime` as the single app integration point, but make native
+credential setup harder to misconfigure.
+
+Changes:
+
+- Add `NativeCredentialConfig`:
+  - `googleServerClientId`
+  - `enableApple`
+  - `providerOrder`
+  - `preferSilent`
+- Add a helper:
+
+```dart
+final runtime = createAuthRuntime(
+  cfg,
+  nativeCredentialConfig: NativeCredentialConfig(
+    googleServerClientId: googleServerClientId,
+    enableApple: Platform.isIOS || Platform.isMacOS,
+  ),
+);
+```
+
+- Keep the existing lower-level `nativeProviders` override for tests and
+  custom apps.
+- Extend `TokenExchange.exchangeIdToken` to include:
+  - `installation_id`
+  - `platform`
+  - `device_name`
+- On Android:
+  - silent Google attempt on app start.
+  - interactive Google sheet on user sign-in tap.
+- On iOS:
+  - show Sign in with Apple as the first native option.
+  - optionally show Google as second option if configured.
+- On all mobile:
+  - if provider returns `NoSession`, `Cancelled`, or `Unavailable`, fall back
+    without showing technical errors.
+  - if provider exchange fails server-side, continue to browser OAuth fallback
+    unless the error is a policy block such as MFA required.
+
+Acceptance criteria:
+
+- App launch with a valid stored session shows authenticated state without UI.
+- App launch with Google silent credential signs in without browser.
+- User tap opens native sheet and returns authenticated state.
+- User cancel falls back to the normal sign-in screen without losing state.
+- Native exchange failure is observable in `credentialEventStream`.
+
+### Phase 3: Web One Tap and Flutter Web UX
+
+Use the hosted auth service login page as the web credential broker. This keeps
+Flutter web simple and avoids putting provider-specific JavaScript inside every
+consumer app.
+
+Changes:
+
+- Keep `/s/login` rendering:
+  - `FedCMNonce`
+  - `GoogleClientID`
+  - existing `fedcm_google.js`
+- Add Sign in with Apple on the login page when
+  `AUTH_PROVIDER_APPLE_CLIENT_ID` is set.
+- Order login options visually:
+  1. Existing remembered/FedCM session auto path.
+  2. Google prompt/button.
+  3. Apple button.
+  4. Email/phone field.
+- Do not block first paint waiting on FedCM/Google. Render the contact field
+  immediately and let One Tap overlay when available.
+- For Flutter web, keep `flutter_web_auth_2` redirect to `/s/login`; the login
+  page handles One Tap and returns the normal authorization code.
+
+Acceptance criteria:
+
+- Chrome/FedCM users can sign in via Google prompt without typing contact.
+- Non-FedCM browsers still show the hosted login page and contact fallback.
+- Apple web button completes via existing provider callback.
+- If One Tap is dismissed, the contact input remains usable immediately.
+
+### Phase 4: Account-Managed MFA Backend
+
+Add:
+
+- `apps/default/service/models/mfa_factor.go`
+- `apps/default/service/models/mfa_challenge.go`
+- `apps/default/service/models/mfa_recovery_code.go`
+- `apps/default/service/models/trusted_device.go`
+- repositories for each model
+- migrations for each table
+- `apps/default/service/mfa/`
+  - `policy.go`
+  - `webauthn.go`
+  - `totp.go`
+  - `challenge.go`
+  - `trusted_device.go`
+  - `recovery.go`
+
+Add AuthenticationService RPCs:
+
+- `GetMFAStatus`
+- `BeginWebAuthnEnrollment`
+- `CompleteWebAuthnEnrollment`
+- `BeginTOTPEnrollment`
+- `CompleteTOTPEnrollment`
+- `ListMFAFactors`
+- `RemoveMFAFactor`
+- `RegenerateRecoveryCodes`
+- `ListTrustedDevices`
+- `RevokeTrustedDevice`
+
+Add login-step endpoints for browser flows:
+
+- `GET /s/mfa/{challengeId}`
+- `POST /s/mfa/{challengeId}/totp`
+- `POST /s/mfa/{challengeId}/recovery`
+- `POST /s/mfa/{challengeId}/webauthn/options`
+- `POST /s/mfa/{challengeId}/webauthn/verify`
+
+Add native token-exchange MFA response:
+
+```json
+{
+  "error": "mfa_required",
+  "mfa_challenge_id": "...",
+  "available_methods": ["webauthn", "totp", "recovery"]
+}
+```
+
+Then add a runtime method:
+
+```dart
+Future<void> completeMfaChallenge({
+  required String challengeId,
+  required MfaAssertion assertion,
+});
+```
+
+MFA policy:
+
+- Optional by default.
+- Required when user enabled at least one active factor.
+- Required for policy-marked clients/roles.
+- Bypass if:
+  - trusted device is valid,
+  - device risk is low,
+  - login method has recent high assurance,
+  - no sensitive step-up is requested.
+
+Claims added after MFA:
+
+- `acr`: `urn:antinvestor:acr:mfa` or stronger
+- `amr`: include identity method plus `otp` or `webauthn`
+- token extras:
+  - `mfa_verified: true`
+  - `mfa_method`
+  - `mfa_verified_at`
+
+Acceptance criteria:
+
+- A user can enroll a passkey and TOTP from account settings.
+- A user receives recovery codes only after successful enrollment.
+- Removing the last factor requires explicit confirmation and step-up.
+- Login prompts for MFA when required and no trusted device exists.
+- Successful MFA creates a trusted device if the user chooses that option.
+- Trusted-device expiry triggers MFA again.
+
+### Phase 5: Account Security UI
+
+Update `ui/auth` to include an account security route:
+
+- `SecurityOverviewScreen`
+- `MFAStatusCard`
+- `PasskeyFactorList`
+- `TOTPEnrollmentSheet`
+- `RecoveryCodesSheet`
+- `TrustedDevicesList`
+
+UX rules:
+
+- Default recommendation is passkey because it is the fastest and most
+  phishing-resistant.
+- TOTP is offered as "Authenticator app" fallback.
+- Recovery codes are shown once, with a clear "saved" confirmation.
+- Never show raw TOTP secret again after enrollment.
+- Avoid forcing MFA setup during first sign-in unless a client policy requires
+  it. Instead, show a dismissible account-security prompt post-login.
+
+Acceptance criteria:
+
+- Users can understand current security state at a glance.
+- Enrollment takes no more than:
+  - passkey: one platform prompt after tapping "Add passkey"
+  - TOTP: scan QR, enter one code, save recovery codes
+- Login challenge screens are short and do not expose provider/security
+  internals.
+
+### Phase 6: Observability and Audit
+
+Metrics:
+
+- `auth.native_exchange.started`
+- `auth.native_exchange.completed`
+- `auth.native_exchange.failed`
+- `auth.native_exchange.duration`
+- `auth.mfa.challenge.created`
+- `auth.mfa.challenge.completed`
+- `auth.mfa.challenge.failed`
+- `auth.mfa.factor.enrolled`
+- `auth.mfa.factor.removed`
+- `auth.mfa.trusted_device.used`
+
+Required labels:
+
+- `client_id`
+- `provider`
+- `platform`
+- `reason`
+- `mfa_method`
+- `grant_type`
+
+Audit/login event properties:
+
+- provider used
+- MFA challenge result
+- trusted device decision
+- failure reason category, never raw tokens or secrets
+
+### Phase 7: Testing
+
+Go unit tests:
+
+- provider issuer registry
+- Google token verifier with test JWKS
+- Apple token verifier with test JWKS
+- replay cache
+- external identity linker
+- MFA policy decisions
+- TOTP verify window
+- recovery code one-time use
+- trusted device expiry
+
+Go integration tests:
+
+- discovery advertises the facade token endpoint
+- facade proxies `authorization_code`, `refresh_token`, and
+  `client_credentials` grants to Hydra
+- facade uses the internal Hydra URL and cannot recursively call itself
+- native Google exchange happy path
+- native Apple exchange happy path
+- wrong `aud`
+- wrong `iss`
+- stale token
+- replayed token
+- MFA required returns `mfa_required`
+- MFA complete then exchange returns Hydra tokens
+- token refresh preserves claims
+- every mobile/FedCM token uses `BuildUserTokenClaims` claim shape
+- client sync enforces the internal FedCM callback redirect URI
+- `/fedcm/token-exchange` rejects wrong-origin, wrong-client, expired, and
+  verifier-mismatched requests
+- web Google FedCM regression
+- contact-code regression
+- service account regression
+
+Flutter tests:
+
+- native provider waterfall ordering
+- silent Google success
+- Apple interactive success
+- cancel/fallback behavior
+- native exchange form includes installation/platform metadata
+- MFA-required response transitions into challenge state
+- recovery from failed MFA
+
+Manual staging tests:
+
+- Android physical device with Google account.
+- iOS physical device with Apple Account and Face ID/Touch ID.
+- Chrome desktop with FedCM.
+- Mobile Chrome with Google One Tap.
+- Safari fallback with Apple button/contact-code path.
+
+## Rollout
+
+1. Deploy backend facade and native exchange behind client-property flag
+   `native_auth_enabled=false`.
+2. Enable for one staging mobile client.
+3. Validate Android Google and iOS Apple physical-device flows.
+4. Enable web login-page ordering changes in staging.
+5. Enable optional MFA enrollment in staging.
+6. Enable one production client at a time.
+7. Turn on MFA-required policy only after recovery-code and support workflows
+   are validated.
+
+## Production Risks
+
+1. Provider token audience misconfiguration.
+   - Mitigation: per-client issuer registry, startup config validation, staging
+     smoke test per client.
+
+2. MFA lockout.
+   - Mitigation: recovery codes, trusted-device display, support recovery path,
+     and no forced setup until recovery path is live.
+
+3. Token endpoint facade breaks normal OAuth grants.
+   - Mitigation: facade proxies non-native grants byte-for-byte, integration
+     tests cover auth code, refresh, and client credentials, and rollout starts
+     on staging gateway only.
+
+## Definition of Done
+
+- Native Google and Apple login produce Hydra access/refresh/ID tokens through
+  the Flutter runtime.
+- Flutter web login reaches One Tap/FedCM before contact-code login.
+- All issued tokens use the same claim shape as existing consent-issued tokens.
+- Users can enroll, use, and recover from account-level MFA.
+- Trusted-device behavior keeps daily login seamless without bypassing MFA
+  policy.
+- Observability distinguishes native provider failures, Hydra failures, and MFA
+  failures.
+
+## References
+
+- Google Identity Services: One Tap returns a Google-signed JWT credential that
+  must be verified server-side.
+  https://developers.google.com/identity/gsi/web/guides/display-google-one-tap
+- Google Android backend auth: mobile apps should send the ID token to the
+  backend, which verifies signature, issuer, audience, and expiry before
+  creating a session.
+  https://developers.google.com/identity/sign-in/android/backend-auth
+- Android Credential Manager Sign in with Google:
+  https://developer.android.com/identity/sign-in/credential-manager-siwg-implementation
+- Apple Sign in with Apple: native apps receive identity tokens and user info
+  that the app server verifies.
+  https://developer.apple.com/documentation/signinwithapple/authenticating-users-with-sign-in-with-apple
+- Apple identity token guidance:
+  https://developer.apple.com/documentation/signinwithapple/receiving-a-users-identity-token
+- RFC 8693 OAuth 2.0 Token Exchange:
+  https://www.rfc-editor.org/rfc/rfc8693
+- Ory Hydra production guide: public port serves discovery, auth, token,
+  revocation, logout, and userinfo; admin port must remain private.
+  https://www.ory.com/docs/hydra/self-hosted/production
+- Ory Hydra custom login and consent flow:
+  https://www.ory.com/docs/hydra/guides/custom-ui-oauth2
+- OWASP Multifactor Authentication Cheat Sheet:
+  https://cheatsheetseries.owasp.org/cheatsheets/Multifactor_Authentication_Cheat_Sheet.html
+- NIST SP 800-63B authentication guidance:
+  https://pages.nist.gov/800-63-4/sp800-63b.html

--- a/ui/runtime/lib/src/protocol/token_exchange.dart
+++ b/ui/runtime/lib/src/protocol/token_exchange.dart
@@ -40,10 +40,8 @@ final class RefreshNetworkError extends RefreshOutcome {
 /// from `package:http/testing.dart` handles both discovery and token
 /// roundtrips. [timeout] is applied to every underlying request.
 class TokenExchange {
-  TokenExchange({
-    http.Client? client,
-    required this.timeout,
-  }) : _client = client ?? http.Client();
+  TokenExchange({http.Client? client, required this.timeout})
+    : _client = client ?? http.Client();
 
   final http.Client _client;
   final Duration timeout;
@@ -86,6 +84,8 @@ class TokenExchange {
     DpopContext ctx, {
     required String subjectToken,
     required String subjectIssuer,
+    String? platform,
+    String? deviceName,
   }) async {
     final form = <String, String>{
       'grant_type': 'urn:ietf:params:oauth:grant-type:token-exchange',
@@ -94,6 +94,11 @@ class TokenExchange {
       'subject_token_type': 'urn:ietf:params:oauth:token-type:id_token',
       'subject_issuer': subjectIssuer,
       if (cfg.audiences.isNotEmpty) 'audience': cfg.audiences.join(','),
+      if (cfg.installationId != null && cfg.installationId!.isNotEmpty)
+        'installation_id': cfg.installationId!,
+      if (platform != null && platform.isNotEmpty) 'platform': platform,
+      if (deviceName != null && deviceName.isNotEmpty)
+        'device_name': deviceName,
     };
     final res = await _postForm(cfg, ctx, form);
     if (res.statusCode < 200 || res.statusCode >= 300) {
@@ -124,18 +129,18 @@ class TokenExchange {
       if (res.statusCode == 400 && _mentionsReuse(res.body)) {
         return const RefreshOutcome.reuseDetected();
       }
-      return RefreshOutcome.networkError(AuthError(
-        AuthErrorCode.tokenRefreshFailed,
-        'refresh failed ${res.statusCode} ${_truncate(res.body)}',
-      ));
+      return RefreshOutcome.networkError(
+        AuthError(
+          AuthErrorCode.tokenRefreshFailed,
+          'refresh failed ${res.statusCode} ${_truncate(res.body)}',
+        ),
+      );
     } on AuthError catch (e) {
       return RefreshOutcome.networkError(e);
     } catch (e) {
-      return RefreshOutcome.networkError(AuthError(
-        AuthErrorCode.tokenRefreshFailed,
-        'refresh failed',
-        cause: e,
-      ));
+      return RefreshOutcome.networkError(
+        AuthError(AuthErrorCode.tokenRefreshFailed, 'refresh failed', cause: e),
+      );
     }
   }
 
@@ -157,16 +162,14 @@ class TokenExchange {
 
     final body = _encodeForm(form);
     Map<String, String> headers() => {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Accept': 'application/json',
-        };
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Accept': 'application/json',
+    };
 
     Future<http.Response> send({String? dpopProof}) async {
       final h = headers();
       if (dpopProof != null) h['DPoP'] = dpopProof;
-      return _client
-          .post(tokenUri, headers: h, body: body)
-          .timeout(timeout);
+      return _client.post(tokenUri, headers: h, body: body).timeout(timeout);
     }
 
     http.Response res;
@@ -176,7 +179,8 @@ class TokenExchange {
           : null;
       res = await send(dpopProof: initialProof);
 
-      if (useDpop && res.statusCode == 401 &&
+      if (useDpop &&
+          res.statusCode == 401 &&
           _headerIgnoreCase(res.headers, 'dpop-nonce') != null) {
         rememberNonce(ctx, discovery.tokenEndpoint, res.headers);
         final retryProof = await buildProof(
@@ -187,7 +191,8 @@ class TokenExchange {
         res = await send(dpopProof: retryProof);
       }
 
-      if (useDpop && res.statusCode == 400 &&
+      if (useDpop &&
+          res.statusCode == 400 &&
           _mentionsInvalidDpopProof(res.body)) {
         rememberClockOffset(ctx, res.headers);
         final retryProof = await buildProof(
@@ -244,10 +249,11 @@ TokenSet _parseTokenBody(String body) {
       'missing access_token or refresh_token',
     );
   }
-  final expiresIn =
-      data['expires_in'] is int ? data['expires_in'] as int : 300;
+  final expiresIn = data['expires_in'] is int ? data['expires_in'] as int : 300;
   final tokenType = TokenType.fromString(data['token_type'] as String?);
-  final idToken = data['id_token'] is String ? data['id_token'] as String : null;
+  final idToken = data['id_token'] is String
+      ? data['id_token'] as String
+      : null;
   return TokenSet(
     accessToken: accessToken,
     refreshToken: refreshToken,
@@ -266,8 +272,10 @@ bool _mentionsInvalidDpopProof(String body) {
 }
 
 String _encodeForm(Map<String, String> form) => form.entries
-    .map((e) =>
-        '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}')
+    .map(
+      (e) =>
+          '${Uri.encodeQueryComponent(e.key)}=${Uri.encodeQueryComponent(e.value)}',
+    )
     .join('&');
 
 String _truncate(String s) => s.length > 200 ? s.substring(0, 200) : s;

--- a/ui/runtime/test/auth_runtime_native_test.dart
+++ b/ui/runtime/test/auth_runtime_native_test.dart
@@ -26,14 +26,13 @@ class _FakeDiscoveryClient implements DiscoveryClient {
   Future<OidcDiscovery> getDiscovery(
     String idpBaseUrl,
     Duration timeout,
-  ) async =>
-      OidcDiscovery(
-        issuer: idpBaseUrl,
-        authorizationEndpoint: '$idpBaseUrl/oauth2/auth',
-        tokenEndpoint: '$idpBaseUrl/oauth2/token',
-        endSessionEndpoint: '$idpBaseUrl/oauth2/sessions/logout',
-        revocationEndpoint: '$idpBaseUrl/oauth2/revoke',
-      );
+  ) async => OidcDiscovery(
+    issuer: idpBaseUrl,
+    authorizationEndpoint: '$idpBaseUrl/oauth2/auth',
+    tokenEndpoint: '$idpBaseUrl/oauth2/token',
+    endSessionEndpoint: '$idpBaseUrl/oauth2/sessions/logout',
+    revocationEndpoint: '$idpBaseUrl/oauth2/revoke',
+  );
 }
 
 class _FakeTokenExchange extends TokenExchange {
@@ -65,14 +64,13 @@ class _FakeTokenExchange extends TokenExchange {
     DpopContext ctx, {
     required String subjectToken,
     required String subjectIssuer,
+    String? platform,
+    String? deviceName,
   }) async {
     idTokenCalls++;
     if (idTokenError != null) throw idTokenError!;
     if (idTokenQueue.isEmpty) {
-      throw AuthError(
-        AuthErrorCode.tokenExchangeFailed,
-        'no id-token queued',
-      );
+      throw AuthError(AuthErrorCode.tokenExchangeFailed, 'no id-token queued');
     }
     return idTokenQueue.removeAt(0);
   }
@@ -97,9 +95,12 @@ class _StubProvider implements NativeCredentialProvider {
   _StubProvider({
     required this.kind,
     required this.availability,
-    List<NativeCredentialOutcome> interactiveOutcomes = const <NativeCredentialOutcome>[],
+    List<NativeCredentialOutcome> interactiveOutcomes =
+        const <NativeCredentialOutcome>[],
     this.throwOnAvailable = false,
-  }) : interactiveOutcomes = List<NativeCredentialOutcome>.of(interactiveOutcomes);
+  }) : interactiveOutcomes = List<NativeCredentialOutcome>.of(
+         interactiveOutcomes,
+       );
 
   @override
   final NativeCredentialProviderKind kind;
@@ -120,9 +121,7 @@ class _StubProvider implements NativeCredentialProvider {
   }
 
   @override
-  Future<NativeCredentialOutcome> attemptSilent({
-    required String nonce,
-  }) async {
+  Future<NativeCredentialOutcome> attemptSilent({required String nonce}) async {
     silentCalls++;
     return const NativeCredentialOutcome.noSession();
   }
@@ -148,20 +147,19 @@ TokenSet _tokenSet({
   String access = 'access-tok',
   String refresh = 'refresh-tok',
   String? idToken,
-}) =>
-    TokenSet(
-      accessToken: access,
-      refreshToken: refresh,
-      expiresAt: DateTime.now().add(const Duration(minutes: 5)),
-      tokenType: TokenType.bearer,
-      idToken: idToken,
-    );
+}) => TokenSet(
+  accessToken: access,
+  refreshToken: refresh,
+  expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+  tokenType: TokenType.bearer,
+  idToken: idToken,
+);
 
 String _makeJwt(Map<String, dynamic> payload) {
   String strip(String s) => s.replaceAll('=', '');
-  final header = strip(base64Url.encode(utf8.encode(
-    json.encode(<String, String>{'alg': 'none'}),
-  )));
+  final header = strip(
+    base64Url.encode(utf8.encode(json.encode(<String, String>{'alg': 'none'}))),
+  );
   final body = strip(base64Url.encode(utf8.encode(json.encode(payload))));
   final sig = strip(base64Url.encode(const <int>[1, 2, 3]));
   return '$header.$body.$sig';
@@ -181,15 +179,15 @@ class _Harness {
   final _FakeOAuthFlow oauth;
 }
 
-_Harness _build({
-  required List<NativeCredentialProvider> providers,
-}) {
-  final cfg = resolveConfig(const AuthConfig(
-    clientId: 'c',
-    idpBaseUrl: 'https://idp.example.com',
-    apiBaseUrl: 'https://api.example.com',
-    redirectScheme: 'com.example.app',
-  ));
+_Harness _build({required List<NativeCredentialProvider> providers}) {
+  final cfg = resolveConfig(
+    const AuthConfig(
+      clientId: 'c',
+      idpBaseUrl: 'https://idp.example.com',
+      apiBaseUrl: 'https://api.example.com',
+      redirectScheme: 'com.example.app',
+    ),
+  );
   final exchange = _FakeTokenExchange();
   final worker = TokenWorker(
     config: cfg,
@@ -220,85 +218,83 @@ void main() {
   tearDown(clearDiscoveryCache);
 
   group('AuthRuntimeImpl native credential waterfall', () {
-    test('availableNativeProviders reports only available providers',
-        () async {
-      final h = _build(providers: [
-        _StubProvider(
-          kind: NativeCredentialProviderKind.apple,
-          availability: false,
-        ),
-        _StubProvider(
-          kind: NativeCredentialProviderKind.google,
-          availability: true,
-        ),
-      ]);
+    test('availableNativeProviders reports only available providers', () async {
+      final h = _build(
+        providers: [
+          _StubProvider(
+            kind: NativeCredentialProviderKind.apple,
+            availability: false,
+          ),
+          _StubProvider(
+            kind: NativeCredentialProviderKind.google,
+            availability: true,
+          ),
+        ],
+      );
       await h.runtime.init();
       final avail = await h.runtime.availableNativeProviders();
       expect(avail, {NativeCredentialProviderKind.google});
       await h.runtime.dispose();
     });
 
-    test('proactive silent attempt: ok → authenticated; no OAuth fallback',
-        () async {
-      final provider = _NonceEchoingProvider(
-        kind: NativeCredentialProviderKind.google,
-      );
-      final h = _build(providers: [provider]);
-      h.exchange.idTokenQueue.add(_tokenSet(access: 'native-at'));
+    test(
+      'proactive silent attempt: ok → authenticated; no OAuth fallback',
+      () async {
+        final provider = _NonceEchoingProvider(
+          kind: NativeCredentialProviderKind.google,
+        );
+        final h = _build(providers: [provider]);
+        h.exchange.idTokenQueue.add(_tokenSet(access: 'native-at'));
 
-      final credEvents = <CredentialEvent>[];
-      final credSub = h.runtime.credentialEventStream.listen(credEvents.add);
+        final credEvents = <CredentialEvent>[];
+        final credSub = h.runtime.credentialEventStream.listen(credEvents.add);
 
-      await h.runtime.init();
-      // Let init flush + proactive silent microtask + worker completion settle.
-      for (var i = 0; i < 20; i++) {
-        await Future<void>.delayed(Duration.zero);
-      }
+        await h.runtime.init();
+        // Let init flush + proactive silent microtask + worker completion settle.
+        for (var i = 0; i < 20; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
 
-      expect(h.worker.state, AuthState.authenticated);
-      expect(provider.silentCalls, 1);
-      expect(h.exchange.idTokenCalls, 1);
-      expect(h.oauth.calls, 0);
-      expect(
-        credEvents.whereType<CredentialSilentAttemptEvent>().length,
-        1,
-      );
-      expect(
-        credEvents.whereType<CredentialOutcomeEvent>().length,
-        1,
-      );
-      await credSub.cancel();
-      await h.runtime.dispose();
-    });
+        expect(h.worker.state, AuthState.authenticated);
+        expect(provider.silentCalls, 1);
+        expect(h.exchange.idTokenCalls, 1);
+        expect(h.oauth.calls, 0);
+        expect(credEvents.whereType<CredentialSilentAttemptEvent>().length, 1);
+        expect(credEvents.whereType<CredentialOutcomeEvent>().length, 1);
+        await credSub.cancel();
+        await h.runtime.dispose();
+      },
+    );
 
     test(
-        'silent-noSession + interactive-success → authenticated; no OAuth fallback',
-        () async {
-      final provider = _NonceEchoingProvider(
-        kind: NativeCredentialProviderKind.google,
-        silentOutcome: const NativeCredentialOutcome.noSession(),
-        // Interactive will yield ok-with-matching-nonce.
-      );
-      final h = _build(providers: [provider]);
-      // Queue two token-exchange responses: one for the (absent) silent,
-      // one for the interactive attempt.
-      h.exchange.idTokenQueue.add(_tokenSet(access: 'native-at'));
-      await h.runtime.init();
+      'silent-noSession + interactive-success → authenticated; no OAuth fallback',
+      () async {
+        final provider = _NonceEchoingProvider(
+          kind: NativeCredentialProviderKind.google,
+          silentOutcome: const NativeCredentialOutcome.noSession(),
+          // Interactive will yield ok-with-matching-nonce.
+        );
+        final h = _build(providers: [provider]);
+        // Queue two token-exchange responses: one for the (absent) silent,
+        // one for the interactive attempt.
+        h.exchange.idTokenQueue.add(_tokenSet(access: 'native-at'));
+        await h.runtime.init();
 
-      for (var i = 0; i < 5; i++) {
-        await Future<void>.delayed(Duration.zero);
-      }
-      // Silent consumed: no worker exchange happened.
-      expect(h.worker.state, AuthState.unauthenticated);
-      expect(h.exchange.idTokenCalls, 0);
+        for (var i = 0; i < 5; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
+        // Silent consumed: no worker exchange happened.
+        expect(h.worker.state, AuthState.unauthenticated);
+        expect(h.exchange.idTokenCalls, 0);
 
-      await h.runtime.ensureAuthenticated();
-      expect(h.worker.state, AuthState.authenticated);
-      expect(provider.interactiveCalls, 1);
-      expect(h.oauth.calls, 0);
-      expect(h.exchange.idTokenCalls, 1);
-      await h.runtime.dispose();
-    });
+        await h.runtime.ensureAuthenticated();
+        expect(h.worker.state, AuthState.authenticated);
+        expect(provider.interactiveCalls, 1);
+        expect(h.oauth.calls, 0);
+        expect(h.exchange.idTokenCalls, 1);
+        await h.runtime.dispose();
+      },
+    );
 
     test('all providers decline → OAuth2 fallback', () async {
       final provider = _StubProvider(
@@ -325,33 +321,33 @@ void main() {
     });
 
     test(
-        'worker exchange failure after interactive-ok → falls through to OAuth2',
-        () async {
-      final provider = _NonceEchoingProvider(
-        kind: NativeCredentialProviderKind.google,
-        silentOutcome: const NativeCredentialOutcome.noSession(),
-      );
-      final h = _build(providers: [provider]);
-      // id-token exchange raises; OAuth2 leg succeeds.
-      h.exchange.idTokenError = AuthError(
-        AuthErrorCode.tokenExchangeFailed,
-        'boom',
-      );
-      h.exchange.codeQueue.add(_tokenSet(access: 'oauth-at'));
-      await h.runtime.init();
+      'worker exchange failure after interactive-ok → falls through to OAuth2',
+      () async {
+        final provider = _NonceEchoingProvider(
+          kind: NativeCredentialProviderKind.google,
+          silentOutcome: const NativeCredentialOutcome.noSession(),
+        );
+        final h = _build(providers: [provider]);
+        // id-token exchange raises; OAuth2 leg succeeds.
+        h.exchange.idTokenError = AuthError(
+          AuthErrorCode.tokenExchangeFailed,
+          'boom',
+        );
+        h.exchange.codeQueue.add(_tokenSet(access: 'oauth-at'));
+        await h.runtime.init();
 
-      for (var i = 0; i < 5; i++) {
-        await Future<void>.delayed(Duration.zero);
-      }
-      await h.runtime.ensureAuthenticated();
-      expect(h.worker.state, AuthState.authenticated);
-      expect(h.oauth.calls, 1);
-      expect(h.exchange.codeCalls, 1);
-      await h.runtime.dispose();
-    });
+        for (var i = 0; i < 5; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
+        await h.runtime.ensureAuthenticated();
+        expect(h.worker.state, AuthState.authenticated);
+        expect(h.oauth.calls, 1);
+        expect(h.exchange.codeCalls, 1);
+        await h.runtime.dispose();
+      },
+    );
 
-    test(
-        'silent id-token with bogus iss is rejected by the worker; '
+    test('silent id-token with bogus iss is rejected by the worker; '
         'proactive attempt leaves state unauthenticated', () async {
       final provider = _BadIssuerProvider();
       final h = _build(providers: [provider]);
@@ -384,16 +380,15 @@ void main() {
       expect(google.signOutCalls, 1);
       final signOuts = events.whereType<CredentialSignOutEvent>().toList();
       expect(signOuts.length, 2);
-      expect(
-        signOuts.map((e) => e.kind).toSet(),
-        {NativeCredentialProviderKind.apple, NativeCredentialProviderKind.google},
-      );
+      expect(signOuts.map((e) => e.kind).toSet(), {
+        NativeCredentialProviderKind.apple,
+        NativeCredentialProviderKind.google,
+      });
       await sub.cancel();
       await h.runtime.dispose();
     });
 
-    test(
-        'ensureAuthenticated called immediately after construction runs '
+    test('ensureAuthenticated called immediately after construction runs '
         'OAuth exactly once (no proactive-silent race)', () async {
       // Provider reports unavailable so the waterfall falls straight
       // through to OAuth. If the proactive-silent microtask were
@@ -422,8 +417,7 @@ void main() {
       await h.runtime.dispose();
     });
 
-    test(
-        'dispose() while proactive silent is mid-flight does not raise '
+    test('dispose() while proactive silent is mid-flight does not raise '
         'unhandled errors', () async {
       final provider = _BlockingSilentProvider();
       final h = _build(providers: [provider]);
@@ -438,40 +432,37 @@ void main() {
 
       // Capture any unhandled zone errors.
       final unhandled = <Object>[];
-      await runZonedGuarded<Future<void>>(
-        () async {
-          await h.runtime.dispose();
-          // Release the provider's pending Future so the microtask
-          // resumes post-dispose. It must exit cleanly.
-          provider.releaseSilent(
-            const NativeCredentialOutcome.noSession(),
-          );
-          for (var i = 0; i < 20; i++) {
-            await Future<void>.delayed(Duration.zero);
-          }
-        },
-        (err, _) => unhandled.add(err),
-      );
+      await runZonedGuarded<Future<void>>(() async {
+        await h.runtime.dispose();
+        // Release the provider's pending Future so the microtask
+        // resumes post-dispose. It must exit cleanly.
+        provider.releaseSilent(const NativeCredentialOutcome.noSession());
+        for (var i = 0; i < 20; i++) {
+          await Future<void>.delayed(Duration.zero);
+        }
+      }, (err, _) => unhandled.add(err));
 
       expect(unhandled, isEmpty, reason: 'dispose should be clean');
     });
 
-    test('provider throwing in isAvailable does not crash the waterfall',
-        () async {
-      final bad = _StubProvider(
-        kind: NativeCredentialProviderKind.apple,
-        availability: true,
-        throwOnAvailable: true,
-      );
-      final h = _build(providers: [bad]);
-      h.exchange.codeQueue.add(_tokenSet(access: 'oauth-at'));
-      await h.runtime.init();
-      // Runtime can still recover via OAuth2.
-      await h.runtime.ensureAuthenticated();
-      expect(h.worker.state, AuthState.authenticated);
-      expect(h.oauth.calls, 1);
-      await h.runtime.dispose();
-    });
+    test(
+      'provider throwing in isAvailable does not crash the waterfall',
+      () async {
+        final bad = _StubProvider(
+          kind: NativeCredentialProviderKind.apple,
+          availability: true,
+          throwOnAvailable: true,
+        );
+        final h = _build(providers: [bad]);
+        h.exchange.codeQueue.add(_tokenSet(access: 'oauth-at'));
+        await h.runtime.init();
+        // Runtime can still recover via OAuth2.
+        await h.runtime.ensureAuthenticated();
+        expect(h.worker.state, AuthState.authenticated);
+        expect(h.oauth.calls, 1);
+        await h.runtime.dispose();
+      },
+    );
   });
 }
 
@@ -482,8 +473,7 @@ class _BadIssuerProvider implements NativeCredentialProvider {
   _BadIssuerProvider();
 
   @override
-  NativeCredentialProviderKind get kind =>
-      NativeCredentialProviderKind.google;
+  NativeCredentialProviderKind get kind => NativeCredentialProviderKind.google;
 
   int silentCalls = 0;
 
@@ -491,9 +481,7 @@ class _BadIssuerProvider implements NativeCredentialProvider {
   Future<bool> isAvailable() async => true;
 
   @override
-  Future<NativeCredentialOutcome> attemptSilent({
-    required String nonce,
-  }) async {
+  Future<NativeCredentialOutcome> attemptSilent({required String nonce}) async {
     silentCalls++;
     return NativeCredentialOutcome.ok(
       NativeCredentialResult(
@@ -512,8 +500,7 @@ class _BadIssuerProvider implements NativeCredentialProvider {
   @override
   Future<NativeCredentialOutcome> attemptInteractive({
     required String nonce,
-  }) async =>
-      const NativeCredentialOutcome.cancelled();
+  }) async => const NativeCredentialOutcome.cancelled();
 
   @override
   Future<void> signOut() async {}
@@ -523,10 +510,7 @@ class _BadIssuerProvider implements NativeCredentialProvider {
 /// runtime passes to [attemptSilent] / [attemptInteractive]. Keeps tests
 /// decoupled from the randomness of the runtime's nonce generator.
 class _NonceEchoingProvider implements NativeCredentialProvider {
-  _NonceEchoingProvider({
-    required this.kind,
-    this.silentOutcome,
-  });
+  _NonceEchoingProvider({required this.kind, this.silentOutcome});
 
   @override
   final NativeCredentialProviderKind kind;
@@ -559,9 +543,7 @@ class _NonceEchoingProvider implements NativeCredentialProvider {
   }
 
   @override
-  Future<NativeCredentialOutcome> attemptSilent({
-    required String nonce,
-  }) async {
+  Future<NativeCredentialOutcome> attemptSilent({required String nonce}) async {
     silentCalls++;
     return silentOutcome ?? _okFor(nonce);
   }
@@ -590,16 +572,13 @@ class _BlockingSilentProvider implements NativeCredentialProvider {
   int silentCalls = 0;
 
   @override
-  NativeCredentialProviderKind get kind =>
-      NativeCredentialProviderKind.google;
+  NativeCredentialProviderKind get kind => NativeCredentialProviderKind.google;
 
   @override
   Future<bool> isAvailable() async => true;
 
   @override
-  Future<NativeCredentialOutcome> attemptSilent({
-    required String nonce,
-  }) {
+  Future<NativeCredentialOutcome> attemptSilent({required String nonce}) {
     silentCalls++;
     return _gate.future;
   }
@@ -607,8 +586,7 @@ class _BlockingSilentProvider implements NativeCredentialProvider {
   @override
   Future<NativeCredentialOutcome> attemptInteractive({
     required String nonce,
-  }) async =>
-      const NativeCredentialOutcome.cancelled();
+  }) async => const NativeCredentialOutcome.cancelled();
 
   @override
   Future<void> signOut() async {}

--- a/ui/runtime/test/protocol/token_exchange_test.dart
+++ b/ui/runtime/test/protocol/token_exchange_test.dart
@@ -13,21 +13,24 @@ import 'package:http/testing.dart';
 
 const _timeout = Duration(seconds: 5);
 
-ResolvedConfig _cfg({List<String>? audiences}) =>
-    resolveConfig(AuthConfig(
-      clientId: 'c',
-      idpBaseUrl: 'https://idp.example.com',
-      apiBaseUrl: 'https://api.example.com',
-      redirectScheme: 'com.example.app',
-      audiences: audiences,
-    ));
+ResolvedConfig _cfg({List<String>? audiences, String? installationId}) =>
+    resolveConfig(
+      AuthConfig(
+        clientId: 'c',
+        idpBaseUrl: 'https://idp.example.com',
+        apiBaseUrl: 'https://api.example.com',
+        redirectScheme: 'com.example.app',
+        audiences: audiences,
+        installationId: installationId,
+      ),
+    );
 
 Map<String, dynamic> _discoveryDoc({bool dpop = false}) => <String, dynamic>{
-      'issuer': 'https://idp.example.com',
-      'authorization_endpoint': 'https://idp.example.com/oauth2/auth',
-      'token_endpoint': 'https://idp.example.com/oauth2/token',
-      if (dpop) 'dpop_signing_alg_values_supported': ['ES256'],
-    };
+  'issuer': 'https://idp.example.com',
+  'authorization_endpoint': 'https://idp.example.com/oauth2/auth',
+  'token_endpoint': 'https://idp.example.com/oauth2/token',
+  if (dpop) 'dpop_signing_alg_values_supported': ['ES256'],
+};
 
 Map<String, dynamic> _tokenResp({
   String accessToken = 'at-1',
@@ -35,14 +38,13 @@ Map<String, dynamic> _tokenResp({
   int expiresIn = 300,
   String tokenType = 'Bearer',
   String? idToken,
-}) =>
-    <String, dynamic>{
-      'access_token': accessToken,
-      'refresh_token': refreshToken,
-      'expires_in': expiresIn,
-      'token_type': tokenType,
-      'id_token': ?idToken,
-    };
+}) => <String, dynamic>{
+  'access_token': accessToken,
+  'refresh_token': refreshToken,
+  'expires_in': expiresIn,
+  'token_type': tokenType,
+  'id_token': ?idToken,
+};
 
 void main() {
   setUp(clearDiscoveryCache);
@@ -57,8 +59,10 @@ void main() {
           return http.Response(jsonEncode(_discoveryDoc()), 200);
         }
         expect(req.url.toString(), 'https://idp.example.com/oauth2/token');
-        expect(req.headers['content-type'],
-            startsWith('application/x-www-form-urlencoded'));
+        expect(
+          req.headers['content-type'],
+          startsWith('application/x-www-form-urlencoded'),
+        );
         expect(req.headers.containsKey('dpop'), isFalse);
         final form = Uri.splitQueryString(req.body);
         expect(form['grant_type'], 'authorization_code');
@@ -66,8 +70,11 @@ void main() {
         expect(form['code'], 'code-xyz');
         expect(form['code_verifier'], 'verifier-xyz');
         expect(form['redirect_uri'], 'com.example.app://callback');
-        return http.Response(jsonEncode(_tokenResp()), 200,
-            headers: {'content-type': 'application/json'});
+        return http.Response(
+          jsonEncode(_tokenResp()),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
       });
 
       final kp = generateDpopKeyPair();
@@ -84,8 +91,7 @@ void main() {
       expect(tokens.tokenType, TokenType.bearer);
     });
 
-    test('DPoP-mode adds DPoP header and retries on nonce challenge',
-        () async {
+    test('DPoP-mode adds DPoP header and retries on nonce challenge', () async {
       final cfg = _cfg();
       var tokenCalls = 0;
       final client = MockClient((req) async {
@@ -105,7 +111,9 @@ void main() {
         final proof = req.headers['dpop']!;
         final payloadB64 = proof.split('.')[1];
         final padded = payloadB64.padRight(
-            payloadB64.length + (4 - payloadB64.length % 4) % 4, '=');
+          payloadB64.length + (4 - payloadB64.length % 4) % 4,
+          '=',
+        );
         final payload =
             jsonDecode(utf8.decode(base64Url.decode(padded))) as Map;
         expect(payload['nonce'], 'n-fresh');
@@ -202,8 +210,13 @@ void main() {
       final exchange = TokenExchange(client: client, timeout: _timeout);
       await expectLater(
         exchange.exchangeCode(cfg, ctx, code: 'c', verifier: 'v'),
-        throwsA(isA<AuthError>()
-            .having((e) => e.code, 'code', AuthErrorCode.tokenExchangeFailed)),
+        throwsA(
+          isA<AuthError>().having(
+            (e) => e.code,
+            'code',
+            AuthErrorCode.tokenExchangeFailed,
+          ),
+        ),
       );
     });
   });
@@ -219,8 +232,9 @@ void main() {
         expect(form['grant_type'], 'refresh_token');
         expect(form['refresh_token'], 'rt-1');
         return http.Response(
-            jsonEncode(_tokenResp(accessToken: 'at-2', refreshToken: 'rt-2')),
-            200);
+          jsonEncode(_tokenResp(accessToken: 'at-2', refreshToken: 'rt-2')),
+          200,
+        );
       });
       final kp = generateDpopKeyPair();
       final ctx = makeDpopContext(kp);
@@ -292,81 +306,101 @@ void main() {
   });
 
   group('exchangeIdToken', () {
-    test('posts RFC 8693 token-exchange grant with id_token subject_token_type',
-        () async {
-      final cfg = _cfg();
-      final client = MockClient((req) async {
-        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
-          return http.Response(jsonEncode(_discoveryDoc()), 200);
-        }
-        expect(req.url.toString(), 'https://idp.example.com/oauth2/token');
-        expect(req.headers['content-type'],
-            startsWith('application/x-www-form-urlencoded'));
-        final form = Uri.splitQueryString(req.body);
-        expect(form['grant_type'],
-            'urn:ietf:params:oauth:grant-type:token-exchange');
-        expect(form['client_id'], 'c');
-        expect(form['subject_token'], 'apple-id-token');
-        expect(form['subject_token_type'],
-            'urn:ietf:params:oauth:token-type:id_token');
-        expect(form['subject_issuer'], 'https://appleid.apple.com');
-        return http.Response(jsonEncode(_tokenResp()), 200,
-            headers: {'content-type': 'application/json'});
-      });
-
-      final kp = generateDpopKeyPair();
-      final ctx = makeDpopContext(kp);
-      final exchange = TokenExchange(client: client, timeout: _timeout);
-      final tokens = await exchange.exchangeIdToken(
-        cfg,
-        ctx,
-        subjectToken: 'apple-id-token',
-        subjectIssuer: 'https://appleid.apple.com',
-      );
-      expect(tokens.accessToken, 'at-1');
-      expect(tokens.refreshToken, 'rt-1');
-      expect(tokens.tokenType, TokenType.bearer);
-    });
-
-    test('DPoP mode attaches a DPoP proof and handles the nonce challenge',
-        () async {
-      final cfg = _cfg();
-      var tokenCalls = 0;
-      final client = MockClient((req) async {
-        if (req.url.path.endsWith('/.well-known/openid-configuration')) {
-          return http.Response(jsonEncode(_discoveryDoc(dpop: true)), 200);
-        }
-        tokenCalls++;
-        expect(req.headers.containsKey('dpop'), isTrue);
-        if (tokenCalls == 1) {
-          return http.Response(
-            jsonEncode({'error': 'use_dpop_nonce'}),
-            401,
-            headers: {'dpop-nonce': 'n-fresh'},
+    test(
+      'posts RFC 8693 token-exchange grant with id_token subject_token_type',
+      () async {
+        final cfg = _cfg(installationId: 'install-123');
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+            return http.Response(jsonEncode(_discoveryDoc()), 200);
+          }
+          expect(req.url.toString(), 'https://idp.example.com/oauth2/token');
+          expect(
+            req.headers['content-type'],
+            startsWith('application/x-www-form-urlencoded'),
           );
-        }
-        final proof = req.headers['dpop']!;
-        final payloadB64 = proof.split('.')[1];
-        final padded = payloadB64.padRight(
-            payloadB64.length + (4 - payloadB64.length % 4) % 4, '=');
-        final payload =
-            jsonDecode(utf8.decode(base64Url.decode(padded))) as Map;
-        expect(payload['nonce'], 'n-fresh');
-        return http.Response(jsonEncode(_tokenResp(tokenType: 'DPoP')), 200);
-      });
+          final form = Uri.splitQueryString(req.body);
+          expect(
+            form['grant_type'],
+            'urn:ietf:params:oauth:grant-type:token-exchange',
+          );
+          expect(form['client_id'], 'c');
+          expect(form['subject_token'], 'apple-id-token');
+          expect(
+            form['subject_token_type'],
+            'urn:ietf:params:oauth:token-type:id_token',
+          );
+          expect(form['subject_issuer'], 'https://appleid.apple.com');
+          expect(form['installation_id'], 'install-123');
+          expect(form['platform'], 'ios');
+          expect(form['device_name'], 'Alice iPhone');
+          return http.Response(
+            jsonEncode(_tokenResp()),
+            200,
+            headers: {'content-type': 'application/json'},
+          );
+        });
 
-      final kp = generateDpopKeyPair();
-      final ctx = makeDpopContext(kp);
-      final exchange = TokenExchange(client: client, timeout: _timeout);
-      final tokens = await exchange.exchangeIdToken(
-        cfg,
-        ctx,
-        subjectToken: 'google-id-token',
-        subjectIssuer: 'https://accounts.google.com',
-      );
-      expect(tokens.tokenType, TokenType.dpop);
-      expect(tokenCalls, 2);
-    });
+        final kp = generateDpopKeyPair();
+        final ctx = makeDpopContext(kp);
+        final exchange = TokenExchange(client: client, timeout: _timeout);
+        final tokens = await exchange.exchangeIdToken(
+          cfg,
+          ctx,
+          subjectToken: 'apple-id-token',
+          subjectIssuer: 'https://appleid.apple.com',
+          platform: 'ios',
+          deviceName: 'Alice iPhone',
+        );
+        expect(tokens.accessToken, 'at-1');
+        expect(tokens.refreshToken, 'rt-1');
+        expect(tokens.tokenType, TokenType.bearer);
+      },
+    );
+
+    test(
+      'DPoP mode attaches a DPoP proof and handles the nonce challenge',
+      () async {
+        final cfg = _cfg();
+        var tokenCalls = 0;
+        final client = MockClient((req) async {
+          if (req.url.path.endsWith('/.well-known/openid-configuration')) {
+            return http.Response(jsonEncode(_discoveryDoc(dpop: true)), 200);
+          }
+          tokenCalls++;
+          expect(req.headers.containsKey('dpop'), isTrue);
+          if (tokenCalls == 1) {
+            return http.Response(
+              jsonEncode({'error': 'use_dpop_nonce'}),
+              401,
+              headers: {'dpop-nonce': 'n-fresh'},
+            );
+          }
+          final proof = req.headers['dpop']!;
+          final payloadB64 = proof.split('.')[1];
+          final padded = payloadB64.padRight(
+            payloadB64.length + (4 - payloadB64.length % 4) % 4,
+            '=',
+          );
+          final payload =
+              jsonDecode(utf8.decode(base64Url.decode(padded))) as Map;
+          expect(payload['nonce'], 'n-fresh');
+          return http.Response(jsonEncode(_tokenResp(tokenType: 'DPoP')), 200);
+        });
+
+        final kp = generateDpopKeyPair();
+        final ctx = makeDpopContext(kp);
+        final exchange = TokenExchange(client: client, timeout: _timeout);
+        final tokens = await exchange.exchangeIdToken(
+          cfg,
+          ctx,
+          subjectToken: 'google-id-token',
+          subjectIssuer: 'https://accounts.google.com',
+        );
+        expect(tokens.tokenType, TokenType.dpop);
+        expect(tokenCalls, 2);
+      },
+    );
 
     test('non-2xx raises tokenExchangeFailed', () async {
       final cfg = _cfg();
@@ -386,8 +420,13 @@ void main() {
           subjectToken: 'bad',
           subjectIssuer: 'https://accounts.google.com',
         ),
-        throwsA(isA<AuthError>()
-            .having((e) => e.code, 'code', AuthErrorCode.tokenExchangeFailed)),
+        throwsA(
+          isA<AuthError>().having(
+            (e) => e.code,
+            'code',
+            AuthErrorCode.tokenExchangeFailed,
+          ),
+        ),
       );
     });
 

--- a/ui/runtime/test/worker/token_worker_test.dart
+++ b/ui/runtime/test/worker/token_worker_test.dart
@@ -57,8 +57,7 @@ class _FakeDiscoveryClient implements DiscoveryClient {
 
 /// Stub [TokenExchange] that records calls and returns canned outcomes.
 class _FakeTokenExchange extends TokenExchange {
-  _FakeTokenExchange()
-      : super(timeout: const Duration(seconds: 5));
+  _FakeTokenExchange() : super(timeout: const Duration(seconds: 5));
 
   List<TokenSet> rotateQueue = [];
   List<RefreshOutcome> refreshQueue = [];
@@ -93,6 +92,8 @@ class _FakeTokenExchange extends TokenExchange {
     DpopContext ctx, {
     required String subjectToken,
     required String subjectIssuer,
+    String? platform,
+    String? deviceName,
   }) async {
     idTokenExchangeCalls++;
     lastSubjectToken = subjectToken;
@@ -143,8 +144,7 @@ class _FakeApiProxy extends ApiProxy {
   }) async {
     fetchCalls++;
     final snap = await tp.ensureFresh();
-    seenAuthHeader =
-        '${snap.tokenType.headerValue} ${snap.accessToken}';
+    seenAuthHeader = '${snap.tokenType.headerValue} ${snap.accessToken}';
     if (cannedError != null) throw cannedError!;
     return cannedResponse ??
         ApiResponse(status: 200, headers: const {}, body: Uint8List(0));
@@ -166,8 +166,7 @@ class _FakeApiProxy extends ApiProxy {
   }) async {
     uploadCalls++;
     final snap = await tp.ensureFresh();
-    seenAuthHeader =
-        '${snap.tokenType.headerValue} ${snap.accessToken}';
+    seenAuthHeader = '${snap.tokenType.headerValue} ${snap.accessToken}';
     return cannedResponse ??
         ApiResponse(status: 200, headers: const {}, body: Uint8List(0));
   }
@@ -177,12 +176,14 @@ class _FakeApiProxy extends ApiProxy {
 // Helpers
 // ---------------------------------------------------------------------------
 
-ResolvedConfig _cfg() => resolveConfig(const AuthConfig(
-      clientId: 'c',
-      idpBaseUrl: 'https://idp.example.com',
-      apiBaseUrl: 'https://api.example.com',
-      redirectScheme: 'com.example.app',
-    ));
+ResolvedConfig _cfg() => resolveConfig(
+  const AuthConfig(
+    clientId: 'c',
+    idpBaseUrl: 'https://idp.example.com',
+    apiBaseUrl: 'https://api.example.com',
+    redirectScheme: 'com.example.app',
+  ),
+);
 
 TokenSet _tokens({
   String access = 'at-1',
@@ -190,14 +191,13 @@ TokenSet _tokens({
   DateTime? expiresAt,
   String? idToken,
   TokenType type = TokenType.bearer,
-}) =>
-    TokenSet(
-      accessToken: access,
-      refreshToken: refresh,
-      expiresAt: expiresAt ?? DateTime.utc(2030, 1, 1),
-      tokenType: type,
-      idToken: idToken,
-    );
+}) => TokenSet(
+  accessToken: access,
+  refreshToken: refresh,
+  expiresAt: expiresAt ?? DateTime.utc(2030, 1, 1),
+  tokenType: type,
+  idToken: idToken,
+);
 
 class _Deps {
   _Deps({
@@ -209,16 +209,17 @@ class _Deps {
     _FakeTokenExchange? exchange,
     _FakeApiProxy? proxy,
     Clock? clock,
-  })  : config = _cfg(),
-        keyManager = km ?? DefaultKeyManager(),
-        tokenStore = store ?? SecureTokenStore(kv: InMemoryKeyValueStore()),
-        rootKeyStore = rootKeyStore ??
-            DefaultRootKeyStore(kv: rootKv ?? InMemoryKeyValueStore()),
-        discoveryClient = disco ?? _FakeDiscoveryClient(),
-        tokenExchange = exchange ?? _FakeTokenExchange(),
-        apiProxy = proxy ?? _FakeApiProxy(),
-        refreshLock = RefreshLock(),
-        clock = clock ?? _fixedNow;
+  }) : config = _cfg(),
+       keyManager = km ?? DefaultKeyManager(),
+       tokenStore = store ?? SecureTokenStore(kv: InMemoryKeyValueStore()),
+       rootKeyStore =
+           rootKeyStore ??
+           DefaultRootKeyStore(kv: rootKv ?? InMemoryKeyValueStore()),
+       discoveryClient = disco ?? _FakeDiscoveryClient(),
+       tokenExchange = exchange ?? _FakeTokenExchange(),
+       apiProxy = proxy ?? _FakeApiProxy(),
+       refreshLock = RefreshLock(),
+       clock = clock ?? _fixedNow;
 
   final ResolvedConfig config;
   final KeyManager keyManager;
@@ -231,16 +232,16 @@ class _Deps {
   final Clock clock;
 
   TokenWorker build() => TokenWorker(
-        config: config,
-        keyManager: keyManager,
-        rootKeyStore: rootKeyStore,
-        tokenStore: tokenStore,
-        discoveryClient: discoveryClient,
-        tokenExchange: tokenExchange,
-        apiProxy: apiProxy,
-        refreshLock: refreshLock,
-        clock: clock,
-      );
+    config: config,
+    keyManager: keyManager,
+    rootKeyStore: rootKeyStore,
+    tokenStore: tokenStore,
+    discoveryClient: discoveryClient,
+    tokenExchange: tokenExchange,
+    apiProxy: apiProxy,
+    refreshLock: refreshLock,
+    clock: clock,
+  );
 }
 
 DateTime _fixedNow() => DateTime.utc(2026, 4, 19, 12, 0, 0);
@@ -260,31 +261,34 @@ void main() {
     await w.destroy();
   });
 
-  test('completeAuth persists session and transitions to authenticated',
-      () async {
-    final d = _Deps();
-    final w = d.build();
-    d.tokenExchange.rotateQueue
-        .add(_tokens(access: 'access-1', refresh: 'refresh-1'));
-    final states = <AuthState>[];
-    w.authStateStream.listen(states.add);
+  test(
+    'completeAuth persists session and transitions to authenticated',
+    () async {
+      final d = _Deps();
+      final w = d.build();
+      d.tokenExchange.rotateQueue.add(
+        _tokens(access: 'access-1', refresh: 'refresh-1'),
+      );
+      final states = <AuthState>[];
+      w.authStateStream.listen(states.add);
 
-    await w.init();
-    await w.completeAuth(
-      code: 'code-1',
-      verifier: 'verif-1',
-      state: 's',
-      nonce: 'n',
-      expectedState: 's',
-    );
-    // Flush microtasks so the broadcast stream delivers.
-    await Future<void>.delayed(Duration.zero);
-    expect(d.tokenExchange.exchangeCalls, 1);
-    expect(w.state, AuthState.authenticated);
-    expect(states.last, AuthState.authenticated);
-    expect(await d.tokenStore.load(d.config.namespace), isNotNull);
-    await w.destroy();
-  });
+      await w.init();
+      await w.completeAuth(
+        code: 'code-1',
+        verifier: 'verif-1',
+        state: 's',
+        nonce: 'n',
+        expectedState: 's',
+      );
+      // Flush microtasks so the broadcast stream delivers.
+      await Future<void>.delayed(Duration.zero);
+      expect(d.tokenExchange.exchangeCalls, 1);
+      expect(w.state, AuthState.authenticated);
+      expect(states.last, AuthState.authenticated);
+      expect(await d.tokenStore.load(d.config.namespace), isNotNull);
+      await w.destroy();
+    },
+  );
 
   test('completeAuth rejects state mismatch', () async {
     final d = _Deps();
@@ -298,11 +302,13 @@ void main() {
         nonce: 'n',
         expectedState: 'B',
       ),
-      throwsA(isA<AuthError>().having(
-        (e) => e.code,
-        'code',
-        AuthErrorCode.oauthFailed,
-      )),
+      throwsA(
+        isA<AuthError>().having(
+          (e) => e.code,
+          'code',
+          AuthErrorCode.oauthFailed,
+        ),
+      ),
     );
     await w.destroy();
   });
@@ -325,47 +331,60 @@ void main() {
   });
 
   test(
-      'prepareAuth appends audience=a,b,c when audiences configured', () async {
-    final config = resolveConfig(const AuthConfig(
-      clientId: 'c',
-      idpBaseUrl: 'https://idp.example.com',
-      apiBaseUrl: 'https://api.example.com',
-      redirectScheme: 'com.example.app',
-      audiences: ['svc-a', 'svc-b', 'svc-c'],
-    ));
-    final w = TokenWorker(
-      config: config,
-      keyManager: DefaultKeyManager(),
-      rootKeyStore: DefaultRootKeyStore(kv: InMemoryKeyValueStore()),
-      tokenStore: SecureTokenStore(kv: InMemoryKeyValueStore()),
-      discoveryClient: _FakeDiscoveryClient(),
-      tokenExchange: _FakeTokenExchange(),
-      apiProxy: _FakeApiProxy(),
-      refreshLock: RefreshLock(),
-      clock: _fixedNow,
-    );
-    await w.init();
-    final req = await w.prepareAuth();
-    expect(req.url, contains('audience=svc-a%2Csvc-b%2Csvc-c'));
-    final uri = Uri.parse(req.url);
-    expect(uri.queryParameters['audience'], 'svc-a,svc-b,svc-c');
-    await w.destroy();
-  });
+    'prepareAuth appends repeated audience params when audiences configured',
+    () async {
+      final config = resolveConfig(
+        const AuthConfig(
+          clientId: 'c',
+          idpBaseUrl: 'https://idp.example.com',
+          apiBaseUrl: 'https://api.example.com',
+          redirectScheme: 'com.example.app',
+          audiences: ['svc-a', 'svc-b', 'svc-c'],
+        ),
+      );
+      final w = TokenWorker(
+        config: config,
+        keyManager: DefaultKeyManager(),
+        rootKeyStore: DefaultRootKeyStore(kv: InMemoryKeyValueStore()),
+        tokenStore: SecureTokenStore(kv: InMemoryKeyValueStore()),
+        discoveryClient: _FakeDiscoveryClient(),
+        tokenExchange: _FakeTokenExchange(),
+        apiProxy: _FakeApiProxy(),
+        refreshLock: RefreshLock(),
+        clock: _fixedNow,
+      );
+      await w.init();
+      final req = await w.prepareAuth();
+      expect(
+        req.url,
+        contains('audience=svc-a&audience=svc-b&audience=svc-c'),
+      );
+      final uri = Uri.parse(req.url);
+      expect(uri.queryParametersAll['audience'], ['svc-a', 'svc-b', 'svc-c']);
+      await w.destroy();
+    },
+  );
 
   test('refresh rotates and persists the new refresh token', () async {
     final d = _Deps();
     final w = d.build();
-    d.tokenExchange.rotateQueue.add(_tokens(
-      access: 'at-1',
-      refresh: 'rt-1',
-      // Near-expiry so ensureFresh triggers a refresh.
-      expiresAt: _fixedNow().add(const Duration(seconds: 5)),
-    ));
-    d.tokenExchange.refreshQueue.add(RefreshOutcome.rotated(_tokens(
-      access: 'at-2',
-      refresh: 'rt-2',
-      expiresAt: _fixedNow().add(const Duration(minutes: 10)),
-    )));
+    d.tokenExchange.rotateQueue.add(
+      _tokens(
+        access: 'at-1',
+        refresh: 'rt-1',
+        // Near-expiry so ensureFresh triggers a refresh.
+        expiresAt: _fixedNow().add(const Duration(seconds: 5)),
+      ),
+    );
+    d.tokenExchange.refreshQueue.add(
+      RefreshOutcome.rotated(
+        _tokens(
+          access: 'at-2',
+          refresh: 'rt-2',
+          expiresAt: _fixedNow().add(const Duration(minutes: 10)),
+        ),
+      ),
+    );
 
     await w.init();
     await w.completeAuth(
@@ -388,11 +407,10 @@ void main() {
   test('reuse-detected refresh wipes and emits SecurityEvent', () async {
     final d = _Deps();
     final w = d.build();
-    d.tokenExchange.rotateQueue.add(_tokens(
-      expiresAt: _fixedNow().add(const Duration(seconds: 5)),
-    ));
-    d.tokenExchange.refreshQueue
-        .add(const RefreshOutcome.reuseDetected());
+    d.tokenExchange.rotateQueue.add(
+      _tokens(expiresAt: _fixedNow().add(const Duration(seconds: 5))),
+    );
+    d.tokenExchange.refreshQueue.add(const RefreshOutcome.reuseDetected());
 
     final events = <SecurityEvent>[];
     w.securityEventStream.listen(events.add);
@@ -410,11 +428,13 @@ void main() {
 
     await expectLater(
       w.ensureFresh(),
-      throwsA(isA<AuthError>().having(
-        (e) => e.code,
-        'code',
-        AuthErrorCode.refreshReuseDetected,
-      )),
+      throwsA(
+        isA<AuthError>().having(
+          (e) => e.code,
+          'code',
+          AuthErrorCode.refreshReuseDetected,
+        ),
+      ),
     );
     // Allow microtask-scheduled stream events to flush.
     await Future<void>.delayed(Duration.zero);
@@ -428,10 +448,12 @@ void main() {
   test('ensureFresh returns cached token when not near expiry', () async {
     final d = _Deps();
     final w = d.build();
-    d.tokenExchange.rotateQueue.add(_tokens(
-      access: 'at-cached',
-      expiresAt: _fixedNow().add(const Duration(minutes: 10)),
-    ));
+    d.tokenExchange.rotateQueue.add(
+      _tokens(
+        access: 'at-cached',
+        expiresAt: _fixedNow().add(const Duration(minutes: 10)),
+      ),
+    );
 
     await w.init();
     await w.completeAuth(
@@ -489,7 +511,7 @@ void main() {
       filename: 'x.bin',
       contentType: 'application/octet-stream',
       bytes: Stream<List<int>>.fromIterable([
-        [1, 2, 3]
+        [1, 2, 3],
       ]),
       length: 3,
     );
@@ -499,37 +521,36 @@ void main() {
     await w.destroy();
   });
 
-  test('getClaims decodes ID token payload; getRoles decodes access token',
-      () async {
-    final d = _Deps();
-    final w = d.build();
-    final id = _makeJwt({'sub': 'u-1', 'email': 'a@b.c'});
-    final access = _makeJwt({
-      'sub': 'u-1',
-      'roles': ['admin', 'user'],
-    });
-    d.tokenExchange.rotateQueue.add(_tokens(
-      access: access,
-      idToken: id,
-    ));
+  test(
+    'getClaims decodes ID token payload; getRoles decodes access token',
+    () async {
+      final d = _Deps();
+      final w = d.build();
+      final id = _makeJwt({'sub': 'u-1', 'email': 'a@b.c'});
+      final access = _makeJwt({
+        'sub': 'u-1',
+        'roles': ['admin', 'user'],
+      });
+      d.tokenExchange.rotateQueue.add(_tokens(access: access, idToken: id));
 
-    await w.init();
-    await w.completeAuth(
-      code: 'c',
-      verifier: 'v',
-      state: 's',
-      nonce: 'n',
-      expectedState: 's',
-    );
+      await w.init();
+      await w.completeAuth(
+        code: 'c',
+        verifier: 'v',
+        state: 's',
+        nonce: 'n',
+        expectedState: 's',
+      );
 
-    final claims = await w.getClaims();
-    expect(claims['sub'], 'u-1');
-    expect(claims['email'], 'a@b.c');
+      final claims = await w.getClaims();
+      expect(claims['sub'], 'u-1');
+      expect(claims['email'], 'a@b.c');
 
-    final roles = await w.getRoles();
-    expect(roles, ['admin', 'user']);
-    await w.destroy();
-  });
+      final roles = await w.getRoles();
+      expect(roles, ['admin', 'user']);
+      await w.destroy();
+    },
+  );
 
   test('logout clears session + transitions to unauthenticated', () async {
     final d = _Deps();
@@ -554,94 +575,97 @@ void main() {
   });
 
   test(
-      'second worker instance decrypts stored session and starts authenticated',
-      () async {
-    // Share the storage backends between both worker instances to
-    // simulate a cold app restart: the KV blob survives, and the root
-    // key store (also backed by flutter_secure_storage in prod) survives.
-    final sessionKv = InMemoryKeyValueStore();
-    final rootKv = InMemoryKeyValueStore();
+    'second worker instance decrypts stored session and starts authenticated',
+    () async {
+      // Share the storage backends between both worker instances to
+      // simulate a cold app restart: the KV blob survives, and the root
+      // key store (also backed by flutter_secure_storage in prod) survives.
+      final sessionKv = InMemoryKeyValueStore();
+      final rootKv = InMemoryKeyValueStore();
 
-    _Deps makeDeps(_FakeTokenExchange? exchange) => _Deps(
-          store: SecureTokenStore(kv: sessionKv),
-          rootKeyStore: DefaultRootKeyStore(kv: rootKv),
-          exchange: exchange,
-        );
+      _Deps makeDeps(_FakeTokenExchange? exchange) => _Deps(
+        store: SecureTokenStore(kv: sessionKv),
+        rootKeyStore: DefaultRootKeyStore(kv: rootKv),
+        exchange: exchange,
+      );
 
-    final d1 = makeDeps(_FakeTokenExchange());
-    final w1 = d1.build();
-    d1.tokenExchange.rotateQueue
-        .add(_tokens(access: 'at-restored', refresh: 'rt-restored'));
-    await w1.init();
-    await w1.completeAuth(
-      code: 'c',
-      verifier: 'v',
-      state: 's',
-      nonce: 'n',
-      expectedState: 's',
-    );
-    expect(w1.state, AuthState.authenticated);
-    await w1.destroy();
+      final d1 = makeDeps(_FakeTokenExchange());
+      final w1 = d1.build();
+      d1.tokenExchange.rotateQueue.add(
+        _tokens(access: 'at-restored', refresh: 'rt-restored'),
+      );
+      await w1.init();
+      await w1.completeAuth(
+        code: 'c',
+        verifier: 'v',
+        state: 's',
+        nonce: 'n',
+        expectedState: 's',
+      );
+      expect(w1.state, AuthState.authenticated);
+      await w1.destroy();
 
-    // Second worker with its own instance of everything except the
-    // storage backends — models a fresh process coming up.
-    final d2 = makeDeps(_FakeTokenExchange());
-    final w2 = d2.build();
-    final states = <AuthState>[];
-    w2.authStateStream.listen(states.add);
-    await w2.init();
-    await Future<void>.delayed(Duration.zero);
-    expect(w2.state, AuthState.authenticated);
-    expect(states, [AuthState.authenticated]);
-    // Restored tokens match the persisted values without making an
-    // exchange call.
-    expect(d2.tokenExchange.exchangeCalls, 0);
-    // fetch uses the restored access token straight away.
-    await w2.fetch(path: '/ping', method: 'GET');
-    expect(d2.apiProxy.seenAuthHeader, 'Bearer at-restored');
-    await w2.destroy();
-  });
+      // Second worker with its own instance of everything except the
+      // storage backends — models a fresh process coming up.
+      final d2 = makeDeps(_FakeTokenExchange());
+      final w2 = d2.build();
+      final states = <AuthState>[];
+      w2.authStateStream.listen(states.add);
+      await w2.init();
+      await Future<void>.delayed(Duration.zero);
+      expect(w2.state, AuthState.authenticated);
+      expect(states, [AuthState.authenticated]);
+      // Restored tokens match the persisted values without making an
+      // exchange call.
+      expect(d2.tokenExchange.exchangeCalls, 0);
+      // fetch uses the restored access token straight away.
+      await w2.fetch(path: '/ping', method: 'GET');
+      expect(d2.apiProxy.seenAuthHeader, 'Bearer at-restored');
+      await w2.destroy();
+    },
+  );
 
   test(
-      'corrupt wrap-key ciphertext wipes session and emits storageCorruption',
-      () async {
-    final sessionKv = InMemoryKeyValueStore();
-    final rootKv = InMemoryKeyValueStore();
-    _Deps makeDeps() => _Deps(
-          store: SecureTokenStore(kv: sessionKv),
-          rootKeyStore: DefaultRootKeyStore(kv: rootKv),
-        );
+    'corrupt wrap-key ciphertext wipes session and emits storageCorruption',
+    () async {
+      final sessionKv = InMemoryKeyValueStore();
+      final rootKv = InMemoryKeyValueStore();
+      _Deps makeDeps() => _Deps(
+        store: SecureTokenStore(kv: sessionKv),
+        rootKeyStore: DefaultRootKeyStore(kv: rootKv),
+      );
 
-    final d1 = makeDeps();
-    final w1 = d1.build();
-    d1.tokenExchange.rotateQueue.add(_tokens());
-    await w1.init();
-    await w1.completeAuth(
-      code: 'c',
-      verifier: 'v',
-      state: 's',
-      nonce: 'n',
-      expectedState: 's',
-    );
-    await w1.destroy();
+      final d1 = makeDeps();
+      final w1 = d1.build();
+      d1.tokenExchange.rotateQueue.add(_tokens());
+      await w1.init();
+      await w1.completeAuth(
+        code: 'c',
+        verifier: 'v',
+        state: 's',
+        nonce: 'n',
+        expectedState: 's',
+      );
+      await w1.destroy();
 
-    // Simulate the root key going missing / being rotated externally
-    // (e.g. user wiped the keychain): the second worker generates a
-    // fresh root key, wrap-key decryption fails, and the session is
-    // wiped with a storageCorruption signal.
-    rootKv.delete('${d1.config.namespace}::root-key');
+      // Simulate the root key going missing / being rotated externally
+      // (e.g. user wiped the keychain): the second worker generates a
+      // fresh root key, wrap-key decryption fails, and the session is
+      // wiped with a storageCorruption signal.
+      rootKv.delete('${d1.config.namespace}::root-key');
 
-    final d2 = makeDeps();
-    final w2 = d2.build();
-    final events = <SecurityEvent>[];
-    w2.securityEventStream.listen(events.add);
-    await w2.init();
-    await Future<void>.delayed(Duration.zero);
-    expect(w2.state, AuthState.unauthenticated);
-    expect(events.any((e) => e is StorageCorruption), isTrue);
-    expect(await d2.tokenStore.load(d2.config.namespace), isNull);
-    await w2.destroy();
-  });
+      final d2 = makeDeps();
+      final w2 = d2.build();
+      final events = <SecurityEvent>[];
+      w2.securityEventStream.listen(events.add);
+      await w2.init();
+      await Future<void>.delayed(Duration.zero);
+      expect(w2.state, AuthState.unauthenticated);
+      expect(events.any((e) => e is StorageCorruption), isTrue);
+      expect(await d2.tokenStore.load(d2.config.namespace), isNull);
+      await w2.destroy();
+    },
+  );
 
   test('operations after destroy() throw StateError', () async {
     final d = _Deps();
@@ -663,8 +687,9 @@ void main() {
         'sub': 'g-user-1',
         'nonce': nonce,
       });
-      d.tokenExchange.idTokenExchangeQueue
-          .add(_tokens(access: 'at-native', refresh: 'rt-native'));
+      d.tokenExchange.idTokenExchangeQueue.add(
+        _tokens(access: 'at-native', refresh: 'rt-native'),
+      );
 
       final states = <AuthState>[];
       w.authStateStream.listen(states.add);
@@ -694,16 +719,16 @@ void main() {
       final d = _Deps();
       final w = d.build();
       const rawNonce = 'nonce-apple-1';
-      final hashed =
-          crypto.sha256.convert(utf8.encode(rawNonce)).toString();
+      final hashed = crypto.sha256.convert(utf8.encode(rawNonce)).toString();
       final idToken = _makeJwt(<String, dynamic>{
         'iss': 'https://appleid.apple.com',
         'aud': 'c',
         'sub': 'a-user-1',
         'nonce': hashed,
       });
-      d.tokenExchange.idTokenExchangeQueue
-          .add(_tokens(access: 'at-apple', refresh: 'rt-apple'));
+      d.tokenExchange.idTokenExchangeQueue.add(
+        _tokens(access: 'at-apple', refresh: 'rt-apple'),
+      );
 
       await w.init();
       await w.completeNativeCredential(
@@ -721,78 +746,85 @@ void main() {
       await w.destroy();
     });
 
-    test('iss mismatch → nativeCredentialIssuerMismatch; no exchange',
-        () async {
-      final d = _Deps();
-      final w = d.build();
-      const nonce = 'nonce-bad-iss';
-      final idToken = _makeJwt(<String, dynamic>{
-        'iss': 'https://evil.example.com',
-        'aud': 'c',
-        'sub': 'g-user-1',
-        'nonce': nonce,
-      });
-      final states = <AuthState>[];
-      w.authStateStream.listen(states.add);
+    test(
+      'iss mismatch → nativeCredentialIssuerMismatch; no exchange',
+      () async {
+        final d = _Deps();
+        final w = d.build();
+        const nonce = 'nonce-bad-iss';
+        final idToken = _makeJwt(<String, dynamic>{
+          'iss': 'https://evil.example.com',
+          'aud': 'c',
+          'sub': 'g-user-1',
+          'nonce': nonce,
+        });
+        final states = <AuthState>[];
+        w.authStateStream.listen(states.add);
 
-      await w.init();
-      await expectLater(
-        w.completeNativeCredential(
-          credential: NativeCredentialResult(
-            provider: NativeCredentialProviderKind.google,
-            idToken: idToken,
-            autoSelected: false,
-            nonce: nonce,
+        await w.init();
+        await expectLater(
+          w.completeNativeCredential(
+            credential: NativeCredentialResult(
+              provider: NativeCredentialProviderKind.google,
+              idToken: idToken,
+              autoSelected: false,
+              nonce: nonce,
+            ),
+            expectedNonce: nonce,
           ),
-          expectedNonce: nonce,
-        ),
-        throwsA(isA<AuthError>().having(
-          (e) => e.code,
-          'code',
-          AuthErrorCode.nativeCredentialIssuerMismatch,
-        )),
-      );
-      await Future<void>.delayed(Duration.zero);
-      expect(d.tokenExchange.idTokenExchangeCalls, 0);
-      expect(w.state, AuthState.unauthenticated);
-      await w.destroy();
-    });
-
-    test('nonce mismatch → nativeCredentialExchangeFailed; no exchange',
-        () async {
-      final d = _Deps();
-      final w = d.build();
-      const expected = 'nonce-expected';
-      final idToken = _makeJwt(<String, dynamic>{
-        'iss': 'https://accounts.google.com',
-        'aud': 'c',
-        'sub': 'g-user-1',
-        'nonce': 'nonce-wrong',
-      });
-      await w.init();
-      await expectLater(
-        w.completeNativeCredential(
-          credential: NativeCredentialResult(
-            provider: NativeCredentialProviderKind.google,
-            idToken: idToken,
-            autoSelected: false,
-            nonce: 'nonce-wrong',
+          throwsA(
+            isA<AuthError>().having(
+              (e) => e.code,
+              'code',
+              AuthErrorCode.nativeCredentialIssuerMismatch,
+            ),
           ),
-          expectedNonce: expected,
-        ),
-        throwsA(isA<AuthError>().having(
-          (e) => e.code,
-          'code',
-          AuthErrorCode.nativeCredentialExchangeFailed,
-        )),
-      );
-      expect(d.tokenExchange.idTokenExchangeCalls, 0);
-      expect(w.state, AuthState.unauthenticated);
-      await w.destroy();
-    });
+        );
+        await Future<void>.delayed(Duration.zero);
+        expect(d.tokenExchange.idTokenExchangeCalls, 0);
+        expect(w.state, AuthState.unauthenticated);
+        await w.destroy();
+      },
+    );
 
     test(
-        'missing nonce claim → nativeCredentialExchangeFailed even when '
+      'nonce mismatch → nativeCredentialExchangeFailed; no exchange',
+      () async {
+        final d = _Deps();
+        final w = d.build();
+        const expected = 'nonce-expected';
+        final idToken = _makeJwt(<String, dynamic>{
+          'iss': 'https://accounts.google.com',
+          'aud': 'c',
+          'sub': 'g-user-1',
+          'nonce': 'nonce-wrong',
+        });
+        await w.init();
+        await expectLater(
+          w.completeNativeCredential(
+            credential: NativeCredentialResult(
+              provider: NativeCredentialProviderKind.google,
+              idToken: idToken,
+              autoSelected: false,
+              nonce: 'nonce-wrong',
+            ),
+            expectedNonce: expected,
+          ),
+          throwsA(
+            isA<AuthError>().having(
+              (e) => e.code,
+              'code',
+              AuthErrorCode.nativeCredentialExchangeFailed,
+            ),
+          ),
+        );
+        expect(d.tokenExchange.idTokenExchangeCalls, 0);
+        expect(w.state, AuthState.unauthenticated);
+        await w.destroy();
+      },
+    );
+
+    test('missing nonce claim → nativeCredentialExchangeFailed even when '
         'credential.nonce is null', () async {
       final d = _Deps();
       final w = d.build();
@@ -816,53 +848,59 @@ void main() {
           ),
           expectedNonce: expected,
         ),
-        throwsA(isA<AuthError>().having(
-          (e) => e.code,
-          'code',
-          AuthErrorCode.nativeCredentialExchangeFailed,
-        )),
+        throwsA(
+          isA<AuthError>().having(
+            (e) => e.code,
+            'code',
+            AuthErrorCode.nativeCredentialExchangeFailed,
+          ),
+        ),
       );
       expect(d.tokenExchange.idTokenExchangeCalls, 0);
       expect(w.state, AuthState.unauthenticated);
       await w.destroy();
     });
 
-    test('exchange failure transitions to unauthenticated and rethrows',
-        () async {
-      final d = _Deps();
-      final w = d.build();
-      const nonce = 'nonce-fail';
-      final idToken = _makeJwt(<String, dynamic>{
-        'iss': 'https://accounts.google.com',
-        'aud': 'c',
-        'sub': 'g-user-1',
-        'nonce': nonce,
-      });
-      d.tokenExchange.idTokenExchangeError = AuthError(
-        AuthErrorCode.tokenExchangeFailed,
-        'boom',
-      );
-
-      await w.init();
-      await expectLater(
-        w.completeNativeCredential(
-          credential: NativeCredentialResult(
-            provider: NativeCredentialProviderKind.google,
-            idToken: idToken,
-            autoSelected: false,
-            nonce: nonce,
-          ),
-          expectedNonce: nonce,
-        ),
-        throwsA(isA<AuthError>().having(
-          (e) => e.code,
-          'code',
+    test(
+      'exchange failure transitions to unauthenticated and rethrows',
+      () async {
+        final d = _Deps();
+        final w = d.build();
+        const nonce = 'nonce-fail';
+        final idToken = _makeJwt(<String, dynamic>{
+          'iss': 'https://accounts.google.com',
+          'aud': 'c',
+          'sub': 'g-user-1',
+          'nonce': nonce,
+        });
+        d.tokenExchange.idTokenExchangeError = AuthError(
           AuthErrorCode.tokenExchangeFailed,
-        )),
-      );
-      expect(w.state, AuthState.unauthenticated);
-      await w.destroy();
-    });
+          'boom',
+        );
+
+        await w.init();
+        await expectLater(
+          w.completeNativeCredential(
+            credential: NativeCredentialResult(
+              provider: NativeCredentialProviderKind.google,
+              idToken: idToken,
+              autoSelected: false,
+              nonce: nonce,
+            ),
+            expectedNonce: nonce,
+          ),
+          throwsA(
+            isA<AuthError>().having(
+              (e) => e.code,
+              'code',
+              AuthErrorCode.tokenExchangeFailed,
+            ),
+          ),
+        );
+        expect(w.state, AuthState.unauthenticated);
+        await w.destroy();
+      },
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

Adds a public `/oauth2/token` facade that exchanges verified **Google/Apple ID tokens** for Hydra-issued Antinvestor sessions, and proxies all ordinary OAuth grants to Hydra unchanged. **Hydra remains the only token issuer.** This is Phase 1 (native credential token-exchange backend) of the [mobile/web One Tap & MFA plan](docs/mobile-web-one-tap-and-mfa-implementation-plan.md).

Disabled by default — double-gated behind `NATIVE_CREDENTIAL_EXCHANGE_ENABLED` (deployment) and per-client `native_auth_enabled` (tenancy property).

## What's included

**Backend**
- `nativecredentials.Verifier` — OIDC issuer registry + JWKS-backed ID-token verification (`iss`/`aud`/`exp`/`iat`/freshness), provider-scoped identity.
- `oauth_token_facade.go` — `/oauth2/token` + `/.well-known/openid-configuration` facade. The native grant verifies the subject token, resolves/links the profile, creates a durable `LoginEvent`, resolves access/roles, and drives the existing headless Hydra authorization-code flow with `BuildUserTokenClaims` (identical token shape to browser login).
- `external_identities` table/model/repository for `(provider, subject)` linking.
- Tenancy client sync enforces the internal FedCM callback redirect URI for `authorization_code` clients.

**Production hardening**
- Per-client provider audience is **required** — no shared global fallback (prevents cross-client audience confusion).
- Facade **fails closed** when the upstream Hydra URL is unset or self-referential (recursion guard), and uses a bounded-timeout Frame HTTP client.
- `/fedcm/token-exchange` binds the one-shot stash to the RP **origin** (a missing `Origin` header no longer bypasses the check) and `client_id`.
- Replay-protected, rate-limited, structured logging on outcomes.
- MFA gate is **not yet enforced** for native exchange (documented in code; tracked in the plan).

**Config:** `NATIVE_CREDENTIAL_EXCHANGE_ENABLED`, `OAUTH2_HYDRA_PUBLIC_INTERNAL_URL`.

**Flutter runtime:** native exchange form carries `installation_id`/`platform`/`device_name`; authorize URL emits repeated `audience` params (test aligned).

## Tests
- Unit coverage: verifier (issuer/claims/validation), facade helpers + endpoints (ordinary-grant proxy, discovery rewrite, recursion guard, native-disabled), `/fedcm/token-exchange` origin/client binding, FedCM callback redirect-URI wiring.
- `go build`, `go vet`, `golangci-lint` (0 issues), new tests pass with `-race`. Flutter: 324 tests pass, `flutter analyze` clean.

## Not in this PR (follow-ups from the plan)
- Hydra integration tests for the native happy path / facade proxying (env-gated suites).
- Web Google **One Tap** (Google Identity Services) on `/s/login` — not wired today; see PR discussion.
- Account-level MFA (factors, challenges, trusted devices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)