### PR TITLE
fix(ui/audit): filter dropdowns overflow the filter row — 0.3.2

### DIFF
--- a/ui/audit/CHANGELOG.md
+++ b/ui/audit/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.2
+
+- Fix: audit log filter dropdowns (Action, Resource Type, Service) set
+  `isExpanded` so long option labels ellipsize within their fixed-width
+  boxes instead of overflowing the filter row.
+
 ## 0.3.0
 
 - `AuditAnalyticsScreen` keeps its entry-derived KPI tiles and adds a

--- a/ui/audit/lib/src/screens/audit_log_screen.dart
+++ b/ui/audit/lib/src/screens/audit_log_screen.dart
@@ -156,6 +156,7 @@ class _AuditLogScreenState extends ConsumerState<AuditLogScreen> {
             width: 160,
             child: DropdownButtonFormField<String>(
               initialValue: _filterAction,
+              isExpanded: true,
               isDense: true,
               decoration: const InputDecoration(
                 labelText: 'Action',
@@ -174,6 +175,7 @@ class _AuditLogScreenState extends ConsumerState<AuditLogScreen> {
             width: 160,
             child: DropdownButtonFormField<String>(
               initialValue: _filterResourceType,
+              isExpanded: true,
               isDense: true,
               decoration: const InputDecoration(
                 labelText: 'Resource Type',
@@ -192,6 +194,7 @@ class _AuditLogScreenState extends ConsumerState<AuditLogScreen> {
             width: 180,
             child: DropdownButtonFormField<String>(
               initialValue: _filterService,
+              isExpanded: true,
               isDense: true,
               decoration: const InputDecoration(
                 labelText: 'Service',

--- a/ui/audit/pubspec.yaml
+++ b/ui/audit/pubspec.yaml
@@ -2,7 +2,7 @@ name: antinvestor_ui_audit
 description: >
   Audit trail UI library for Antinvestor. Browse, search, analyze audit entries
   with embeddable widgets for object-level and system-wide activity tracking.
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/antinvestor/service-authentication
 homepage: https://github.com/antinvestor/service-authentication/tree/main/ui/audit
 issue_tracker: https://github.com/antinvestor/service-authentication/issues


### PR DESCRIPTION
The Action/Resource Type/Service dropdowns sat in fixed-width boxes
without isExpanded, so long option labels overflowed to the right
(visible debug stripes in the audit log header). isExpanded makes the
selected label ellipsize within its box.
