### PR TITLE
feat(login): wire Google One Tap / FedCM on the web login page

### DIFF
--- a/apps/default/service/handlers/login_page_google_onetap_internal_test.go
+++ b/apps/default/service/handlers/login_page_google_onetap_internal_test.go
@@ -1,0 +1,111 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// renderLoginPage executes the real login template (loaded from tmpl/ at init)
+// with the given payload and returns the produced HTML.
+func renderLoginPage(t *testing.T, payload map[string]any) string {
+	t.Helper()
+	require.NotNil(t, loginTmpl, "login template must be loaded")
+	var buf bytes.Buffer
+	require.NoError(t, loginTmpl.Execute(&buf, payload))
+	return buf.String()
+}
+
+func baseLoginPayload() map[string]any {
+	return map[string]any{
+		"t":                  map[string]string{},
+		"lang":               "en",
+		"error":              "",
+		"loginEventId":       "le-123",
+		"ClientID":           "antinvestor-client",
+		"GoogleClientID":     "web-client.apps.googleusercontent.com",
+		"FedCMNonce":         "nonce-xyz",
+		"PostHogAPIKey":      "",
+		"PostHogHost":        "",
+		"enableContactLogin": true,
+	}
+}
+
+func TestLoginPageWiresGoogleOneTapWhenEnabled(t *testing.T) {
+	payload := baseLoginPayload()
+	payload["enableGoogleLogin"] = true
+
+	html := renderLoginPage(t, payload)
+
+	// The Google FedCM script is loaded and the install() call is present with
+	// the Google web client ID, the per-login nonce, and the login event id.
+	require.Contains(t, html, "/static/js/fedcm_google.js")
+	require.Contains(t, html, "stawiGoogleFedCM.install")
+	require.Contains(t, html, "web-client.apps.googleusercontent.com")
+	require.Contains(t, html, "nonce-xyz")
+	require.Contains(t, html, "loginEventId: \"le-123\"")
+
+	// The Google form is FedCM-managed and still carries its OAuth-redirect
+	// fallback action so non-FedCM browsers keep working.
+	require.Contains(t, html, "data-fedcm-google")
+	require.Contains(t, html, "/s/social/login/le-123?provider=google")
+
+	// The first-party FedCM probe still runs first (returning-user path).
+	require.Contains(t, html, "stawiFedCM.probeAndComplete")
+}
+
+func TestLoginPageOmitsGoogleOneTapWhenDisabled(t *testing.T) {
+	payload := baseLoginPayload()
+	payload["enableGoogleLogin"] = false
+
+	html := renderLoginPage(t, payload)
+
+	// No Google script, install call, or Google sign-in form when disabled.
+	// (Note: the literal "data-fedcm-google" still appears in the tracking-loop
+	// JS, so assert on the Google-gated markers instead of that attribute name.)
+	require.NotContains(t, html, "fedcm_google.js")
+	require.NotContains(t, html, "stawiGoogleFedCM")
+	require.NotContains(t, html, "provider=google")
+	// First-party FedCM probe is independent of Google and remains.
+	require.Contains(t, html, "stawiFedCM.probeAndComplete")
+}
+
+func TestLoginPageGoogleOneTapClientIDIsGoogleNotHydra(t *testing.T) {
+	// Regression guard: the FedCM clientId passed to Google must be the Google
+	// web client ID, never the Antinvestor/Hydra ClientID (which is used only
+	// for the first-party /fedcm/config.json probe).
+	payload := baseLoginPayload()
+	payload["enableGoogleLogin"] = true
+	payload["GoogleClientID"] = "GOOGLE-AUD"
+	payload["ClientID"] = "HYDRA-CLIENT"
+
+	html := renderLoginPage(t, payload)
+
+	// Scope to the Google install() call: its clientId must be the Google
+	// audience, not the Hydra client (which legitimately appears in the
+	// first-party probe elsewhere on the page).
+	idx := strings.Index(html, "stawiGoogleFedCM.install")
+	require.GreaterOrEqual(t, idx, 0, "google install call must be present")
+	installBlock := html[idx:]
+	require.Contains(t, installBlock, "clientId: \"GOOGLE-AUD\"")
+	require.NotContains(t, installBlock, "clientId: \"HYDRA-CLIENT\"")
+
+	// Sanity: the Hydra client id is still used by the first-party probe.
+	require.Contains(t, html, "clientId: \"HYDRA-CLIENT\"")
+}

--- a/apps/default/tmpl/login.html
+++ b/apps/default/tmpl/login.html
@@ -24,7 +24,7 @@
 <!-- Primary: Sign in with Google -->
 {{if .enableGoogleLogin}}
 <div class="google-hero-section">
-    <form method="post" action="/s/social/login/{{.loginEventId}}?provider=google" class="social-login-form">
+    <form method="post" action="/s/social/login/{{.loginEventId}}?provider=google" class="social-login-form" data-fedcm-google>
         <button type="submit" class="btn-google-hero" aria-label="{{ if .t.aria_continue_with_provider }}{{ .t.aria_continue_with_provider }}{{ else }}Sign in with Google{{ end }}">
             <svg width="20" height="20" viewBox="0 0 48 48" class="social-icon" aria-hidden="true">
                 <path fill="#EA4335" d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"/>
@@ -135,18 +135,39 @@
 </script>
 <script src="/static/js/posthog.js" defer></script>
 <script src="/static/js/fedcm.js" defer></script>
+{{if .enableGoogleLogin}}<script src="/static/js/fedcm_google.js" defer></script>{{end}}
 <script>
   document.addEventListener("DOMContentLoaded", function () {
-    // Same-origin FedCM probe (returning users with idp_session cookie).
-    if (window.stawiFedCM && "{{ .ClientID }}" && "{{ .loginEventId }}") {
-      window.stawiFedCM.probeAndComplete({
-        configURL: "/fedcm/config.json",
-        clientId: "{{ .ClientID }}",
-        nonce: "{{ .FedCMNonce }}",
-        loginEventId: "{{ .loginEventId }}",
-        mediation: "optional",
-      });
-    }
+    // FedCM sign-in waterfall. The first-party probe (returning users with an
+    // idp_session cookie) runs first; if it does not sign the user in, Google
+    // One Tap/FedCM is offered. They run sequentially so the browser never
+    // sees two concurrent navigator.credentials.get() calls.
+    (async function () {
+      var navigated = null;
+      if (window.stawiFedCM && "{{ .ClientID }}" && "{{ .loginEventId }}") {
+        navigated = await window.stawiFedCM.probeAndComplete({
+          configURL: "/fedcm/config.json",
+          clientId: "{{ .ClientID }}",
+          nonce: "{{ .FedCMNonce }}",
+          loginEventId: "{{ .loginEventId }}",
+          mediation: "optional",
+        });
+      }
+      if (navigated) return;
+      {{if .enableGoogleLogin}}
+      // Google One Tap/FedCM. install() binds the Google button for manual
+      // clicks (FedCM-first, native OAuth fallback) and auto-prompts the
+      // account chooser. clientId is the Google web client ID; nonce binds the
+      // returned id_token to this server-issued login event.
+      if (window.stawiGoogleFedCM && "{{ .GoogleClientID }}" && "{{ .loginEventId }}") {
+        window.stawiGoogleFedCM.install({
+          clientId: "{{ .GoogleClientID }}",
+          nonce: "{{ .FedCMNonce }}",
+          loginEventId: "{{ .loginEventId }}",
+        });
+      }
+      {{end}}
+    })();
 
     // Per-method click tracking.
     var trackClick = function (form, method) {
@@ -159,6 +180,9 @@
     };
     trackClick(document.getElementById("contactLoginForm"), "contact");
     document.querySelectorAll("form.social-login-form").forEach(function (f) {
+      // fedcm_google.js owns click tracking for the FedCM-managed Google form;
+      // skip it here so the click is not counted twice.
+      if (f.hasAttribute("data-fedcm-google")) return;
       var action = f.getAttribute("action") || "";
       var match = action.match(/provider=([a-z]+)/);
       var prov = (match && match[1]) || "unknown";


### PR DESCRIPTION
## Summary

Turns on **Google One Tap / FedCM on the hosted `/s/login` page** for web users. This is **front-end wiring only** — the backend was already complete (Phase 3 of the [One Tap & MFA plan](docs/mobile-web-one-tap-and-mfa-implementation-plan.md)).

Before this, `static/js/fedcm_google.js` and the completion endpoint `POST /s/social/google/fedcm-complete` (verifies the Google ID token's `iss`/`aud`/`exp`/signature/`email_verified` and the server-issued nonce, then runs the normal Hydra `AcceptLoginRequest`) both existed — but `login.html` never loaded the script, so clicking "Sign in with Google" only did the OAuth redirect. One Tap was never offered.

## Changes (`tmpl/login.html` only, plus tests)

- Load `fedcm_google.js` when Google is enabled (`enableGoogleLogin`, which is set only when `AUTH_PROVIDER_GOOGLE_CLIENT_ID` is configured).
- Mark the Google form `data-fedcm-google` so the script intercepts clicks (**FedCM first, native OAuth redirect as fallback**) and can auto-prompt the account chooser.
- Call `stawiGoogleFedCM.install({ clientId: GoogleClientID, nonce: FedCMNonce, loginEventId })`. `clientId` is the **Google web client ID** (the FedCM audience); `nonce` is the same per-login nonce the backend verifies against `LoginEvent.fedcm_nonce`.
- Run the first-party FedCM probe and Google FedCM **sequentially** in one async waterfall, so the browser never sees two concurrent `navigator.credentials.get()` calls: returning users complete silently via the `idp_session`; everyone else is offered Google One Tap.
- Delegate Google-button click analytics to `fedcm_google.js` to avoid double-counting `sign_in_method_clicked`.

## Behavior

- **Chrome / FedCM browsers:** One Tap chip (or account chooser) on `/s/login`; on selection the Google ID token is posted to the existing endpoint and the user is signed in without typing a contact.
- **Returning users** with an `idp_session`: still complete via the silent first-party probe first.
- **Non-FedCM browsers / dismissal:** unchanged — the Google button falls back to the OAuth redirect and the contact field stays immediately usable.
- Nothing renders when Google isn't configured.

## Tests
- Login-template **render tests**: wiring present when Google enabled, absent when disabled, and the Google FedCM `clientId` is the Google web client ID (not the Hydra client used by the first-party probe).
- Rendered inline script validated as syntactically correct JS (`node --check`); `fedcm_google.js` / `fedcm.js` unchanged and already valid.
- `go build`, `go vet`, `golangci-lint` (0 issues) pass.

## Notes / follow-ups
- `fedcm_google.js` auto-escalates to the full account chooser on first visit (its existing, documented behavior). If that's too aggressive for web UX, it can be dialed back to One-Tap-chip-only (`mediation: "optional"` without the auto-click) in a follow-up — say the word.
- Apple web button (`AUTH_PROVIDER_APPLE_CLIENT_ID`) is a separate plan item, not included here.
- The repo's `test` CI job is currently red on `main` due to pre-existing testcontainers/event-bus env issues, unrelated to this change (which touches only the login template + a unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)