### PR TITLE
feat(tenancy): separate Thesa Studio production and staging clients

### DIFF
--- a/apps/tenancy/migrations/0001/20260420_partition_thesa.sql
+++ b/apps/tenancy/migrations/0001/20260420_partition_thesa.sql
@@ -34,9 +34,9 @@ INSERT INTO clients (
     '{"types": ["code"]}',
     'openid offline_access profile',
     '{"service_tenancy":["*"],"service_device":["*"],"service_profile":["*"],"service_notification":["*"],"service_payment":["*"],"service_ledger":["*"],"service_setting":["*"],"service_file":["*"],"service_trustage":["*"]}',
-    '{"uris":["https://thesa.stawi.org/auth/callback","https://thesa.pages.dev/auth/callback","https://thesa0.web.app/auth/callback","org.stawi.thesa://auth/callback","http://localhost:5173/auth/callback","https://accounts.stawi.org/_internal/fedcm-callback"]}',
+    '{"uris":["https://thesa.stawi.org/auth/callback","https://thesa.pages.dev/auth/callback","org.stawi.thesa://auth/callback","http://localhost:5173/auth/callback","https://accounts.stawi.org/_internal/fedcm-callback"]}',
     'https://stawi.org/images/logo.png',
-    '{"uris":["https://thesa.stawi.org/","https://thesa.pages.dev/","https://thesa0.web.app/","http://localhost:5173/"]}',
+    '{"uris":["https://thesa.stawi.org/","https://thesa.pages.dev/","http://localhost:5173/"]}',
     'none'
 ) ON CONFLICT (id) DO NOTHING;
 

--- a/apps/tenancy/migrations/0001/20260604_partition_thesa_staging.sql
+++ b/apps/tenancy/migrations/0001/20260604_partition_thesa_staging.sql
@@ -1,0 +1,59 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+-- Thesa Development — Staging tenant for the Thesa Studio admin console.
+--
+-- All IDs are stable xids registered in apps/tenancy/migrations/IDS.md.
+-- Re-seeding is a no-op (ON CONFLICT DO NOTHING).
+
+INSERT INTO tenants (id, tenant_id, partition_id, name, description, environment)
+VALUES (
+    'd8gueekpf2tfslum7lmg',
+    'd8gueekpf2tfslum7lmg',
+    'd8gueekpf2tfslum7ln0',
+    'Thesa Development',
+    'Staging tenant for the Thesa Studio admin console',
+    'staging'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO partitions (id, tenant_id, partition_id, parent_id, name, description, allow_auto_access, properties)
+VALUES (
+    'd8gueekpf2tfslum7ln0',
+    'd8gueekpf2tfslum7lmg',
+    'd8gueekpf2tfslum7ln0',
+    'd8gueekpf2tfslum7ln0',
+    'Thesa Development',
+    'Staging tenant for the Thesa Studio admin console',
+    true,
+    '{
+      "default_role": "user",
+      "allow_auto_access": true,
+      "support_contacts": {"msisdn": "+256757546244", "email": "info@antinvestor.com"}
+    }'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO partition_roles (id, created_at, modified_at, version, tenant_id, partition_id, name, is_default, properties) VALUES
+  ('d8gueekpf2tfslum7lng',  NOW(), NOW(), 1, 'd8gueekpf2tfslum7lmg', 'd8gueekpf2tfslum7ln0', 'owner',  false, '{"description":"Full control across all services"}'),
+  ('d8gueekpf2tfslum7lo0',  NOW(), NOW(), 1, 'd8gueekpf2tfslum7lmg', 'd8gueekpf2tfslum7ln0', 'admin',  false, '{"description":"Manage partitions, access, roles, and pages"}'),
+  ('d8gueekpf2tfslum7log', NOW(), NOW(), 1, 'd8gueekpf2tfslum7lmg', 'd8gueekpf2tfslum7ln0', 'member', true,  '{"description":"Read-only access, auto-assigned on access creation"}')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO clients (
+    id, tenant_id, partition_id, name, client_id,
+    type, grant_types, response_types, scopes, audiences, redirect_uris,
+    logo_uri, post_logout_redirect_uris, token_endpoint_auth_method
+) VALUES (
+    'd8gueekpf2tfslum7lp0',
+    'd8gueekpf2tfslum7lmg', 'd8gueekpf2tfslum7ln0',
+    'Thesa Studio Development',
+    'd8gueekpf2tfslum7lpg',
+    'public',
+    '{"types": ["authorization_code","refresh_token"]}',
+    '{"types": ["code"]}',
+    'openid offline_access profile',
+    '{"service_tenancy":["*"],"service_device":["*"],"service_profile":["*"],"service_notification":["*"],"service_payment":["*"],"service_ledger":["*"],"service_setting":["*"],"service_file":["*"],"service_trustage":["*"]}',
+    '{"uris":["https://thesa-dev.stawi.org/auth/callback","https://thesa0.web.app/auth/callback","org.stawi.thesa://auth/callback","http://localhost:5173/auth/callback","https://accounts.stawi.org/_internal/fedcm-callback"]}',
+    'https://stawi.org/images/logo.png',
+    '{"uris":["https://thesa-dev.stawi.org/","https://thesa0.web.app/","http://localhost:5173/"]}',
+    'none'
+) ON CONFLICT (id) DO NOTHING;

--- a/apps/tenancy/migrations/0001/20260605_backfill_thesa_studio_drop_staging_host.sql
+++ b/apps/tenancy/migrations/0001/20260605_backfill_thesa_studio_drop_staging_host.sql
@@ -1,0 +1,45 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+-- Backfill: remove the staging host https://thesa0.web.app from the PRODUCTION
+-- Thesa Studio client. thesa0.web.app is a staging origin and now belongs to
+-- the dedicated "Thesa Studio Development" client (20260604_partition_thesa_staging.sql);
+-- production keeps only thesa.stawi.org and thesa.pages.dev.
+--
+-- Idempotent: the WHERE guard skips clients that no longer contain the URI.
+-- Clearing synced_at forces the next sync cycle to push the trimmed URI list
+-- to Hydra. Client id c2f4j7au6s7f91uqnom0 = production "Thesa Studio".
+
+-- Redirect URIs: drop https://thesa0.web.app/auth/callback
+UPDATE clients
+SET redirect_uris = jsonb_set(
+      redirect_uris,
+      '{uris}',
+      COALESCE(
+        (
+          SELECT jsonb_agg(elem)
+          FROM jsonb_array_elements(redirect_uris -> 'uris') AS elem
+          WHERE elem #>> '{}' <> 'https://thesa0.web.app/auth/callback'
+        ),
+        '[]'::jsonb
+      )
+    ),
+    synced_at = NULL
+WHERE id = 'c2f4j7au6s7f91uqnom0'
+  AND redirect_uris -> 'uris' @> '["https://thesa0.web.app/auth/callback"]'::jsonb;
+
+-- Post-logout redirect URIs: drop https://thesa0.web.app/
+UPDATE clients
+SET post_logout_redirect_uris = jsonb_set(
+      post_logout_redirect_uris,
+      '{uris}',
+      COALESCE(
+        (
+          SELECT jsonb_agg(elem)
+          FROM jsonb_array_elements(post_logout_redirect_uris -> 'uris') AS elem
+          WHERE elem #>> '{}' <> 'https://thesa0.web.app/'
+        ),
+        '[]'::jsonb
+      )
+    ),
+    synced_at = NULL
+WHERE id = 'c2f4j7au6s7f91uqnom0'
+  AND post_logout_redirect_uris -> 'uris' @> '["https://thesa0.web.app/"]'::jsonb;

--- a/apps/tenancy/migrations/IDS.md
+++ b/apps/tenancy/migrations/IDS.md
@@ -23,6 +23,7 @@ configuration.
 ## Tenants
 | xid | name | file |
 |-----|------|------|
+| d8gueekpf2tfslum7lmg | Thesa Development | apps/tenancy/migrations/0001/20260604_partition_thesa_staging.sql |
 | c2f4j7au6s7f91uqnojg | Thesa | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
 | 9bsv0s0hijjg02z5lbjg | Stawi | apps/tenancy/migrations/0001/20260420_partition_stawi.sql |
 | 9bsv0s0hijjg09bzz6dg | Stawi Development | apps/tenancy/migrations/0001/20260420_partition_stawi.sql |
@@ -36,6 +37,7 @@ configuration.
 ## Partitions
 | xid | tenant | parent | file |
 |-----|--------|--------|------|
+| d8gueekpf2tfslum7ln0 | d8gueekpf2tfslum7lmg | d8gueekpf2tfslum7ln0 | apps/tenancy/migrations/0001/20260604_partition_thesa_staging.sql |
 | c2f4j7au6s7f91uqnokg | c2f4j7au6s7f91uqnojg | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
 | d7b4qekpf2tshigkrv60 | c2f4j7au6s7f91uqnojg | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
 | 9bsv0s0hijjg02qk7l1g | 9bsv0s0hijjg02z5lbjg | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_stawi.sql |
@@ -51,6 +53,7 @@ configuration.
 ## Clients (OAuth2)
 | xid | client_id (xid) | partition | file |
 |-----|-----------------|-----------|------|
+| d8gueekpf2tfslum7lp0 | d8gueekpf2tfslum7lpg | d8gueekpf2tfslum7ln0 | apps/tenancy/migrations/0001/20260604_partition_thesa_staging.sql |
 | c2f4j7au6s7f91uqnom0 | c2f4j7au6s7f91uqnomg | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
 | d7b4qekpf2tshigkrv80 | d7b4qekpf2tshigkrv8g | d7b4qekpf2tshigkrv60 | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
 | d6l82t4pf2t82gudn7tg | d6qbqdkpf2t52mcunf40 | 9bsv0s0hijjg02qk7l1g | apps/tenancy/migrations/0001/20260420_partition_stawi.sql |
@@ -140,6 +143,9 @@ configuration.
 ## Partition roles
 | xid | role | partition | file |
 |-----|------|-----------|------|
+| d8gueekpf2tfslum7log | member | d8gueekpf2tfslum7ln0 | apps/tenancy/migrations/0001/20260604_partition_thesa_staging.sql |
+| d8gueekpf2tfslum7lo0 | admin  | d8gueekpf2tfslum7ln0 | apps/tenancy/migrations/0001/20260604_partition_thesa_staging.sql |
+| d8gueekpf2tfslum7lng | owner  | d8gueekpf2tfslum7ln0 | apps/tenancy/migrations/0001/20260604_partition_thesa_staging.sql |
 | c2f4j7au6s7f91uqnol0 | owner  | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
 | c2f4j7au6s7f91uqnol1 | admin  | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |
 | c2f4j7au6s7f91uqnol2 | member | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260420_partition_thesa.sql |


### PR DESCRIPTION
## Summary

Splits Thesa Studio into dedicated production and staging clients per the confirmed host/env mapping:

| Env | Hosts |
|-----|-------|
| **production** | `thesa.stawi.org`, `thesa.pages.dev` |
| **staging** | `thesa-dev.stawi.org`, `thesa0.web.app` |

## Changes
- **New staging tenant/partition/client** (`20260604_partition_thesa_staging.sql`, scaffolded via `tools/migrations/new-partition.sh`): "Thesa Development" tenant → "Thesa Studio Development" client (`client_id d8gueekpf2tfslum7lpg`) with redirect URIs `thesa-dev.stawi.org` + `thesa0.web.app` (+ native, localhost, fedcm). New xids registered in `IDS.md`.
- **Production "Thesa Studio"** (`c2f4j7au6s7f91uqnom0`): `thesa0.web.app` removed from the seed (keeps `thesa.stawi.org` + `thesa.pages.dev`) and dropped from already-seeded clusters via an idempotent backfill (`20260605_backfill_thesa_studio_drop_staging_host.sql`, clears `synced_at`).

## Verification
Postgres 16: staging client created with the staging hosts; prod client trimmed to `thesa.stawi.org` + `thesa.pages.dev`; backfill idempotent (re-run updates 0). `check-ids` passes (IDS.md in sync).

> Note: the staging Studio gets its own tenant/partition claims (not the platform root), matching how every other app's dev environment is structured. If the staging admin console needs root-equivalent access grants, that's handled via ReBAC access, not the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)