### PR TITLE
feat(ui): gate-backed analytics for audit and tenancy pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ WORK_STATE.md
 pubspec.lock
 **/.flutter-plugins-dependencies
 .claude/
+
+# Local-only pub dependency overrides (path overrides for unpublished packages)
+pubspec_overrides.yaml

--- a/ui/audit/CHANGELOG.md
+++ b/ui/audit/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.3.0
+
+- `AuditAnalyticsScreen` keeps its entry-derived KPI tiles and adds a
+  gate-backed Request Activity trend (`AuditRequestActivitySection`)
+  sourced from the thesa analytics gate via `antinvestor_ui_core`'s
+  `analyticsDataSourceProvider`, querying frame's built-in
+  `{pkg}/completed_calls` metric (`auditCompletedCallsMetric`, a spec
+  constant pending confirmation of the exact package segment).
+- Added `auditAnalyticsSpec` (a `ServiceAnalyticsSpec`) for host apps to
+  register on their `ThesaAnalyticsDataSource`, plus `analyticsGateMessage`
+  for friendly gate error states (400 allowlist, 403 unscoped, 5xx backend
+  down).
+- Requires `antinvestor_ui_core` >= 0.5.0 (unpublished; use a local path
+  override during development).
+
 ## 0.1.0
 
 - Initial release

--- a/ui/audit/lib/antinvestor_ui_audit.dart
+++ b/ui/audit/lib/antinvestor_ui_audit.dart
@@ -31,6 +31,9 @@ export 'src/widgets/actor_activity_widget.dart';
 export 'src/widgets/audit_entry_tile.dart';
 export 'src/widgets/integrity_badge.dart';
 
+// -- Analytics --
+export 'src/analytics/audit_analytics.dart';
+
 // -- Screens --
 export 'src/screens/audit_log_screen.dart';
 export 'src/screens/audit_detail_screen.dart';

--- a/ui/audit/lib/src/analytics/audit_analytics.dart
+++ b/ui/audit/lib/src/analytics/audit_analytics.dart
@@ -1,0 +1,59 @@
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+
+/// Frame's built-in RPC volume metric for the audit service.
+///
+/// Frame names these instruments `{pkg}/completed_calls` (the
+/// `telemetry.Views` rewrite of the `{pkg}/latency` histogram), labelled by
+/// `method` and `status`. The thesa gate allowlists any
+/// `.+/completed_calls$` metric.
+///
+/// TODO(analytics): the audit service does not currently register a
+/// `telemetry.NewTracer` with an explicit package name, so the exact `{pkg}`
+/// segment is unconfirmed. Verify with a grouped or timeseries query against
+/// the gate once audit telemetry is visible and update this constant (it is
+/// the single place the metric name is declared).
+const String auditCompletedCallsMetric = 'audit/completed_calls';
+
+/// Analytics catalog for the audit service, consumed by the thesa-gated
+/// metrics pipeline.
+///
+/// Host apps register this spec on their [ThesaAnalyticsDataSource]:
+///
+/// ```dart
+/// analyticsDataSourceProvider.overrideWith(
+///   (ref) => ThesaAnalyticsDataSource(transport, specs: [auditAnalyticsSpec]),
+/// );
+/// ```
+///
+/// KPI tiles on the audit dashboard stay entry-derived (entity API); only
+/// the request-activity trend is queried through the gate. Tenant scoping
+/// is injected server-side from the caller's JWT; no tenant/partition
+/// filters are declared (or ever sent) here.
+const ServiceAnalyticsSpec auditAnalyticsSpec = ServiceAnalyticsSpec(
+  service: 'audit',
+  charts: [
+    ChartConfig.timeSeries(
+      auditCompletedCallsMetric,
+      label: 'Request activity',
+    ),
+  ],
+);
+
+/// Maps analytics gate failures to short, user-facing messages.
+///
+/// The gate's error contract: 400 -> metric rejected by the server-side
+/// allowlist, 403 -> caller's JWT carries no tenant scope, 5xx -> metrics
+/// backend unreachable.
+String analyticsGateMessage(Object error) {
+  if (error is AnalyticsQueryException) {
+    return switch (error.statusCode) {
+      400 => 'This metric is not available from the analytics gate.',
+      403 => 'Analytics are not available for your current sign-in scope.',
+      >= 500 =>
+        'The analytics backend is temporarily unavailable. '
+            'Please try again shortly.',
+      _ => 'Could not load analytics (HTTP ${error.statusCode}).',
+    };
+  }
+  return 'Could not load analytics.';
+}

--- a/ui/audit/lib/src/screens/audit_analytics_screen.dart
+++ b/ui/audit/lib/src/screens/audit_analytics_screen.dart
@@ -1,12 +1,20 @@
 import 'package:antinvestor_api_audit/antinvestor_api_audit.dart';
-import 'package:antinvestor_ui_core/widgets/service_analytics_page.dart';
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import '../analytics/audit_analytics.dart';
 import '../providers/audit_providers.dart';
 
 /// Analytics dashboard for the audit service showing KPI cards,
-/// action distribution, and recent entries.
+/// action distribution, recent entries, and the gate-backed request
+/// activity trend.
+///
+/// KPI tiles stay derived from audit entries (entity API). The request
+/// activity trend comes from the thesa analytics gate
+/// ([analyticsDataSourceProvider]) via frame's built-in
+/// `{pkg}/completed_calls` metric. Tenant scoping is injected server-side;
+/// this screen never sends tenant or partition filters.
 class AuditAnalyticsScreen extends ConsumerWidget {
   const AuditAnalyticsScreen({super.key});
 
@@ -41,16 +49,13 @@ class AuditAnalyticsScreen extends ConsumerWidget {
       error: (error, _) => Center(child: Text('Error: $error')),
       data: (allEntries) {
         final todayEntries = todayAsync.value ?? [];
-        final uniqueActors =
-            allEntries.map((e) => e.profileId).toSet().length;
-        final uniqueServices =
-            allEntries.map((e) => e.service).toSet().length;
+        final uniqueActors = allEntries.map((e) => e.profileId).toSet().length;
+        final uniqueServices = allEntries.map((e) => e.service).toSet().length;
 
         // Build action distribution for chart placeholder.
         final actionCounts = <String, int>{};
         for (final entry in allEntries) {
-          actionCounts[entry.action] =
-              (actionCounts[entry.action] ?? 0) + 1;
+          actionCounts[entry.action] = (actionCounts[entry.action] ?? 0) + 1;
         }
 
         // Recent events for the sidebar.
@@ -59,15 +64,13 @@ class AuditAnalyticsScreen extends ConsumerWidget {
             'delete' => (EventSeverity.warning, Icons.delete_outline),
             'login' => (EventSeverity.info, Icons.login),
             'create' => (EventSeverity.success, Icons.add_circle_outline),
-            'grant_permission' => (
-                EventSeverity.info,
-                Icons.security_outlined
-              ),
+            'grant_permission' => (EventSeverity.info, Icons.security_outlined),
             'export' => (EventSeverity.info, Icons.download_outlined),
             _ => (EventSeverity.info, Icons.edit_outlined),
           };
           return ServiceEvent(
-            title: '${e.action} ${e.resourceType}'
+            title:
+                '${e.action} ${e.resourceType}'
                 '${e.resourceId.isNotEmpty ? ' (${e.resourceId.substring(0, e.resourceId.length.clamp(0, 8))})' : ''}',
             timeAgo: _relativeTime(e.createdAt),
             icon: icon,
@@ -104,6 +107,7 @@ class AuditAnalyticsScreen extends ConsumerWidget {
           chartSubtitle: 'Breakdown of audit actions over recent entries',
           chartWidget: _ActionDistributionChart(actionCounts: actionCounts),
           events: recentEvents,
+          bottomSection: const AuditRequestActivitySection(),
           onViewAllEvents: () => context.go('/services/audit/log'),
           actions: [
             OutlinedButton.icon(
@@ -170,8 +174,7 @@ class _ActionDistributionChart extends StatelessWidget {
                   borderRadius: BorderRadius.circular(4),
                   child: LinearProgressIndicator(
                     value: maxCount > 0 ? sorted[i].value / maxCount : 0,
-                    backgroundColor:
-                        theme.colorScheme.surfaceContainerHighest,
+                    backgroundColor: theme.colorScheme.surfaceContainerHighest,
                     color: colors[i % colors.length],
                     minHeight: 20,
                   ),
@@ -182,8 +185,9 @@ class _ActionDistributionChart extends StatelessWidget {
                 width: 36,
                 child: Text(
                   '${sorted[i].value}',
-                  style: theme.textTheme.bodySmall
-                      ?.copyWith(fontWeight: FontWeight.w600),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
                   textAlign: TextAlign.end,
                 ),
               ),
@@ -192,6 +196,135 @@ class _ActionDistributionChart extends StatelessWidget {
           if (i < sorted.length - 1) const SizedBox(height: 8),
         ],
       ],
+    );
+  }
+}
+
+/// Gate-backed request activity trend for the audit service.
+///
+/// Queries the thesa analytics gate for [auditCompletedCallsMetric] over a
+/// selectable time range and renders friendly states for gate errors
+/// (400 allowlist, 403 unscoped, 5xx backend down).
+class AuditRequestActivitySection extends ConsumerStatefulWidget {
+  const AuditRequestActivitySection({super.key});
+
+  @override
+  ConsumerState<AuditRequestActivitySection> createState() =>
+      _AuditRequestActivitySectionState();
+}
+
+class _AuditRequestActivitySectionState
+    extends ConsumerState<AuditRequestActivitySection> {
+  AnalyticsTimeRange _timeRange = AnalyticsTimeRange.last30Days();
+
+  ServiceTimeSeriesParams get _params => ServiceTimeSeriesParams(
+    auditAnalyticsSpec.service,
+    auditCompletedCallsMetric,
+    timeRange: _timeRange,
+  );
+
+  void _refresh() => ref.invalidate(serviceTimeSeriesProvider(_params));
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final trendAsync = ref.watch(serviceTimeSeriesProvider(_params));
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: cs.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: cs.outlineVariant),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Request Activity',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Completed audit service calls over time',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: cs.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                reverse: true,
+                child: TimeRangeSelector(
+                  value: _timeRange,
+                  onChanged: (range) => setState(() => _timeRange = range),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          trendAsync.when(
+            data: (series) => TimeSeriesChart(
+              series: series,
+              granularity: _timeRange.granularity,
+            ),
+            loading: () => const SizedBox(
+              height: 240,
+              child: Center(child: CircularProgressIndicator()),
+            ),
+            error: (e, _) => _GateErrorCard(
+              message: analyticsGateMessage(e),
+              onRetry: _refresh,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GateErrorCard extends StatelessWidget {
+  const _GateErrorCard({required this.message, this.onRetry});
+
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.errorContainer.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.insights_outlined, color: cs.error, size: 20),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(color: cs.error, fontSize: 13),
+            ),
+          ),
+          if (onRetry != null) ...[
+            const SizedBox(width: 8),
+            TextButton(onPressed: onRetry, child: const Text('Retry')),
+          ],
+        ],
+      ),
     );
   }
 }

--- a/ui/audit/pubspec.yaml
+++ b/ui/audit/pubspec.yaml
@@ -2,7 +2,7 @@ name: antinvestor_ui_audit
 description: >
   Audit trail UI library for Antinvestor. Browse, search, analyze audit entries
   with embeddable widgets for object-level and system-wide activity tracking.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/antinvestor/service-authentication
 homepage: https://github.com/antinvestor/service-authentication/tree/main/ui/audit
 issue_tracker: https://github.com/antinvestor/service-authentication/issues
@@ -19,7 +19,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  antinvestor_ui_core: ^0.3.0
+  # 0.5.0 ships the thesa-gated analytics pipeline (ServiceAnalyticsSpec,
+  # ThesaAnalyticsDataSource). Not on pub.dev yet -- develop against the
+  # local checkout via the gitignored pubspec_overrides.yaml.
+  antinvestor_ui_core: ^0.5.0
   antinvestor_api_audit: ^0.1.0
   antinvestor_api_common: ^1.52.0
   connectrpc: ^1.0.0
@@ -34,6 +37,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  http: ^1.6.0
 
 flutter:
   uses-material-design: true

--- a/ui/audit/test/_helpers/fake_analytics_transport.dart
+++ b/ui/audit/test/_helpers/fake_analytics_transport.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Recording fake for the [AnalyticsTransport] used by
+/// `ThesaAnalyticsDataSource` in tests.
+///
+/// Captures every POSTed path + decoded JSON body and replies either via
+/// [handler] or with an empty success payload appropriate for the endpoint.
+class FakeAnalyticsTransport {
+  /// Every request made through this transport, in order.
+  final List<({String path, Map<String, dynamic> body})> calls = [];
+
+  /// Optional per-request response factory. When null, the transport
+  /// returns zero/empty payloads with HTTP 200.
+  http.Response Function(String path, Map<String, dynamic> body)? handler;
+
+  Future<http.Response> call(String path, {Object? body}) async {
+    final decoded = json.decode(body! as String) as Map<String, dynamic>;
+    calls.add((path: path, body: decoded));
+    final h = handler;
+    if (h != null) return h(path, decoded);
+    return http.Response(json.encode(_emptyPayloadFor(path)), 200);
+  }
+
+  static Map<String, dynamic> _emptyPayloadFor(String path) {
+    if (path.endsWith('/scalar')) return {'value': 0};
+    if (path.endsWith('/timeseries')) return {'points': <Object>[]};
+    if (path.endsWith('/grouped')) return {'segments': <Object>[]};
+    return {'items': <Object>[]};
+  }
+}

--- a/ui/audit/test/analytics/audit_analytics_contract_test.dart
+++ b/ui/audit/test/analytics/audit_analytics_contract_test.dart
@@ -1,0 +1,143 @@
+import 'dart:convert';
+
+import 'package:antinvestor_ui_audit/antinvestor_ui_audit.dart';
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import '../_helpers/fake_analytics_transport.dart';
+
+void main() {
+  final timeRange = AnalyticsTimeRange(
+    start: DateTime.utc(2026, 1, 1),
+    end: DateTime.utc(2026, 1, 31),
+    granularity: TimeGranularity.day,
+  );
+  const wireTimeRange = {
+    'start': '2026-01-01T00:00:00.000Z',
+    'end': '2026-01-31T00:00:00.000Z',
+  };
+
+  late FakeAnalyticsTransport transport;
+  late ThesaAnalyticsDataSource dataSource;
+
+  setUp(() {
+    transport = FakeAnalyticsTransport();
+    dataSource = ThesaAnalyticsDataSource(
+      transport.call,
+      specs: const [auditAnalyticsSpec],
+    );
+  });
+
+  test('request activity trend posts an exact timeseries body', () async {
+    await dataSource.getTimeSeries(
+      'audit',
+      auditCompletedCallsMetric,
+      timeRange: timeRange,
+    );
+
+    expect(transport.calls, hasLength(1));
+    expect(transport.calls.single.path, '/api/analytics/query/timeseries');
+    expect(transport.calls.single.body, {
+      'metric': 'audit/completed_calls',
+      'aggregation': 'sum',
+      'time_range': wireTimeRange,
+      'step': 'day',
+    });
+  });
+
+  test('grouped query on completed_calls posts an exact body', () async {
+    await dataSource.getDistribution(
+      'audit',
+      auditCompletedCallsMetric,
+      'status',
+      timeRange: timeRange,
+    );
+
+    expect(transport.calls, hasLength(1));
+    expect(transport.calls.single.path, '/api/analytics/query/grouped');
+    expect(transport.calls.single.body, {
+      'metric': 'audit/completed_calls',
+      'aggregation': 'sum',
+      'group_by': 'status',
+      'time_range': wireTimeRange,
+    });
+  });
+
+  test('no request ever carries tenant or partition filters', () async {
+    await dataSource.getTimeSeries(
+      'audit',
+      auditCompletedCallsMetric,
+      timeRange: timeRange,
+    );
+    await dataSource.getDistribution(
+      'audit',
+      auditCompletedCallsMetric,
+      'status',
+      timeRange: timeRange,
+    );
+
+    for (final call in transport.calls) {
+      final filters =
+          (call.body['filters'] as Map<String, dynamic>?) ?? const {};
+      expect(filters.keys, isNot(contains('tenant_id')));
+      expect(filters.keys, isNot(contains('partition_id')));
+    }
+  });
+
+  test('gate errors surface status code and server message', () async {
+    transport.handler = (path, body) =>
+        http.Response(json.encode({'error': 'metric not allowed'}), 400);
+
+    await expectLater(
+      dataSource.getTimeSeries(
+        'audit',
+        auditCompletedCallsMetric,
+        timeRange: timeRange,
+      ),
+      throwsA(
+        isA<AnalyticsQueryException>()
+            .having((e) => e.statusCode, 'statusCode', 400)
+            .having((e) => e.message, 'message', 'metric not allowed'),
+      ),
+    );
+  });
+
+  test('analyticsGateMessage maps gate statuses to friendly text', () {
+    const path = '/api/analytics/query/timeseries';
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 400,
+          message: 'metric not allowed',
+          path: path,
+        ),
+      ),
+      'This metric is not available from the analytics gate.',
+    );
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 403,
+          message: 'no tenant scope',
+          path: path,
+        ),
+      ),
+      'Analytics are not available for your current sign-in scope.',
+    );
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 503,
+          message: 'backend down',
+          path: path,
+        ),
+      ),
+      contains('temporarily unavailable'),
+    );
+    expect(
+      analyticsGateMessage(StateError('boom')),
+      'Could not load analytics.',
+    );
+  });
+}

--- a/ui/audit/test/screens/audit_analytics_screen_test.dart
+++ b/ui/audit/test/screens/audit_analytics_screen_test.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+
+import 'package:antinvestor_api_audit/antinvestor_api_audit.dart';
+import 'package:antinvestor_ui_audit/antinvestor_ui_audit.dart';
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import '../_helpers/fake_analytics_transport.dart';
+
+void main() {
+  late FakeAnalyticsTransport transport;
+
+  setUp(() {
+    transport = FakeAnalyticsTransport();
+  });
+
+  List<AuditEntryObject> sampleEntries() => [
+    AuditEntryObject(
+      id: 'a1',
+      profileId: 'p1',
+      action: 'create',
+      resourceType: 'tenant',
+      service: 'tenancy',
+    ),
+    AuditEntryObject(
+      id: 'a2',
+      profileId: 'p2',
+      action: 'delete',
+      resourceType: 'partition',
+      service: 'tenancy',
+    ),
+    AuditEntryObject(
+      id: 'a3',
+      profileId: 'p1',
+      action: 'login',
+      resourceType: 'session',
+      service: 'auth',
+    ),
+  ];
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1600, 2600);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      ProviderScope(
+        // Disable Riverpod's automatic retry so failed gate queries settle
+        // in their error state instead of flipping back to loading.
+        retry: (retryCount, error) => null,
+        overrides: [
+          auditEntriesProvider.overrideWith(
+            (ref, params) => Future.value(sampleEntries()),
+          ),
+          analyticsDataSourceProvider.overrideWithValue(
+            ThesaAnalyticsDataSource(
+              transport.call,
+              specs: const [auditAnalyticsSpec],
+            ),
+          ),
+        ],
+        child: const MaterialApp(home: Scaffold(body: AuditAnalyticsScreen())),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('keeps entry-derived KPI tiles', (tester) async {
+    await pumpScreen(tester);
+
+    expect(find.text('Total Entries'), findsOneWidget);
+    expect(find.text('Unique Actors'), findsOneWidget);
+    expect(find.text('2'), findsAtLeastNWidgets(1)); // unique actors/services
+    expect(find.text('Unique Services'), findsOneWidget);
+  });
+
+  testWidgets('renders the gate-backed request activity trend', (tester) async {
+    transport.handler = (path, body) {
+      expect(path, '/api/analytics/query/timeseries');
+      expect(body['metric'], auditCompletedCallsMetric);
+      return http.Response(
+        json.encode({
+          'points': [
+            {'timestamp': '2026-06-01T00:00:00Z', 'value': 10},
+            {'timestamp': '2026-06-02T00:00:00Z', 'value': 14},
+          ],
+        }),
+        200,
+      );
+    };
+
+    await pumpScreen(tester);
+
+    expect(find.text('Request Activity'), findsOneWidget);
+    expect(find.byType(TimeSeriesChart), findsOneWidget);
+    expect(find.text('No data'), findsNothing);
+  });
+
+  testWidgets('shows an empty trend state when the gate has no data', (
+    tester,
+  ) async {
+    await pumpScreen(tester);
+
+    expect(find.text('Request Activity'), findsOneWidget);
+    expect(find.text('No data'), findsOneWidget);
+  });
+
+  for (final (status, fragment) in [
+    (400, 'not available from the analytics gate'),
+    (403, 'not available for your current sign-in scope'),
+    (503, 'temporarily unavailable'),
+  ]) {
+    testWidgets('renders friendly state for gate HTTP $status', (tester) async {
+      transport.handler = (path, body) =>
+          http.Response(json.encode({'error': 'gate says no'}), status);
+
+      await pumpScreen(tester);
+
+      expect(find.textContaining(fragment), findsOneWidget);
+      expect(find.textContaining('gate says no'), findsNothing);
+      expect(find.text('Retry'), findsOneWidget);
+      // Entity-derived KPIs are unaffected by gate failures.
+      expect(find.text('Total Entries'), findsOneWidget);
+    });
+  }
+}

--- a/ui/tenancy/CHANGELOG.md
+++ b/ui/tenancy/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.3.0
+
+- `PartitionAnalyticsPage` drops its mocked 12-month growth bars and fake
+  "Top Performing Tenants" table. Growth is now a real timeseries from the
+  thesa analytics gate (`identity_organizations_created_total`) with a
+  selectable time range, and the tenant table ranks live tenants by their
+  actual partition counts. KPI cards stay entity-derived inventory counts.
+- Added `tenancyAnalyticsSpec` (a `ServiceAnalyticsSpec`) for host apps to
+  register on their `ThesaAnalyticsDataSource`, plus `analyticsGateMessage`
+  for friendly gate error states (400 allowlist, 403 unscoped, 5xx backend
+  down).
+- Dropped the now-unused `fl_chart` dependency.
+- Requires `antinvestor_ui_core` >= 0.5.0 (unpublished; use a local path
+  override during development).
+
 ## 0.1.0
 
 - Initial release

--- a/ui/tenancy/lib/antinvestor_ui_tenancy.dart
+++ b/ui/tenancy/lib/antinvestor_ui_tenancy.dart
@@ -1,5 +1,8 @@
 library;
 
+// Analytics
+export 'src/analytics/tenancy_analytics.dart';
+
 // Routing
 export 'src/routing/tenancy_route_module.dart';
 

--- a/ui/tenancy/lib/src/analytics/tenancy_analytics.dart
+++ b/ui/tenancy/lib/src/analytics/tenancy_analytics.dart
@@ -1,0 +1,54 @@
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+
+/// Organization creation counter emitted by the fintech identity service
+/// (`identity_organizations_created_total`). Organizations are the closest
+/// gate-visible signal for tenant/partition growth until the tenancy
+/// service emits its own business metrics.
+const String organizationsCreatedMetric =
+    'identity_organizations_created_total';
+
+/// Analytics catalog for the tenancy service, consumed by the thesa-gated
+/// metrics pipeline.
+///
+/// Host apps register this spec on their [ThesaAnalyticsDataSource]:
+///
+/// ```dart
+/// analyticsDataSourceProvider.overrideWith(
+///   (ref) =>
+///       ThesaAnalyticsDataSource(transport, specs: [tenancyAnalyticsSpec]),
+/// );
+/// ```
+///
+/// KPI tiles on the partition analytics page stay entity-derived (tenant /
+/// partition / role counts); only the growth trend is queried through the
+/// gate. Tenant scoping is injected server-side from the caller's JWT; no
+/// tenant/partition filters are declared (or ever sent) here.
+const ServiceAnalyticsSpec tenancyAnalyticsSpec = ServiceAnalyticsSpec(
+  service: 'tenancy',
+  charts: [
+    ChartConfig.timeSeries(
+      organizationsCreatedMetric,
+      label: 'Organizations created',
+      granularity: TimeGranularity.month,
+    ),
+  ],
+);
+
+/// Maps analytics gate failures to short, user-facing messages.
+///
+/// The gate's error contract: 400 -> metric rejected by the server-side
+/// allowlist, 403 -> caller's JWT carries no tenant scope, 5xx -> metrics
+/// backend unreachable.
+String analyticsGateMessage(Object error) {
+  if (error is AnalyticsQueryException) {
+    return switch (error.statusCode) {
+      400 => 'This metric is not available from the analytics gate.',
+      403 => 'Analytics are not available for your current sign-in scope.',
+      >= 500 =>
+        'The analytics backend is temporarily unavailable. '
+            'Please try again shortly.',
+      _ => 'Could not load analytics (HTTP ${error.statusCode}).',
+    };
+  }
+  return 'Could not load analytics.';
+}

--- a/ui/tenancy/lib/src/screens/partition_analytics_page.dart
+++ b/ui/tenancy/lib/src/screens/partition_analytics_page.dart
@@ -1,18 +1,46 @@
-import 'package:fl_chart/fl_chart.dart';
+import 'package:antinvestor_api_tenancy/antinvestor_api_tenancy.dart';
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../analytics/tenancy_analytics.dart';
 import '../providers/partition_providers.dart';
 
-class PartitionAnalyticsPage extends ConsumerWidget {
+/// Analytics overview for the tenancy service.
+///
+/// KPI cards stay entity-derived (tenant / partition / role inventory
+/// counts). The growth trend is a real timeseries from the thesa analytics
+/// gate ([analyticsDataSourceProvider]) over
+/// [organizationsCreatedMetric], and the tenant table is derived from the
+/// live tenant/partition entity snapshot. Tenant scoping is injected
+/// server-side; this page never sends tenant or partition filters.
+class PartitionAnalyticsPage extends ConsumerStatefulWidget {
   const PartitionAnalyticsPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<PartitionAnalyticsPage> createState() =>
+      _PartitionAnalyticsPageState();
+}
+
+class _PartitionAnalyticsPageState
+    extends ConsumerState<PartitionAnalyticsPage> {
+  AnalyticsTimeRange _timeRange = AnalyticsTimeRange.lastYear();
+
+  ServiceTimeSeriesParams get _growthParams => ServiceTimeSeriesParams(
+    tenancyAnalyticsSpec.service,
+    organizationsCreatedMetric,
+    timeRange: _timeRange,
+  );
+
+  void _refresh() => ref.invalidate(serviceTimeSeriesProvider(_growthParams));
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final tenantsAsync = ref.watch(tenantsProvider);
     final partitionsAsync = ref.watch(partitionsProvider);
     final rolesAsync = ref.watch(partitionRolesProvider);
+    final growthAsync = ref.watch(serviceTimeSeriesProvider(_growthParams));
 
     final tenantsCount = tenantsAsync.whenOrNull(data: (d) => d.length) ?? 0;
     final partitionsCount =
@@ -24,12 +52,15 @@ class PartitionAnalyticsPage extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Tenancy Service',
-              style: theme.textTheme.headlineSmall
-                  ?.copyWith(fontWeight: FontWeight.w700)),
+          Text(
+            'Tenancy Service',
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+          ),
           const SizedBox(height: 24),
 
-          // KPI cards
+          // KPI cards (entity inventory counts)
           Row(
             children: [
               _KpiCard(
@@ -53,7 +84,7 @@ class PartitionAnalyticsPage extends ConsumerWidget {
           ),
           const SizedBox(height: 24),
 
-          // Chart
+          // Growth trend (thesa analytics gate)
           Container(
             padding: const EdgeInsets.all(20),
             decoration: BoxDecoration(
@@ -64,31 +95,96 @@ class PartitionAnalyticsPage extends ConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('Partition Growth',
-                    style: theme.textTheme.titleMedium
-                        ?.copyWith(fontWeight: FontWeight.w600)),
-                Text('12-month network-wide scaling metrics',
-                    style: theme.textTheme.bodySmall?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant)),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            'Organization Growth',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Organizations created over time',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      reverse: true,
+                      child: TimeRangeSelector(
+                        value: _timeRange,
+                        initialPreset: TimeRangePreset.lastYear,
+                        onChanged: (range) =>
+                            setState(() => _timeRange = range),
+                      ),
+                    ),
+                  ],
+                ),
                 const SizedBox(height: 16),
-                SizedBox(
-                  height: 200,
-                  child: _PartitionGrowthChart(),
+                growthAsync.when(
+                  data: (series) => TimeSeriesChart(
+                    series: series,
+                    mode: ChartMode.bar,
+                    granularity:
+                        _timeRange.granularity ?? TimeGranularity.month,
+                  ),
+                  loading: () => const SizedBox(
+                    height: 240,
+                    child: Center(child: CircularProgressIndicator()),
+                  ),
+                  error: (e, _) => _GateErrorCard(
+                    message: analyticsGateMessage(e),
+                    onRetry: _refresh,
+                  ),
                 ),
               ],
             ),
           ),
           const SizedBox(height: 24),
 
-          // Top tenants
-          _buildTopTenants(context),
+          // Tenants by partition count (entity inventory)
+          _TenantsTable(
+            tenants: tenantsAsync.value ?? const [],
+            partitions: partitionsAsync.value ?? const [],
+          ),
         ],
       ),
     );
   }
+}
 
-  Widget _buildTopTenants(BuildContext context) {
+/// Real tenant table derived from the entity snapshot, ranked by the number
+/// of partitions each tenant owns.
+class _TenantsTable extends StatelessWidget {
+  const _TenantsTable({required this.tenants, required this.partitions});
+
+  final List<TenantObject> tenants;
+  final List<PartitionObject> partitions;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
+    final partitionCounts = <String, int>{};
+    for (final p in partitions) {
+      partitionCounts.update(p.tenantId, (v) => v + 1, ifAbsent: () => 1);
+    }
+    final ranked = tenants.toList()
+      ..sort(
+        (a, b) =>
+            (partitionCounts[b.id] ?? 0).compareTo(partitionCounts[a.id] ?? 0),
+      );
+    final top = ranked.take(5).toList();
+
     return Container(
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
@@ -99,46 +195,53 @@ class PartitionAnalyticsPage extends ConsumerWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text('Top Performing Tenants',
-              style: theme.textTheme.titleMedium
-                  ?.copyWith(fontWeight: FontWeight.w600)),
-          const SizedBox(height: 16),
-          SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: DataTable(
-              showCheckboxColumn: false,
-              columns: const [
-                DataColumn(label: Text('ORGANIZATION')),
-                DataColumn(label: Text('PARTITIONS'), numeric: true),
-                DataColumn(label: Text('IOPS AVG')),
-                DataColumn(label: Text('SECURITY SCORE')),
-                DataColumn(label: Text('STATUS')),
-              ],
-              rows: [
-                DataRow(cells: [
-                  const DataCell(Text('Vortex Dynamics')),
-                  const DataCell(Text('2,490')),
-                  const DataCell(Text('14.2k/s')),
-                  const DataCell(Text('98%')),
-                  DataCell(_StatusBadge('OPTIMIZED', Colors.green)),
-                ]),
-                DataRow(cells: [
-                  const DataCell(Text('Nexus Logistics')),
-                  const DataCell(Text('1,823')),
-                  const DataCell(Text('11.8k/s')),
-                  const DataCell(Text('95%')),
-                  DataCell(_StatusBadge('OPTIMIZED', Colors.green)),
-                ]),
-                DataRow(cells: [
-                  const DataCell(Text('Atlas Industries')),
-                  const DataCell(Text('1,204')),
-                  const DataCell(Text('9.4k/s')),
-                  const DataCell(Text('87%')),
-                  DataCell(_StatusBadge('ACTIVE', Colors.blue)),
-                ]),
-              ],
+          Text(
+            'Largest Tenants',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
             ),
           ),
+          const SizedBox(height: 16),
+          if (top.isEmpty)
+            Text(
+              'No tenants in the current scope',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            )
+          else
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: DataTable(
+                showCheckboxColumn: false,
+                columns: const [
+                  DataColumn(label: Text('TENANT')),
+                  DataColumn(label: Text('PARTITIONS'), numeric: true),
+                  DataColumn(label: Text('STATUS')),
+                ],
+                rows: [
+                  for (final tenant in top)
+                    DataRow(
+                      cells: [
+                        DataCell(
+                          Text(
+                            tenant.name.isNotEmpty ? tenant.name : tenant.id,
+                          ),
+                        ),
+                        DataCell(Text('${partitionCounts[tenant.id] ?? 0}')),
+                        DataCell(
+                          _StatusBadge(
+                            tenant.state.name,
+                            tenant.state == STATE.ACTIVE
+                                ? Colors.green
+                                : Colors.blue,
+                          ),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+            ),
         ],
       ),
     );
@@ -172,13 +275,19 @@ class _KpiCard extends StatelessWidget {
           children: [
             Icon(icon, size: 24, color: theme.colorScheme.tertiary),
             const SizedBox(height: 12),
-            Text(value,
-                style: theme.textTheme.headlineMedium
-                    ?.copyWith(fontWeight: FontWeight.w700)),
+            Text(
+              value,
+              style: theme.textTheme.headlineMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
             const SizedBox(height: 4),
-            Text(label,
-                style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.onSurfaceVariant)),
+            Text(
+              label,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
           ],
         ),
       ),
@@ -203,93 +312,45 @@ class _StatusBadge extends StatelessWidget {
       child: Text(
         label,
         style: Theme.of(context).textTheme.labelSmall?.copyWith(
-              color: color,
-              fontWeight: FontWeight.w600,
-            ),
+          color: color,
+          fontWeight: FontWeight.w600,
+        ),
       ),
     );
   }
 }
 
-class _PartitionGrowthChart extends StatelessWidget {
+/// Friendly inline error card for analytics gate failures.
+class _GateErrorCard extends StatelessWidget {
+  const _GateErrorCard({required this.message, this.onRetry});
+
+  final String message;
+  final VoidCallback? onRetry;
+
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return BarChart(
-      BarChartData(
-        alignment: BarChartAlignment.spaceAround,
-        maxY: 2000,
-        barTouchData: BarTouchData(enabled: false),
-        titlesData: FlTitlesData(
-          show: true,
-          bottomTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              getTitlesWidget: (value, meta) {
-                const months = [
-                  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-                  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
-                ];
-                if (value.toInt() >= 0 && value.toInt() < months.length) {
-                  return Padding(
-                    padding: const EdgeInsets.only(top: 8),
-                    child: Text(months[value.toInt()],
-                        style: TextStyle(
-                            fontSize: 10,
-                            color: theme.colorScheme.onSurfaceVariant)),
-                  );
-                }
-                return const SizedBox.shrink();
-              },
+    final cs = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: cs.errorContainer.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          Icon(Icons.insights_outlined, color: cs.error, size: 20),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: TextStyle(color: cs.error, fontSize: 13),
             ),
           ),
-          leftTitles: AxisTitles(
-            sideTitles: SideTitles(
-              showTitles: true,
-              reservedSize: 40,
-              getTitlesWidget: (value, meta) {
-                return Text('${value.toInt()}',
-                    style: TextStyle(
-                        fontSize: 10,
-                        color: theme.colorScheme.onSurfaceVariant));
-              },
-            ),
-          ),
-          topTitles:
-              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-          rightTitles:
-              const AxisTitles(sideTitles: SideTitles(showTitles: false)),
-        ),
-        borderData: FlBorderData(show: false),
-        gridData: FlGridData(
-          show: true,
-          drawVerticalLine: false,
-          horizontalInterval: 500,
-          getDrawingHorizontalLine: (_) => FlLine(
-            color: theme.colorScheme.outlineVariant,
-            strokeWidth: 1,
-          ),
-        ),
-        barGroups: List.generate(12, (i) {
-          final values = [
-            800, 950, 1100, 1050, 1200, 1400,
-            1350, 1500, 1600, 1550, 1700, 1850,
-          ];
-          return BarChartGroupData(
-            x: i,
-            barRods: [
-              BarChartRodData(
-                toY: values[i].toDouble(),
-                color: theme.colorScheme.tertiary,
-                width: 16,
-                borderRadius: const BorderRadius.only(
-                  topLeft: Radius.circular(4),
-                  topRight: Radius.circular(4),
-                ),
-              ),
-            ],
-          );
-        }),
+          if (onRetry != null) ...[
+            const SizedBox(width: 8),
+            TextButton(onPressed: onRetry, child: const Text('Retry')),
+          ],
+        ],
       ),
     );
   }

--- a/ui/tenancy/pubspec.yaml
+++ b/ui/tenancy/pubspec.yaml
@@ -2,7 +2,7 @@ name: antinvestor_ui_tenancy
 description: >
   Tenancy management UI library for Antinvestor. Tenants, partitions, roles,
   access control, service accounts, and permission management.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/antinvestor/service-authentication
 homepage: https://github.com/antinvestor/service-authentication/tree/main/ui/tenancy
 issue_tracker: https://github.com/antinvestor/service-authentication/issues
@@ -19,13 +19,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  antinvestor_ui_core: ^0.2.0
+  # 0.5.0 ships the thesa-gated analytics pipeline (ServiceAnalyticsSpec,
+  # ThesaAnalyticsDataSource). Not on pub.dev yet -- develop against the
+  # local checkout via the gitignored pubspec_overrides.yaml.
+  antinvestor_ui_core: ^0.5.0
   antinvestor_ui_profile: ^0.2.0
   antinvestor_api_tenancy: ^1.54.0
   antinvestor_api_common: ^1.52.0
   antinvestor_api_profile: ^1.52.0
   connectrpc: ^1.0.0
-  fl_chart: ^1.2.0
   flutter_riverpod: ^3.3.1
   go_router: ^17.2.0
   intl: ^0.20.2
@@ -35,6 +37,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  http: ^1.6.0
 
 flutter:
   uses-material-design: true

--- a/ui/tenancy/test/_helpers/fake_analytics_transport.dart
+++ b/ui/tenancy/test/_helpers/fake_analytics_transport.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Recording fake for the [AnalyticsTransport] used by
+/// `ThesaAnalyticsDataSource` in tests.
+///
+/// Captures every POSTed path + decoded JSON body and replies either via
+/// [handler] or with an empty success payload appropriate for the endpoint.
+class FakeAnalyticsTransport {
+  /// Every request made through this transport, in order.
+  final List<({String path, Map<String, dynamic> body})> calls = [];
+
+  /// Optional per-request response factory. When null, the transport
+  /// returns zero/empty payloads with HTTP 200.
+  http.Response Function(String path, Map<String, dynamic> body)? handler;
+
+  Future<http.Response> call(String path, {Object? body}) async {
+    final decoded = json.decode(body! as String) as Map<String, dynamic>;
+    calls.add((path: path, body: decoded));
+    final h = handler;
+    if (h != null) return h(path, decoded);
+    return http.Response(json.encode(_emptyPayloadFor(path)), 200);
+  }
+
+  static Map<String, dynamic> _emptyPayloadFor(String path) {
+    if (path.endsWith('/scalar')) return {'value': 0};
+    if (path.endsWith('/timeseries')) return {'points': <Object>[]};
+    if (path.endsWith('/grouped')) return {'segments': <Object>[]};
+    return {'items': <Object>[]};
+  }
+}

--- a/ui/tenancy/test/analytics/tenancy_analytics_contract_test.dart
+++ b/ui/tenancy/test/analytics/tenancy_analytics_contract_test.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:antinvestor_ui_tenancy/antinvestor_ui_tenancy.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import '../_helpers/fake_analytics_transport.dart';
+
+void main() {
+  final timeRange = AnalyticsTimeRange(
+    start: DateTime.utc(2025, 6, 1),
+    end: DateTime.utc(2026, 6, 1),
+    granularity: TimeGranularity.month,
+  );
+  const wireTimeRange = {
+    'start': '2025-06-01T00:00:00.000Z',
+    'end': '2026-06-01T00:00:00.000Z',
+  };
+
+  late FakeAnalyticsTransport transport;
+  late ThesaAnalyticsDataSource dataSource;
+
+  setUp(() {
+    transport = FakeAnalyticsTransport();
+    dataSource = ThesaAnalyticsDataSource(
+      transport.call,
+      specs: const [tenancyAnalyticsSpec],
+    );
+  });
+
+  test('growth trend posts an exact monthly timeseries body', () async {
+    await dataSource.getTimeSeries(
+      'tenancy',
+      organizationsCreatedMetric,
+      timeRange: timeRange,
+    );
+
+    expect(transport.calls, hasLength(1));
+    expect(transport.calls.single.path, '/api/analytics/query/timeseries');
+    expect(transport.calls.single.body, {
+      'metric': 'identity_organizations_created_total',
+      'aggregation': 'sum',
+      'time_range': wireTimeRange,
+      'step': 'month',
+    });
+  });
+
+  test('spec granularity wins over the time range granularity', () async {
+    await dataSource.getTimeSeries(
+      'tenancy',
+      organizationsCreatedMetric,
+      timeRange: AnalyticsTimeRange(
+        start: DateTime.utc(2025, 6, 1),
+        end: DateTime.utc(2026, 6, 1),
+        granularity: TimeGranularity.week,
+      ),
+    );
+
+    expect(transport.calls.single.body['step'], 'month');
+  });
+
+  test('no request ever carries tenant or partition filters', () async {
+    await dataSource.getTimeSeries(
+      'tenancy',
+      organizationsCreatedMetric,
+      timeRange: timeRange,
+    );
+
+    for (final call in transport.calls) {
+      final filters =
+          (call.body['filters'] as Map<String, dynamic>?) ?? const {};
+      expect(filters.keys, isNot(contains('tenant_id')));
+      expect(filters.keys, isNot(contains('partition_id')));
+    }
+  });
+
+  test('gate errors surface status code and server message', () async {
+    transport.handler = (path, body) =>
+        http.Response(json.encode({'error': 'no tenant scope'}), 403);
+
+    await expectLater(
+      dataSource.getTimeSeries(
+        'tenancy',
+        organizationsCreatedMetric,
+        timeRange: timeRange,
+      ),
+      throwsA(
+        isA<AnalyticsQueryException>()
+            .having((e) => e.statusCode, 'statusCode', 403)
+            .having((e) => e.message, 'message', 'no tenant scope'),
+      ),
+    );
+  });
+
+  test('analyticsGateMessage maps gate statuses to friendly text', () {
+    const path = '/api/analytics/query/timeseries';
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 400,
+          message: 'metric not allowed',
+          path: path,
+        ),
+      ),
+      'This metric is not available from the analytics gate.',
+    );
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 403,
+          message: 'no tenant scope',
+          path: path,
+        ),
+      ),
+      'Analytics are not available for your current sign-in scope.',
+    );
+    expect(
+      analyticsGateMessage(
+        const AnalyticsQueryException(
+          statusCode: 503,
+          message: 'backend down',
+          path: path,
+        ),
+      ),
+      contains('temporarily unavailable'),
+    );
+    expect(
+      analyticsGateMessage(StateError('boom')),
+      'Could not load analytics.',
+    );
+  });
+}

--- a/ui/tenancy/test/screens/partition_analytics_page_test.dart
+++ b/ui/tenancy/test/screens/partition_analytics_page_test.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+
+import 'package:antinvestor_api_tenancy/antinvestor_api_tenancy.dart';
+import 'package:antinvestor_ui_core/antinvestor_ui_core.dart';
+import 'package:antinvestor_ui_tenancy/antinvestor_ui_tenancy.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+
+import '../_helpers/fake_analytics_transport.dart';
+
+void main() {
+  late FakeAnalyticsTransport transport;
+
+  setUp(() {
+    transport = FakeAnalyticsTransport();
+  });
+
+  final tenants = [
+    TenantObject(id: 't1', name: 'Acme Group', state: STATE.ACTIVE),
+    TenantObject(id: 't2', name: 'Umbrella Ltd', state: STATE.ACTIVE),
+  ];
+  final partitions = [
+    PartitionObject(id: 'p1', name: 'HQ', tenantId: 't1'),
+    PartitionObject(id: 'p2', name: 'Branch', tenantId: 't1'),
+    PartitionObject(id: 'p3', name: 'Main', tenantId: 't2'),
+  ];
+  final roles = [PartitionRoleObject(partitionId: 'p1', name: 'admin')];
+
+  Future<void> pumpPage(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1600, 2400);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.reset);
+    await tester.pumpWidget(
+      ProviderScope(
+        // Disable Riverpod's automatic retry so failed gate queries settle
+        // in their error state instead of flipping back to loading.
+        retry: (retryCount, error) => null,
+        overrides: [
+          tenantsProvider.overrideWith((ref) => Future.value(tenants)),
+          partitionsProvider.overrideWith((ref) => Future.value(partitions)),
+          partitionRolesProvider.overrideWith((ref) => Future.value(roles)),
+          analyticsDataSourceProvider.overrideWithValue(
+            ThesaAnalyticsDataSource(
+              transport.call,
+              specs: const [tenancyAnalyticsSpec],
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: PartitionAnalyticsPage()),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('keeps entity-derived KPI counts', (tester) async {
+    await pumpPage(tester);
+
+    expect(find.text('Total Tenants'), findsOneWidget);
+    expect(find.text('2'), findsAtLeastNWidgets(1));
+    expect(find.text('Total Partitions'), findsOneWidget);
+    expect(find.text('3'), findsAtLeastNWidgets(1));
+    expect(find.text('Total Roles'), findsOneWidget);
+    expect(find.text('1'), findsAtLeastNWidgets(1));
+  });
+
+  testWidgets('renders the growth trend from the gate timeseries', (
+    tester,
+  ) async {
+    transport.handler = (path, body) {
+      expect(path, '/api/analytics/query/timeseries');
+      expect(body['metric'], organizationsCreatedMetric);
+      expect(body['step'], 'month');
+      return http.Response(
+        json.encode({
+          'points': [
+            {'timestamp': '2026-01-01T00:00:00Z', 'value': 4},
+            {'timestamp': '2026-02-01T00:00:00Z', 'value': 7},
+          ],
+        }),
+        200,
+      );
+    };
+
+    await pumpPage(tester);
+
+    expect(find.text('Organization Growth'), findsOneWidget);
+    expect(find.byType(TimeSeriesChart), findsOneWidget);
+    expect(find.text('No data'), findsNothing);
+  });
+
+  testWidgets('mock growth and tenant fixtures are gone', (tester) async {
+    await pumpPage(tester);
+
+    // The fake hard-coded table rows from the previous implementation.
+    expect(find.text('Vortex Dynamics'), findsNothing);
+    expect(find.text('Nexus Logistics'), findsNothing);
+    expect(find.text('Atlas Industries'), findsNothing);
+    // Empty gate response renders an honest empty state, not fake bars.
+    expect(find.text('No data'), findsOneWidget);
+  });
+
+  testWidgets('ranks real tenants by partition count', (tester) async {
+    await pumpPage(tester);
+
+    expect(find.text('Largest Tenants'), findsOneWidget);
+    expect(find.text('Acme Group'), findsOneWidget);
+    expect(find.text('Umbrella Ltd'), findsOneWidget);
+
+    // Acme (2 partitions) is ranked above Umbrella (1 partition).
+    final acmeY = tester.getTopLeft(find.text('Acme Group')).dy;
+    final umbrellaY = tester.getTopLeft(find.text('Umbrella Ltd')).dy;
+    expect(acmeY, lessThan(umbrellaY));
+  });
+
+  for (final (status, fragment) in [
+    (400, 'not available from the analytics gate'),
+    (403, 'not available for your current sign-in scope'),
+    (503, 'temporarily unavailable'),
+  ]) {
+    testWidgets('renders friendly state for gate HTTP $status', (tester) async {
+      transport.handler = (path, body) =>
+          http.Response(json.encode({'error': 'gate says no'}), status);
+
+      await pumpPage(tester);
+
+      expect(find.textContaining(fragment), findsOneWidget);
+      expect(find.textContaining('gate says no'), findsNothing);
+      expect(find.text('Retry'), findsOneWidget);
+      // Entity-derived KPIs and the tenant table are unaffected.
+      expect(find.text('Total Tenants'), findsOneWidget);
+      expect(find.text('Largest Tenants'), findsOneWidget);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
Converts the audit and tenancy analytics pages to the standardized thesa-gated metrics pipeline from `antinvestor_ui_core` 0.5.0.

### ui/audit — `AuditAnalyticsScreen`
- Entry-derived KPI tiles (Total Entries, Entries Today, Unique Actors, Unique Services) and the recent-events panel are unchanged (entity API)
- New gate-backed "Request Activity" trend (`AuditRequestActivitySection`) over frame's built-in `{pkg}/completed_calls` metric, with a selectable time range
- The exact frame package segment for the audit service is unconfirmed (the service registers no explicit `telemetry.NewTracer` name), so the metric name is a single spec constant `auditCompletedCallsMetric = 'audit/completed_calls'` with a TODO to verify via a grouped/timeseries query once audit telemetry is visible in the gate

### ui/tenancy — `PartitionAnalyticsPage`
- Mocked 12-month growth bars replaced by a real gate timeseries over `identity_organizations_created_total` (monthly step, selectable range; honest empty state instead of fake data)
- Fake "Top Performing Tenants" table replaced by a real "Largest Tenants" table ranking live tenants by their actual partition counts (entity inventory)
- KPI cards stay entity-derived inventory counts; unused `fl_chart` dependency dropped

Both packages export `ServiceAnalyticsSpec`s for host apps to register on their `ThesaAnalyticsDataSource`, render friendly gate error states (400 allowlist, 403 unscoped, 5xx backend down), and never send tenant/partition filters client-side (the server injects scoping from the JWT).

## Trend -> metric mapping
| Page | Chart | Metric |
| --- | --- | --- |
| Audit | Request Activity | `audit/completed_calls` (constant, TODO confirm pkg) |
| Tenancy | Organization Growth | `identity_organizations_created_total` |

## Notes
- `antinvestor_ui_core: ^0.5.0` is not published yet (pub.dev has 0.4.1); CI for UI packages is lenient/non-blocking. Local development uses gitignored `pubspec_overrides.yaml` path overrides against the `common` repo branch `feat/ui-core-thesa-analytics`.
- `identity_organizations_created_total` is emitted by service-fintech's identity app, not service-authentication; it is the closest gate-visible growth signal until tenancy emits its own business metrics.

## Testing
- Mocked-transport contract tests in both packages assert the exact POST bodies (timeseries + grouped) and that no tenant/partition filters leak
- Widget tests cover entity KPIs, gate trends with data, empty states, removal of the mock fixtures, tenant ranking, and 400/403/503 friendly states
- `flutter analyze --no-fatal-infos` clean, `dart format` clean (touched files), `flutter test` green (19 + 19 tests)