### PR TITLE
fix(tenancy): rename Stawi Jobs to Stawi Opportunities

### DIFF
--- a/apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql
+++ b/apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql
@@ -1,16 +1,16 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Stawi Jobs — remote job board platform for Africa and beyond.
+-- Stawi Opportunities — remote opportunities platform for Africa and beyond.
 -- Includes both production and development/test environments.
 
 -- Production tenant
 INSERT INTO tenants (id, tenant_id, partition_id, name, description, environment)
 VALUES ('d7gi6lkpf2t67dlsqre0','c2f4j7au6s7f91uqnojg','c2f4j7au6s7f91uqnokg',
-        'Stawi Jobs','Remote job board platform for Africa and beyond','production')
+        'Stawi Opportunities','Remote opportunities platform for Africa and beyond','production')
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO partitions (id, tenant_id, partition_id, parent_id, name, description, allow_auto_access, properties)
 VALUES ('d7gi6lkpf2t67dlsqreg','d7gi6lkpf2t67dlsqre0','d7gi6lkpf2t67dlsqreg','c2f4j7au6s7f91uqnokg',
-        'Stawi Jobs','Remote job board platform',true,
+        'Stawi Opportunities','Remote opportunities platform',true,
         '{"default_role":"user","allow_auto_access":true,"support_contacts":{"email":"hello@stawi.jobs"}}')
 ON CONFLICT (id) DO NOTHING;
 
@@ -28,7 +28,7 @@ INSERT INTO clients (
 ) VALUES (
     'd7gi6lkpf2t67dlsqrgg',
     'd7gi6lkpf2t67dlsqre0','d7gi6lkpf2t67dlsqreg',
-    'Stawi Jobs Web',
+    'Stawi Opportunities Web',
     'd7is2kspf2t7cl19qlp0',
     'public',
     '{"types": ["authorization_code","refresh_token"]}',
@@ -44,12 +44,12 @@ INSERT INTO clients (
 -- Development/test tenant
 INSERT INTO tenants (id, tenant_id, partition_id, name, description, environment)
 VALUES ('d7gi6lkpf2t67dlsqrh0','c2f4j7au6s7f91uqnojg','c2f4j7au6s7f91uqnokg',
-        'Stawi Jobs Development','Remote job board platform for Africa and beyond','staging')
+        'Stawi Opportunities Development','Remote opportunities platform for Africa and beyond','staging')
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO partitions (id, tenant_id, partition_id, parent_id, name, description, allow_auto_access, properties)
 VALUES ('d7gi6lkpf2t67dlsqrhg','d7gi6lkpf2t67dlsqrh0','d7gi6lkpf2t67dlsqrhg','c2f4j7au6s7f91uqnokg',
-        'Stawi Jobs Development','Remote job board platform',true,
+        'Stawi Opportunities Development','Remote opportunities platform',true,
         '{"default_role":"user","allow_auto_access":true,"support_contacts":{"email":"hello@stawi.jobs"}}')
 ON CONFLICT (id) DO NOTHING;
 
@@ -67,7 +67,7 @@ INSERT INTO clients (
 ) VALUES (
     'd7gi6ncpf2t7oh5akfr0',
     'd7gi6lkpf2t67dlsqrh0','d7gi6lkpf2t67dlsqrhg',
-    'Stawi Jobs Development',
+    'Stawi Opportunities Development',
     'd7is2kspf2t7cl19qlpg',
     'public',
     '{"types": ["authorization_code","refresh_token"]}',

--- a/apps/tenancy/migrations/0001/20260605_backfill_rename_stawi_jobs_to_opportunities.sql
+++ b/apps/tenancy/migrations/0001/20260605_backfill_rename_stawi_jobs_to_opportunities.sql
@@ -1,0 +1,27 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+-- Backfill: rename the "Stawi Jobs" tenant/partition/client display names to
+-- "Stawi Opportunities" for consistency with the opportunities.stawi.org
+-- rebrand. The seeds use ON CONFLICT (id) DO NOTHING, so the renamed seed only
+-- affects fresh installs; this migration updates already-seeded clusters.
+--
+-- Idempotent: after the rename no row matches LIKE 'Stawi Jobs%', so re-runs
+-- are no-ops. Clearing clients.synced_at forces the next sync cycle to push the
+-- new client_name to Hydra. Affected xids (see IDS.md):
+--   tenants     d7gi6lkpf2t67dlsqre0, d7gi6lkpf2t67dlsqrh0
+--   partitions  d7gi6lkpf2t67dlsqreg, d7gi6lkpf2t67dlsqrhg
+--   clients     d7gi6lkpf2t67dlsqrgg, d7gi6ncpf2t7oh5akfr0
+
+UPDATE tenants
+SET name = replace(name, 'Stawi Jobs', 'Stawi Opportunities'),
+    description = replace(description, 'job board', 'opportunities')
+WHERE name LIKE 'Stawi Jobs%';
+
+UPDATE partitions
+SET name = replace(name, 'Stawi Jobs', 'Stawi Opportunities'),
+    description = replace(description, 'job board', 'opportunities')
+WHERE name LIKE 'Stawi Jobs%';
+
+UPDATE clients
+SET name = replace(name, 'Stawi Jobs', 'Stawi Opportunities'),
+    synced_at = NULL
+WHERE name LIKE 'Stawi Jobs%';

--- a/apps/tenancy/migrations/IDS.md
+++ b/apps/tenancy/migrations/IDS.md
@@ -30,8 +30,8 @@ configuration.
 | 9bsv0s0hijjghdbz96dg | Stawi AI Builder Development | apps/tenancy/migrations/0001/20260420_partition_stawi_dev.sql |
 | d6q1aekpf2taeg5iovp0 | Ant Investor | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
 | d6q1aekpf2taeg5iovqg | Ant Investor Development | apps/tenancy/migrations/0001/20260420_partition_ant_investor.sql |
-| d7gi6lkpf2t67dlsqre0 | Stawi Jobs | apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql |
-| d7gi6lkpf2t67dlsqrh0 | Stawi Jobs Development | apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql |
+| d7gi6lkpf2t67dlsqre0 | Stawi Opportunities | apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql |
+| d7gi6lkpf2t67dlsqrh0 | Stawi Opportunities Development | apps/tenancy/migrations/0001/20260420_partition_stawi_jobs.sql |
 
 ## Partitions
 | xid | tenant | parent | file |


### PR DESCRIPTION
## Summary

Renames the "Stawi Jobs" tenant/partition/client display names to **"Stawi Opportunities"** (prod + dev) for consistency with the `opportunities.stawi.org` rebrand. The xids and `client_id`s are unchanged — only display names/descriptions.

## Changes
- **Seed** (`20260420_partition_stawi_jobs.sql`): names + descriptions renamed (fresh installs).
- **IDS.md**: registry names updated.
- **Backfill** (`20260605_backfill_rename_stawi_jobs_to_opportunities.sql`): updates names/descriptions on already-seeded clusters (seeds are `ON CONFLICT DO NOTHING`) and clears `clients.synced_at` to push the new `client_name` to Hydra.

| entity | client_id / xid | new name |
|--------|-----------------|----------|
| client (prod) | `d7is2kspf2t7cl19qlp0` | Stawi Opportunities Web |
| client (dev) | `d7is2kspf2t7cl19qlpg` | Stawi Opportunities Development |
| tenant/partition (prod) | `d7gi6lkpf2t67dlsqre0` / `…reg` | Stawi Opportunities |
| tenant/partition (dev) | `d7gi6lkpf2t67dlsqrh0` / `…rhg` | Stawi Opportunities Development |

## Verification
Postgres 16: all six entities renamed, descriptions updated, `synced_at` cleared, re-run updates 0 rows. `check-ids` passes; no Go code references the display name.

> `DIFF_NOTES.md` keeps its two "Stawi Jobs frontend" references as historical rollout notes (documenting a past client_id change), not renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)