### PR TITLE
fix(tenancy): move Stawi Jobs redirect URIs to opportunities.stawi.org

### DIFF
--- a/apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql
+++ b/apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql
@@ -35,9 +35,9 @@ INSERT INTO clients (
     '{"types": ["code"]}',
     'openid offline_access profile',
     '{"service_profile":["*"]}',
-    '{"uris":["https://jobs.stawi.org/auth/callback/","https://accounts.stawi.org/_internal/fedcm-callback"]}',
+    '{"uris":["https://opportunities.stawi.org/auth/callback/","https://accounts.stawi.org/_internal/fedcm-callback"]}',
     'https://stawi.org/images/logo.png',
-    '{"uris":["https://jobs.stawi.org/"]}',
+    '{"uris":["https://opportunities.stawi.org/"]}',
     'none'
 ) ON CONFLICT (id) DO NOTHING;
 
@@ -74,8 +74,8 @@ INSERT INTO clients (
     '{"types": ["code"]}',
     'openid offline_access profile',
     '{"service_profile":["*"]}',
-    '{"uris":["https://jobs-dev.stawi.org/auth/callback/","http://localhost:5170/auth/callback/","https://accounts.stawi.org/_internal/fedcm-callback"]}',
+    '{"uris":["https://opportunities-dev.stawi.org/auth/callback/","http://localhost:5170/auth/callback/","https://accounts.stawi.org/_internal/fedcm-callback"]}',
     'https://stawi.org/images/logo.png',
-    '{"uris":["https://jobs-dev.stawi.org/","http://localhost:5170/"]}',
+    '{"uris":["https://opportunities-dev.stawi.org/","http://localhost:5170/"]}',
     'none'
 ) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260604_backfill_stawi_jobs_opportunities_redirect_uris.sql
+++ b/apps/tenancy/migrations/0001/20260604_backfill_stawi_jobs_opportunities_redirect_uris.sql
@@ -1,0 +1,95 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+-- Backfill: rename the Stawi Jobs platform host from jobs.stawi.org to
+-- opportunities.stawi.org (and jobs-dev.stawi.org to
+-- opportunities-dev.stawi.org for the development client) in the redirect
+-- and post-logout URIs.
+--
+-- The seeds use ON CONFLICT (id) DO NOTHING, so already-seeded clusters
+-- still carry the old jobs.stawi.org URIs. This migration rewrites them in
+-- place. Idempotent: each statement's WHERE guard skips clusters that have
+-- already been migrated. Clearing synced_at forces the next sync cycle to
+-- push the corrected URI list to Hydra.
+
+-- ── Production client (Stawi Jobs Web, id d7gi6lkpf2t67dlsqrgg) ───────────
+
+-- Redirect URIs: jobs.stawi.org -> opportunities.stawi.org
+UPDATE clients
+SET redirect_uris = jsonb_set(
+      redirect_uris,
+      '{uris}',
+      (
+        SELECT jsonb_agg(
+          CASE
+            WHEN elem #>> '{}' = 'https://jobs.stawi.org/auth/callback/'
+            THEN to_jsonb('https://opportunities.stawi.org/auth/callback/'::text)
+            ELSE elem
+          END
+        )
+        FROM jsonb_array_elements(redirect_uris -> 'uris') AS elem
+      )
+    ),
+    synced_at = NULL
+WHERE id = 'd7gi6lkpf2t67dlsqrgg'
+  AND redirect_uris -> 'uris' @> '["https://jobs.stawi.org/auth/callback/"]'::jsonb;
+
+-- Post-logout redirect URIs: jobs.stawi.org -> opportunities.stawi.org
+UPDATE clients
+SET post_logout_redirect_uris = jsonb_set(
+      post_logout_redirect_uris,
+      '{uris}',
+      (
+        SELECT jsonb_agg(
+          CASE
+            WHEN elem #>> '{}' = 'https://jobs.stawi.org/'
+            THEN to_jsonb('https://opportunities.stawi.org/'::text)
+            ELSE elem
+          END
+        )
+        FROM jsonb_array_elements(post_logout_redirect_uris -> 'uris') AS elem
+      )
+    ),
+    synced_at = NULL
+WHERE id = 'd7gi6lkpf2t67dlsqrgg'
+  AND post_logout_redirect_uris -> 'uris' @> '["https://jobs.stawi.org/"]'::jsonb;
+
+-- ── Development client (Stawi Jobs Development, id d7gi6ncpf2t7oh5akfr0) ──
+
+-- Redirect URIs: jobs-dev.stawi.org -> opportunities-dev.stawi.org
+UPDATE clients
+SET redirect_uris = jsonb_set(
+      redirect_uris,
+      '{uris}',
+      (
+        SELECT jsonb_agg(
+          CASE
+            WHEN elem #>> '{}' = 'https://jobs-dev.stawi.org/auth/callback/'
+            THEN to_jsonb('https://opportunities-dev.stawi.org/auth/callback/'::text)
+            ELSE elem
+          END
+        )
+        FROM jsonb_array_elements(redirect_uris -> 'uris') AS elem
+      )
+    ),
+    synced_at = NULL
+WHERE id = 'd7gi6ncpf2t7oh5akfr0'
+  AND redirect_uris -> 'uris' @> '["https://jobs-dev.stawi.org/auth/callback/"]'::jsonb;
+
+-- Post-logout redirect URIs: jobs-dev.stawi.org -> opportunities-dev.stawi.org
+UPDATE clients
+SET post_logout_redirect_uris = jsonb_set(
+      post_logout_redirect_uris,
+      '{uris}',
+      (
+        SELECT jsonb_agg(
+          CASE
+            WHEN elem #>> '{}' = 'https://jobs-dev.stawi.org/'
+            THEN to_jsonb('https://opportunities-dev.stawi.org/'::text)
+            ELSE elem
+          END
+        )
+        FROM jsonb_array_elements(post_logout_redirect_uris -> 'uris') AS elem
+      )
+    ),
+    synced_at = NULL
+WHERE id = 'd7gi6ncpf2t7oh5akfr0'
+  AND post_logout_redirect_uris -> 'uris' @> '["https://jobs-dev.stawi.org/"]'::jsonb;


### PR DESCRIPTION
## Summary

The Stawi Jobs platform is served from **opportunities.stawi.org** (prod) and **opportunities-dev.stawi.org** (dev), but the seeded OAuth clients still pointed at `jobs.stawi.org` / `jobs-dev.stawi.org`, so the authorization-code redirect did not match the deployed host (login bounce failed).

## Changes
- **Seed** (`20260420_partition_stawi_jobs.sql`): fresh installs now use the opportunities hosts for both the production (`d7gi6lkpf2t67dlsqrgg`) and development (`d7gi6ncpf2t7oh5akfr0`) clients — `redirect_uris` and `post_logout_redirect_uris`.
- **Backfill** (`20260604_backfill_stawi_jobs_opportunities_redirect_uris.sql`): rewrites the URIs on already-seeded clusters (seeds are `ON CONFLICT DO NOTHING`) and clears `synced_at` to force a Hydra re-sync.

`localhost:5170` and the `/_internal/fedcm-callback` entries are preserved.

## Verification
Applied against Postgres 16: both clients swapped correctly (prod→`opportunities.stawi.org`, dev→`opportunities-dev.stawi.org`), other URIs preserved, `synced_at` cleared, and the migration is idempotent (re-run updates 0 rows).

| client | client_id | partition_id | host |
|--------|-----------|--------------|------|
| Stawi Jobs Web (prod) | `d7is2kspf2t7cl19qlp0` | `d7gi6lkpf2t67dlsqreg` | opportunities.stawi.org |
| Stawi Jobs Development | `d7is2kspf2t7cl19qlpg` | `d7gi6lkpf2t67dlsqrhg` | opportunities-dev.stawi.org |

> Follow-up: deployment-manifest CORS for the opportunities hosts is handled separately in the deployments repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)