### PR TITLE
test: exercise Postgres RLS and add cross-tenant isolation tests

### DIFF
--- a/apps/audit/service/repository/migrate.go
+++ b/apps/audit/service/repository/migrate.go
@@ -25,7 +25,10 @@ import (
 // SQL migration files found at migrationPath.
 func Migrate(ctx context.Context, dbManager datastore.Manager, migrationPath string) error {
 	pool := dbManager.GetPool(ctx, datastore.DefaultMigrationPoolName)
+	// Models must be passed as pointers: tenancy enrollment checks for the
+	// tenancy.Tenanted interface whose methods have pointer receivers, so
+	// value models silently skip RLS policy installation.
 	return dbManager.Migrate(ctx, pool, migrationPath,
-		models.AuditEntry{},
+		&models.AuditEntry{},
 	)
 }

--- a/apps/default/service/repository/tenant_isolation_test.go
+++ b/apps/default/service/repository/tenant_isolation_test.go
@@ -1,0 +1,133 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/antinvestor/service-authentication/apps/default/service/models"
+	"github.com/antinvestor/service-authentication/apps/default/tests"
+	"github.com/pitabwire/frame/frametests/definition"
+	"github.com/pitabwire/frame/security"
+	"github.com/pitabwire/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// TenantIsolationTestSuite exercises Postgres row level security across
+// tenants. The base suite wires frametests/rlstest so application queries
+// run as a non-superuser role — without that, the testcontainer superuser
+// bypasses FORCE ROW LEVEL SECURITY and these assertions would pass
+// vacuously even if the policies were broken.
+type TenantIsolationTestSuite struct {
+	tests.BaseTestSuite
+}
+
+func TestTenantIsolationTestSuite(t *testing.T) {
+	suite.Run(t, new(TenantIsolationTestSuite))
+}
+
+// tenantCtx builds a context carrying authentication claims for the given
+// tenant/partition. It deliberately starts from the raw test context —
+// the context returned by CreateService carries the skip-tenancy flag for
+// fixture setup and would bypass RLS scoping.
+func tenantCtx(t *testing.T, tenantID, partitionID string) context.Context {
+	claims := &security.AuthenticationClaims{
+		TenantID:    tenantID,
+		PartitionID: partitionID,
+		AccessID:    util.IDString(),
+		SessionID:   util.IDString(),
+	}
+	claims.Subject = "user-" + tenantID
+	return claims.ClaimsToContext(t.Context())
+}
+
+func (suite *TenantIsolationTestSuite) TestLogin_CrossTenantReadsReturnNothing() {
+	suite.WithTestDependancies(suite.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		_, _, deps := suite.CreateService(t, dep)
+		repo := deps.LoginRepo
+
+		ctxA := tenantCtx(t, "tenant-iso-a", "partition-iso-a")
+		ctxB := tenantCtx(t, "tenant-iso-b", "partition-iso-b")
+
+		login := &models.Login{
+			ProfileID: "profile-iso-a",
+			Source:    string(models.LoginSourceDirect),
+		}
+		require.NoError(t, repo.Create(ctxA, login))
+		require.NotEmpty(t, login.ID)
+		require.Equal(t, "tenant-iso-a", login.TenantID,
+			"row must be stamped with the creating tenant")
+
+		// Tenant A sees its own row through the restricted role.
+		own, err := repo.GetByProfileID(ctxA, login.ProfileID)
+		require.NoError(t, err)
+		require.Equal(t, login.ID, own.ID)
+
+		// Tenant B must not see tenant A's login by any lookup path.
+		_, err = repo.GetByProfileID(ctxB, login.ProfileID)
+		require.Error(t, err, "cross-tenant GetByProfileID must not return tenant A's login")
+
+		// A claim-less context keeps match-all semantics (system path).
+		all, err := repo.GetByProfileID(t.Context(), login.ProfileID)
+		require.NoError(t, err)
+		assert.Equal(t, login.ID, all.ID)
+	})
+}
+
+func (suite *TenantIsolationTestSuite) TestLoginEvent_CrossTenantReadsReturnNothing() {
+	suite.WithTestDependancies(suite.T(), func(t *testing.T, dep *definition.DependencyOption) {
+		_, _, deps := suite.CreateService(t, dep)
+		repo := deps.LoginEventRepo
+
+		ctxA := tenantCtx(t, "tenant-iso-a", "partition-iso-a")
+		ctxB := tenantCtx(t, "tenant-iso-b", "partition-iso-b")
+
+		event := &models.LoginEvent{
+			ProfileID:        "profile-iso-a",
+			LoginID:          util.IDString(),
+			LoginChallengeID: "challenge-iso-a",
+			ContactID:        util.IDString(),
+			Status:           1,
+		}
+		require.NoError(t, repo.Create(ctxA, event))
+		require.NotEmpty(t, event.ID)
+		require.Equal(t, "tenant-iso-a", event.TenantID,
+			"row must be stamped with the creating tenant")
+
+		// Tenant A sees its own event through the restricted role.
+		own, err := repo.GetByLoginChallenge(ctxA, event.LoginChallengeID)
+		require.NoError(t, err)
+		require.NotNil(t, own)
+		require.Equal(t, event.ID, own.ID)
+
+		// Tenant B must not see tenant A's event by any lookup path.
+		crossChallenge, err := repo.GetByLoginChallenge(ctxB, event.LoginChallengeID)
+		require.NoError(t, err)
+		assert.Nil(t, crossChallenge, "cross-tenant GetByLoginChallenge must not return tenant A's event")
+
+		crossRecent, err := repo.GetMostRecentByProfileID(ctxB, event.ProfileID)
+		require.NoError(t, err)
+		assert.Nil(t, crossRecent, "cross-tenant GetMostRecentByProfileID must not return tenant A's event")
+
+		// A claim-less context keeps match-all semantics (system path).
+		all, err := repo.GetByLoginChallenge(t.Context(), event.LoginChallengeID)
+		require.NoError(t, err)
+		require.NotNil(t, all)
+		assert.Equal(t, event.ID, all.ID)
+	})
+}

--- a/apps/default/tests/base_testsuite.go
+++ b/apps/default/tests/base_testsuite.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pitabwire/frame/frametests"
 	"github.com/pitabwire/frame/frametests/definition"
 	"github.com/pitabwire/frame/frametests/deps/testpostgres"
+	"github.com/pitabwire/frame/frametests/rlstest"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/util"
 	"github.com/stretchr/testify/require"
@@ -267,7 +268,15 @@ func (bs *BaseTestSuite) CreateService(
 	err = ensureHydraServiceClients(ctx, cfg.Oauth2ServiceAdminURI)
 	require.NoError(t, err)
 
+	// The postgres testcontainer user is a SUPERUSER which bypasses RLS even
+	// with FORCE ROW LEVEL SECURITY, so tenancy isolation would never be
+	// exercised. rlstest drops application connections to an unprivileged
+	// role after migration so the suite runs with RLS actually enforced.
+	require.NoError(t, rlstest.CreateRole(ctx, testDS.String()))
+	rlsProv := rlstest.New()
+
 	opts := []frame.Option{frame.WithName("authentication_tests"), frame.WithConfig(&cfg),
+		frame.WithTenancyProvider(rlsProv),
 		frame.WithDatastore(), frame.WithCache(cfg.CacheName, cache.NewInMemoryCache())}
 
 	if bs.handler != nil {
@@ -294,6 +303,11 @@ func (bs *BaseTestSuite) CreateService(
 
 	err = repository.Migrate(ctx, svc.DatastoreManager(), "../../migrations/0001")
 	require.NoError(t, err)
+
+	// Migration ran as superuser; grant the restricted role access to the
+	// migrated tables, then switch all application queries to it.
+	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
+	rlsProv.Enable()
 
 	go func() {
 		_ = svc.Run(ctx, "")

--- a/apps/tenancy/service/business/partition.go
+++ b/apps/tenancy/service/business/partition.go
@@ -176,7 +176,15 @@ func (pb *partitionBusiness) GetPartition(
 
 func (pb *partitionBusiness) GetPartitionParents(ctx context.Context, request *tenancyv1.GetPartitionParentsRequest) ([]*tenancyv1.PartitionObject, error) {
 
-	parentList, err := pb.partitionRepo.GetParents(ctx, request.GetId())
+	// Confirm the requested partition is visible under the caller's tenancy
+	// scope before traversing. Ancestor partitions carry their own
+	// partition_id, so the recursive walk itself has to run on the system
+	// path — RLS would otherwise filter out every parent row.
+	if _, err := pb.partitionRepo.GetByID(ctx, request.GetId()); err != nil {
+		return nil, err
+	}
+
+	parentList, err := pb.partitionRepo.GetParents(security.SkipTenancyChecksOnClaims(ctx), request.GetId())
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +226,12 @@ func (pb *partitionBusiness) CreatePartition(
 	partition.TenantID = tenant.GetID()
 	partition.PartitionID = tenant.PartitionID
 
-	err = pb.partitionRepo.Create(ctx, partition)
+	// Creating a partition is an administrative write into the target
+	// tenant's scope: the row is stamped with the tenant being extended,
+	// not the caller's own tenancy, so the insert must run on the system
+	// path. Authorisation is enforced upstream (Keto) and the scoped
+	// GetByID above proved the caller can see the target tenant.
+	err = pb.partitionRepo.Create(security.SkipTenancyChecksOnClaims(ctx), partition)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/tenancy/service/repository/migrate.go
+++ b/apps/tenancy/service/repository/migrate.go
@@ -29,8 +29,11 @@ func Migrate(ctx context.Context, dbManager datastore.Manager, migrationPath str
 		return errors.New("datastore pool is not initialised")
 	}
 
+	// Models must be passed as pointers: tenancy enrollment checks for the
+	// tenancy.Tenanted interface whose methods have pointer receivers, so
+	// value models silently skip RLS policy installation.
 	return dbManager.Migrate(ctx, pool, migrationPath,
-		models.Tenant{}, models.Partition{}, models.PartitionRole{},
-		models.Access{}, models.AccessRole{}, models.Page{},
-		models.Client{}, models.ServiceAccount{}, models.ServiceNamespace{})
+		&models.Tenant{}, &models.Partition{}, &models.PartitionRole{},
+		&models.Access{}, &models.AccessRole{}, &models.Page{},
+		&models.Client{}, &models.ServiceAccount{}, &models.ServiceNamespace{})
 }

--- a/apps/tenancy/tests/base_testsuite.go
+++ b/apps/tenancy/tests/base_testsuite.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pitabwire/frame/frametests/definition"
 	"github.com/pitabwire/frame/frametests/deps/testnats"
 	"github.com/pitabwire/frame/frametests/deps/testpostgres"
+	"github.com/pitabwire/frame/frametests/rlstest"
 	"github.com/pitabwire/frame/security"
 	"github.com/pitabwire/util"
 	"github.com/stretchr/testify/require"
@@ -258,8 +259,11 @@ func (bs *BaseTestSuite) createServiceInternal(
 	cfg.DatabaseMigrate = true
 	cfg.DatabaseTraceQueries = true
 
+	// Migrate pins a dedicated connection for its advisory lock (frame
+	// >= v1.95) and runs the migration queries on a second one, so a
+	// single-connection pool deadlocks before the first table exists.
 	testDSLimited := testDS.
-		ExtendQuery("pool_max_conns", "1").
+		ExtendQuery("pool_max_conns", "2").
 		ExtendQuery("pool_min_conns", "0").
 		ExtendQuery("pool_max_conn_lifetime", "1s").
 		ExtendQuery("pool_max_conn_idle_time", "200ms").
@@ -287,8 +291,16 @@ func (bs *BaseTestSuite) createServiceInternal(
 	cfg.AuthorizationServiceReadURI = bs.ketoReadURI
 	cfg.AuthorizationServiceWriteURI = bs.ketoWriteURI
 
+	// The postgres testcontainer user is a SUPERUSER which bypasses RLS even
+	// with FORCE ROW LEVEL SECURITY, so tenancy isolation would never be
+	// exercised. rlstest drops application connections to an unprivileged
+	// role after migration so the suite runs with RLS actually enforced.
+	require.NoError(t, rlstest.CreateRole(ctx, testDS.String()))
+	rlsProv := rlstest.New()
+
 	ctx, svc := frame.NewServiceWithContext(ctx, frame.WithName("tenancy tests"),
-		frame.WithConfig(&cfg), frame.WithDatastore(), frametests.WithNoopDriver())
+		frame.WithConfig(&cfg), frame.WithTenancyProvider(rlsProv),
+		frame.WithDatastore(), frametests.WithNoopDriver())
 
 	auth := svc.SecurityManager().GetAuthorizer(ctx)
 	implementation := handlers.NewTenancyServer(ctx, svc, auth, nil)
@@ -316,6 +328,11 @@ func (bs *BaseTestSuite) createServiceInternal(
 	err = repository.Migrate(ctx, svc.DatastoreManager(), "../../migrations/0001")
 	require.NoError(t, err)
 	svc.DatastoreManager().RemovePool(ctx, datastore.DefaultMigrationPoolName)
+
+	// Migration ran as superuser; grant the restricted role access to the
+	// migrated tables, then switch all application queries to it.
+	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
+	rlsProv.Enable()
 
 	_ = svc.Run(ctx, "")
 

--- a/apps/tenancy/tests/tenant_isolation_test.go
+++ b/apps/tenancy/tests/tenant_isolation_test.go
@@ -1,0 +1,114 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/antinvestor/service-authentication/apps/tenancy/service/models"
+	"github.com/pitabwire/frame/frametests/definition"
+	"github.com/pitabwire/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// TenantIsolationTestSuite exercises Postgres row level security across
+// tenants. The base suite wires frametests/rlstest so application queries
+// run as a non-superuser role — without that, the testcontainer superuser
+// bypasses FORCE ROW LEVEL SECURITY and these assertions would pass
+// vacuously even if the policies were broken.
+type TenantIsolationTestSuite struct {
+	BaseTestSuite
+}
+
+func TestTenantIsolationTestSuite(t *testing.T) {
+	suite.Run(t, new(TenantIsolationTestSuite))
+}
+
+func (suite *TenantIsolationTestSuite) TestPartition_CrossTenantReadsReturnNothing() {
+	t := suite.T()
+	ctx, _, deps := suite.CreateService(t, definition.NewDependancyOption("partition_isolation", util.RandomAlphaNumericString(8), nil))
+	repo := deps.PartitionRepo
+
+	ctxA := suite.WithAuthClaims(ctx, "tenant-iso-a", "partition-iso-a", "profile-a")
+	ctxB := suite.WithAuthClaims(ctx, "tenant-iso-b", "partition-iso-b", "profile-b")
+
+	partition := &models.Partition{
+		Name:        "tenant-a-private-partition",
+		Description: "visible to tenant A only",
+		State:       1,
+	}
+	partition.GenID(ctxA)
+	require.NoError(t, repo.Create(ctxA, partition))
+	require.Equal(t, "tenant-iso-a", partition.TenantID,
+		"row must be stamped with the creating tenant")
+
+	// Tenant A sees its own partition through the restricted role.
+	own, err := repo.GetByID(ctxA, partition.GetID())
+	require.NoError(t, err)
+	require.Equal(t, partition.GetID(), own.GetID())
+
+	// Tenant B must not see tenant A's partition by any lookup path.
+	_, err = repo.GetByID(ctxB, partition.GetID())
+	require.Error(t, err, "cross-tenant GetByID must not return tenant A's partition")
+
+	count, err := repo.CountByTenantID(ctxB, "tenant-iso-a")
+	require.NoError(t, err)
+	assert.Zero(t, count, "cross-tenant count must not include tenant A's partitions")
+
+	// A claim-less context keeps match-all semantics (system path).
+	all, err := repo.GetByID(ctx, partition.GetID())
+	require.NoError(t, err)
+	assert.Equal(t, partition.GetID(), all.GetID())
+}
+
+func (suite *TenantIsolationTestSuite) TestAccess_CrossTenantReadsReturnNothing() {
+	t := suite.T()
+	ctx, _, deps := suite.CreateService(t, definition.NewDependancyOption("access_isolation", util.RandomAlphaNumericString(8), nil))
+	accessRepo := deps.AccessRepo
+
+	ctxA := suite.WithAuthClaims(ctx, "tenant-iso-a", "partition-iso-a", "profile-a")
+	ctxB := suite.WithAuthClaims(ctx, "tenant-iso-b", "partition-iso-b", "profile-b")
+
+	access := &models.Access{
+		ProfileID: "profile-iso-a",
+		State:     1,
+	}
+	access.GenID(ctxA)
+	require.NoError(t, accessRepo.Create(ctxA, access))
+	require.Equal(t, "tenant-iso-a", access.TenantID,
+		"row must be stamped with the creating tenant")
+	require.Equal(t, "partition-iso-a", access.PartitionID,
+		"row must be stamped with the creating partition")
+
+	// Tenant A sees its own access through the restricted role.
+	own, err := accessRepo.GetByPartitionAndProfile(ctxA, access.PartitionID, access.ProfileID)
+	require.NoError(t, err)
+	require.Equal(t, access.GetID(), own.GetID())
+
+	// Tenant B must not see tenant A's access by any lookup path.
+	_, err = accessRepo.GetByPartitionAndProfile(ctxB, access.PartitionID, access.ProfileID)
+	require.Error(t, err, "cross-tenant GetByPartitionAndProfile must not return tenant A's access")
+
+	crossList, err := accessRepo.ListByProfileID(ctxB, access.ProfileID)
+	require.NoError(t, err)
+	assert.Empty(t, crossList, "cross-tenant list must not contain tenant A's access records")
+
+	// A claim-less context keeps match-all semantics (system path).
+	allList, err := accessRepo.ListByProfileID(ctx, access.ProfileID)
+	require.NoError(t, err)
+	assert.Len(t, allList, 1)
+}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.54.2
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame v1.98.1
+	github.com/pitabwire/frame v1.98.2
 	github.com/pitabwire/util v0.9.1
 	github.com/posthog/posthog-go v1.15.0
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -222,8 +222,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame v1.98.1 h1:MdHUk9ux0XTgrerATnpQ5nC3iT0v7MXFEbChQ91/FEc=
-github.com/pitabwire/frame v1.98.1/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
+github.com/pitabwire/frame v1.98.2 h1:Kv/9w4+P/2En9hGBrXawNPOk0DMwek8HUg0A21WMnu8=
+github.com/pitabwire/frame v1.98.2/go.mod h1:k6TV0rPXAgR8hG5CH3vjqepmitIiw5EvHVM7dfR1xV8=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary

frame >= v1.95 installs Postgres RLS tenancy policies during `pool.Migrate`, and both app suites migrate through the service path — but every test query ran as the testcontainer **superuser**, which bypasses RLS even with `FORCE ROW LEVEL SECURITY`. Tenant isolation was never exercised and there were no cross-tenant assertions. Exercising it for the first time exposed two production bugs (below).

## Changes

- **Bump `pitabwire/frame` to v1.98.2** and wire `frametests/rlstest` into both base test suites (`apps/default/tests/base_testsuite.go`, `apps/tenancy/tests/base_testsuite.go`): `rlstest.CreateRole` before service init, `frame.WithTenancyProvider(rlsProv)` on service construction, then `rlstest.GrantAll` + `rlsProv.Enable()` after migration. All application queries now run as an unprivileged role with RLS enforced.
- **Fix a migration deadlock** in the tenancy suite: frame's `Migrate` pins a dedicated connection for its advisory lock and runs migration queries on a second connection, so `pool_max_conns=1` deadlocks on the first migration query. Raised to 2. (The same deadlock class is what has been timing out service-files CI.)
- **New cross-tenant isolation tests:**
  - `apps/default/service/repository/tenant_isolation_test.go` — `Login` and `LoginEvent` rows created under tenant A claims are invisible to tenant B via `GetByProfileID`, `GetByLoginChallenge`, `GetMostRecentByProfileID`; claim-less (system) contexts keep match-all semantics.
  - `apps/tenancy/tests/tenant_isolation_test.go` — `Partition` and `Access` rows created under tenant A are invisible to tenant B via `GetByID`, `CountByTenantID`, `GetByPartitionAndProfile`, `ListByProfileID`.

## Production bugs found (the headline)

1. **The tenancy and audit services were installing NO RLS policies at all.** `apps/tenancy/service/repository/migrate.go` and `apps/audit/service/repository/migrate.go` passed migration models **by value** (`models.Tenant{}` …). Tenancy enrollment checks for the `tenancy.Tenanted` interface, whose methods have pointer receivers, so value models silently skip policy installation — `tenants`, `partitions`, `accesses`, `clients`, `service_accounts`, `audit_entries`, etc. had no `app_tenancy_isolation` policy. The new isolation tests failed with cross-tenant leakage until the models were passed as pointers. On next deploy/migration the policies will be installed idempotently.
2. **Two tenancy business flows break under enforced RLS** (latent until fix 1 ships):
   - `CreatePartition` stamps the new row with the *target* tenant's identifiers — an administrative cross-tenant write that `WITH CHECK` rejects for tenant-scoped callers. It now validates the target tenant via the scoped read, then inserts on the system path (Keto still authorises upstream).
   - `GetPartitionParents` — ancestor partitions carry their own `partition_id`, so the recursive CTE returned nothing under a child-partition scope. It now validates the requested partition is visible under the caller's scope, then traverses on the system path.

## Pre-existing failure (not addressed)

`TestFedCMFlow/TestColdStartThenIDAssertion` fails identically on unmodified `main` (`/fedcm/token-exchange` 401 `invalid_token` after a successful id-assertion; auth CI has been red since Jun 4). Verified by running the test on a stashed tree — unrelated to RLS/this PR.

## Verification

- `go test -count=1 -p 1 ./...` — all packages pass except the pre-existing FedCM failure above
- `go test -count=1 ./apps/tenancy/...` — fully green after the production fixes
- `golangci-lint run` on all changed packages — 0 issues; `go build ./...` clean