### PR TITLE
fix(tenancy): keep thesa.stawi.org as a Thesa Studio redirect URI

### DIFF
--- a/apps/tenancy/migrations/0001/20260420_partition_thesa.sql
+++ b/apps/tenancy/migrations/0001/20260420_partition_thesa.sql
@@ -34,9 +34,9 @@ INSERT INTO clients (
     '{"types": ["code"]}',
     'openid offline_access profile',
     '{"service_tenancy":["*"],"service_device":["*"],"service_profile":["*"],"service_notification":["*"],"service_payment":["*"],"service_ledger":["*"],"service_setting":["*"],"service_file":["*"],"service_trustage":["*"]}',
-    '{"uris":["https://thesa.pages.dev/auth/callback","https://thesa0.web.app/auth/callback","org.stawi.thesa://auth/callback","http://localhost:5173/auth/callback","https://accounts.stawi.org/_internal/fedcm-callback"]}',
+    '{"uris":["https://thesa.stawi.org/auth/callback","https://thesa.pages.dev/auth/callback","https://thesa0.web.app/auth/callback","org.stawi.thesa://auth/callback","http://localhost:5173/auth/callback","https://accounts.stawi.org/_internal/fedcm-callback"]}',
     'https://stawi.org/images/logo.png',
-    '{"uris":["https://thesa.pages.dev/","https://thesa0.web.app/","http://localhost:5173/"]}',
+    '{"uris":["https://thesa.stawi.org/","https://thesa.pages.dev/","https://thesa0.web.app/","http://localhost:5173/"]}',
     'none'
 ) ON CONFLICT (id) DO NOTHING;
 

--- a/apps/tenancy/migrations/0001/20260604_backfill_thesa_studio_restore_thesa_stawi_org_redirect.sql
+++ b/apps/tenancy/migrations/0001/20260604_backfill_thesa_studio_restore_thesa_stawi_org_redirect.sql
@@ -1,0 +1,34 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+-- Backfill: keep https://thesa.stawi.org as a valid Thesa Studio host
+-- alongside the Firebase Hosting URIs (thesa0.web.app, thesa.pages.dev).
+--
+-- 20260527_backfill_thesa_studio_firebase_redirect_uris.sql moved the admin
+-- console to Firebase and dropped thesa.stawi.org. The primary-domain host is
+-- still in use, so re-add it as an additional redirect and post-logout URI.
+--
+-- Additive + idempotent: the WHERE guard skips clients that already contain the
+-- URI, so re-runs are no-ops. Clearing synced_at forces the next sync cycle to
+-- push the updated URI list to Hydra. Client id c2f4j7au6s7f91uqnom0 =
+-- "Thesa Studio".
+
+-- Redirect URI: append https://thesa.stawi.org/auth/callback
+UPDATE clients
+SET redirect_uris = jsonb_set(
+      redirect_uris,
+      '{uris}',
+      (redirect_uris -> 'uris') || '["https://thesa.stawi.org/auth/callback"]'::jsonb
+    ),
+    synced_at = NULL
+WHERE id = 'c2f4j7au6s7f91uqnom0'
+  AND NOT (redirect_uris -> 'uris' @> '["https://thesa.stawi.org/auth/callback"]'::jsonb);
+
+-- Post-logout redirect URI: append https://thesa.stawi.org/
+UPDATE clients
+SET post_logout_redirect_uris = jsonb_set(
+      post_logout_redirect_uris,
+      '{uris}',
+      (post_logout_redirect_uris -> 'uris') || '["https://thesa.stawi.org/"]'::jsonb
+    ),
+    synced_at = NULL
+WHERE id = 'c2f4j7au6s7f91uqnom0'
+  AND NOT (post_logout_redirect_uris -> 'uris' @> '["https://thesa.stawi.org/"]'::jsonb);


### PR DESCRIPTION
## Summary

The Firebase migration (`20260527_backfill_thesa_studio_firebase_redirect_uris.sql`) moved the Thesa Studio admin console to `thesa0.web.app` / `thesa.pages.dev` and **dropped `thesa.stawi.org`** from the Thesa Studio OAuth client's redirect URIs. The primary-domain host is still in use, so restore it **alongside** the Firebase hosts (not instead of).

## Changes
- **Seed** (`20260420_partition_thesa.sql`): add `https://thesa.stawi.org/auth/callback` and `https://thesa.stawi.org/` back to the Thesa Studio client (`c2f4j7au6s7f91uqnom0`) `redirect_uris` / `post_logout_redirect_uris`.
- **Backfill** (`20260604_...restore_thesa_stawi_org_redirect.sql`): additively appends the URIs on already-seeded clusters (idempotent, `WHERE`-guarded) and clears `synced_at` for a Hydra re-sync.

`thesa.stawi.org` is already allowed in CORS on the consuming services, so no CORS change is needed here.

## Verification
Applied against Postgres 16: `thesa.stawi.org` appended, Firebase + localhost + fedcm-callback preserved, `synced_at` cleared, re-run updates 0 rows.

> ⚠️ Note: this re-enables the admin surface on the primary domain, which the Firebase migration had intentionally moved off (to avoid exposing the sensitive admin console on `stawi.org`). Restored by request — flag if that security posture should be revisited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)