### PR TITLE
feat(tenancy): seed service-payment-pawapay client and service account

### DIFF
--- a/apps/tenancy/migrations/0001/20260611_service_payment_pawapay.sql
+++ b/apps/tenancy/migrations/0001/20260611_service_payment_pawapay.sql
@@ -1,0 +1,41 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+-- Service account: service-payment-pawapay
+-- pawaPay payment provider integration. Bridges the payment service
+-- to the pawaPay Merchant API v2 mobile money aggregator (MTN MoMo,
+-- Airtel Money, M-Pesa, Orange Money and others) for deposit and
+-- payout flows. Needs payment service for status callbacks.
+
+INSERT INTO clients (
+    id, tenant_id, partition_id, name, client_id, client_secret,
+    type, grant_types, scopes, audiences,
+    token_endpoint_auth_method, service_account_id, properties
+) VALUES (
+    'd8le7qspf2t8u08dff3g',
+    'c2f4j7au6s7f91uqnojg',
+    'c2f4j7au6s7f91uqnokg',
+    'sa-service_payment_pawapay',
+    'service-payment-pawapay',
+    '',
+    'internal',
+    '{"types": ["client_credentials"]}',
+    'system_int openid',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    'private_key_jwt',
+    'd8le7qspf2t8u08dff40',
+    '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO service_accounts (
+    id, tenant_id, partition_id, profile_id,
+    client_id, client_ref, type, audiences, properties
+) VALUES (
+    'd8le7qspf2t8u08dff40',
+    'c2f4j7au6s7f91uqnojg',
+    'c2f4j7au6s7f91uqnokg',
+    'd8le7qspf2t8u08dff4g',
+    'service-payment-pawapay',
+    'd8le7qspf2t8u08dff3g',
+    'internal',
+    '{"service_notification":["*"],"service_payment":["*"],"service_profile":["*"],"service_tenancy":["*"]}',
+    '{}'
+) ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

Adds the tenancy seed migration for `service-payment-pawapay`, the new pawaPay mobile money integration service (antinvestor/service-payment#159), so it can authenticate via private_key_jwt client credentials like the other payment integrations.

- `clients` row: `service-payment-pawapay`, `private_key_jwt`, `client_credentials`, scopes `system_int openid`, audiences `service_notification/service_payment/service_profile/service_tenancy` — identical shape to the mpesa/mtn/airtel/polar/stripe seeds
- `service_accounts` row cross-referencing the client
- Fresh xid identifiers (`d8le7qsp…`), idempotent `ON CONFLICT (id) DO NOTHING`

Companion PRs:
- Integration service: antinvestor/service-payment#159
- Cluster deployment: stawi-org/deployment.manifests (feat/payment-pawapay)