### PR TITLE
fix(fedcm): send Origin header on token-exchange in E2E flow test

### DIFF
--- a/apps/default/service/handlers/providers/providers_test.go
+++ b/apps/default/service/handlers/providers/providers_test.go
@@ -202,8 +202,15 @@ func (suite *ProvidersTestSuite) TestStateCodec_DecodeTamperedData() {
 	encoded, err := codec.Encode("test", map[string]string{"k": "v"})
 	require.NoError(t, err)
 
-	// Tamper with the encoded data
-	tampered := encoded[:len(encoded)-2] + "XX"
+	// Tamper with the encoded data by flipping one ciphertext bit.
+	// (Replacing trailing base64 chars was flaky: RawURL base64's final
+	// character carries only partial bits, so with a random nonce the
+	// replacement occasionally decoded to identical bytes and the AEAD
+	// correctly accepted it.)
+	raw, err := base64.RawURLEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	raw[len(raw)/2] ^= 0x01
+	tampered := base64.RawURLEncoding.EncodeToString(raw)
 	err = codec.Decode("test", tampered, new(map[string]string))
 	assert.Error(t, err)
 }

--- a/apps/default/tests/fedcm/fedcm_flow_test.go
+++ b/apps/default/tests/fedcm/fedcm_flow_test.go
@@ -441,6 +441,10 @@ func (s *FedCMFlowSuite) doFedCMTokenExchange(
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL()+"/fedcm/token-exchange", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
+	// Browsers always send Origin on cross-site/same-site POST fetches; the
+	// token-exchange endpoint binds the one-shot stash to the RP origin recorded
+	// at id-assertion time and rejects requests without a matching Origin.
+	req.Header.Set("Origin", s.baseURL())
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
@@ -475,6 +479,9 @@ func (s *FedCMFlowSuite) doFedCMTokenExchangeExpectStatus(
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.baseURL()+"/fedcm/token-exchange", bytes.NewReader(body))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
+	// Send the matching Origin so replay rejection is exercised via the
+	// one-shot stash deletion, not the origin-binding check.
+	req.Header.Set("Origin", s.baseURL())
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

`TestFedCMFlow/TestColdStartThenIDAssertion` has been failing on `main` since June 4 with a 401 `{"error":"invalid_token"}` from `POST /fedcm/token-exchange`.

## Root cause

PR #698 (7f93103) hardened `/fedcm/token-exchange` to bind the one-shot stash to the RP origin recorded by `/fedcm/id-assertion`:

- `apps/default/service/handlers/fedcm_token_exchange.go:86` — `if stash.Origin != "" && r.Header.Get("Origin") != stash.Origin` → 401. A missing Origin header no longer bypasses the check (this is intentional; see unit test `TestFedCMTokenExchangeRejectsMissingOriginWhenStashed`).
- The id-assertion endpoint always records the RP origin, so the stash always carries one.

The E2E flow test simulates a browser but only sent `Origin` on the id-assertion POST, not on the follow-up token-exchange POST. Real browsers always send `Origin` on POST fetches, so the production hardening is correct — the test fixture was the broken layer.

## Fix

Send the matching `Origin` header in `doFedCMTokenExchange` and `doFedCMTokenExchangeExpectStatus` (`apps/default/tests/fedcm/fedcm_flow_test.go`). The replay step (step 6) still asserts 401, now exercised via the one-shot stash deletion as designed.

## Verification

- `go test ./apps/default/tests/fedcm/ -run 'TestFedCMFlow/TestColdStartThenIDAssertion' -count=1` — PASS (was FAIL on unmodified main)
- `go test ./apps/default/tests/... -count=1` — ok (flow + security suites, 25.6s)
- `go test ./apps/default/service/handlers/ -count=1` — ok (57.8s)
- `go build ./...` — clean
- `golangci-lint run ./apps/default/tests/fedcm/...` — 0 issues