### PR TITLE
chore(tenancy): apply canonical buf formatting

### DIFF
--- a/proto/tenancy/tenancy/v1/tenancy.proto
+++ b/proto/tenancy/tenancy/v1/tenancy.proto
@@ -1216,9 +1216,7 @@ service TenancyService {
   // GetTenant retrieves a tenant by ID.
   rpc GetTenant(GetTenantRequest) returns (GetTenantResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["tenant_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["tenant_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "getTenant"
       summary: "Get tenant"
@@ -1230,9 +1228,7 @@ service TenancyService {
   // ListTenant retrieves all tenants matching criteria.
   rpc ListTenant(ListTenantRequest) returns (stream ListTenantResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["tenant_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["tenant_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "listTenants"
       summary: "List tenants"
@@ -1243,9 +1239,7 @@ service TenancyService {
 
   // CreateTenant creates a new tenant.
   rpc CreateTenant(CreateTenantRequest) returns (CreateTenantResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["tenant_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["tenant_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "createTenant"
       summary: "Create tenant"
@@ -1256,9 +1250,7 @@ service TenancyService {
 
   // UpdateTenant updates an existing tenant.
   rpc UpdateTenant(UpdateTenantRequest) returns (UpdateTenantResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["tenant_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["tenant_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "updateTenant"
       summary: "Update tenant"
@@ -1269,9 +1261,7 @@ service TenancyService {
 
   // RemoveTenant soft-deletes a tenant and all its partitions.
   rpc RemoveTenant(RemoveTenantRequest) returns (RemoveTenantResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["tenant_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["tenant_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "removeTenant"
       summary: "Remove tenant"
@@ -1283,9 +1273,7 @@ service TenancyService {
   // ListPartition retrieves all partitions matching criteria.
   rpc ListPartition(ListPartitionRequest) returns (stream ListPartitionResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["partition_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["partition_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "listPartitions"
       summary: "List partitions"
@@ -1296,9 +1284,7 @@ service TenancyService {
 
   // CreatePartition creates a new partition.
   rpc CreatePartition(CreatePartitionRequest) returns (CreatePartitionResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["partition_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["partition_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "createPartition"
       summary: "Create partition"
@@ -1310,9 +1296,7 @@ service TenancyService {
   // GetPartition retrieves a partition by ID or domain.
   rpc GetPartition(GetPartitionRequest) returns (GetPartitionResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["partition_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["partition_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "getPartition"
       summary: "Get partition"
@@ -1324,9 +1308,7 @@ service TenancyService {
   // GetPartitionParents retrieves the parent hierarchy.
   rpc GetPartitionParents(GetPartitionParentsRequest) returns (GetPartitionParentsResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["partition_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["partition_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "getPartitionParents"
       summary: "Get partition parents"
@@ -1337,9 +1319,7 @@ service TenancyService {
 
   // RemovePartition soft-deletes a partition.
   rpc RemovePartition(RemovePartitionRequest) returns (RemovePartitionResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["partition_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["partition_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "removePartition"
       summary: "Remove partition"
@@ -1350,9 +1330,7 @@ service TenancyService {
 
   // UpdatePartition updates an existing partition.
   rpc UpdatePartition(UpdatePartitionRequest) returns (UpdatePartitionResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["partition_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["partition_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "updatePartition"
       summary: "Update partition"
@@ -1363,9 +1341,7 @@ service TenancyService {
 
   // CreatePartitionRole creates a role within a partition.
   rpc CreatePartitionRole(CreatePartitionRoleRequest) returns (CreatePartitionRoleResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["role_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["role_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "createPartitionRole"
       summary: "Create partition role"
@@ -1377,9 +1353,7 @@ service TenancyService {
   // ListPartitionRole retrieves all roles for a partition.
   rpc ListPartitionRole(ListPartitionRoleRequest) returns (stream ListPartitionRoleResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["role_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["role_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "listPartitionRoles"
       summary: "List partition roles"
@@ -1390,9 +1364,7 @@ service TenancyService {
 
   // UpdatePartitionRole updates an existing partition role.
   rpc UpdatePartitionRole(UpdatePartitionRoleRequest) returns (UpdatePartitionRoleResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["role_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["role_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "updatePartitionRole"
       summary: "Update partition role"
@@ -1403,9 +1375,7 @@ service TenancyService {
 
   // RemovePartitionRole deletes a partition role.
   rpc RemovePartitionRole(RemovePartitionRoleRequest) returns (RemovePartitionRoleResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["role_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["role_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "removePartitionRole"
       summary: "Remove partition role"
@@ -1416,9 +1386,7 @@ service TenancyService {
 
   // CreatePage creates a custom UI page for a partition.
   rpc CreatePage(CreatePageRequest) returns (CreatePageResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["page_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["page_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "createPage"
       summary: "Create custom page"
@@ -1430,9 +1398,7 @@ service TenancyService {
   // ListPage retrieves all custom pages for a partition.
   rpc ListPage(ListPageRequest) returns (stream ListPageResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["page_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["page_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "listPages"
       summary: "List custom pages"
@@ -1444,9 +1410,7 @@ service TenancyService {
   // GetPage retrieves a custom page.
   rpc GetPage(GetPageRequest) returns (GetPageResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["page_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["page_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "getPage"
       summary: "Get custom page"
@@ -1457,9 +1421,7 @@ service TenancyService {
 
   // UpdatePage updates an existing custom page.
   rpc UpdatePage(UpdatePageRequest) returns (UpdatePageResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["page_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["page_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "updatePage"
       summary: "Update custom page"
@@ -1470,9 +1432,7 @@ service TenancyService {
 
   // RemovePage deletes a custom page.
   rpc RemovePage(RemovePageRequest) returns (RemovePageResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["page_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["page_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "removePage"
       summary: "Remove custom page"
@@ -1483,9 +1443,7 @@ service TenancyService {
 
   // CreateAccess grants a profile access to a partition.
   rpc CreateAccess(CreateAccessRequest) returns (CreateAccessResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["access_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["access_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "createAccess"
       summary: "Create access grant"
@@ -1497,9 +1455,7 @@ service TenancyService {
   // GetAccess retrieves an access grant.
   rpc GetAccess(GetAccessRequest) returns (GetAccessResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["access_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["access_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "getAccess"
       summary: "Get access grant"
@@ -1511,9 +1467,7 @@ service TenancyService {
   // ListAccess retrieves all access grants for a partition or profile.
   rpc ListAccess(ListAccessRequest) returns (stream ListAccessResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["access_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["access_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "listAccess"
       summary: "List access grants"
@@ -1524,9 +1478,7 @@ service TenancyService {
 
   // RemoveAccess revokes a profile's access to a partition.
   rpc RemoveAccess(RemoveAccessRequest) returns (RemoveAccessResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["access_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["access_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "removeAccess"
       summary: "Remove access grant"
@@ -1537,9 +1489,7 @@ service TenancyService {
 
   // CreateAccessRole assigns a role to an access grant.
   rpc CreateAccessRole(CreateAccessRoleRequest) returns (CreateAccessRoleResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["permission_grant"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["permission_grant"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "createAccessRole"
       summary: "Assign role to access"
@@ -1551,9 +1501,7 @@ service TenancyService {
   // ListAccessRole retrieves all roles for an access grant.
   rpc ListAccessRole(ListAccessRoleRequest) returns (stream ListAccessRoleResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["access_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["access_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "listAccessRoles"
       summary: "List access roles"
@@ -1564,9 +1512,7 @@ service TenancyService {
 
   // RemoveAccessRole removes a role from an access grant.
   rpc RemoveAccessRole(RemoveAccessRoleRequest) returns (RemoveAccessRoleResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["permission_grant"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["permission_grant"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "removeAccessRole"
       summary: "Remove access role"
@@ -1577,9 +1523,7 @@ service TenancyService {
 
   // CreateServiceAccount registers a service account (bot) for a partition.
   rpc CreateServiceAccount(CreateServiceAccountRequest) returns (CreateServiceAccountResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["service_account_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["service_account_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "createServiceAccount"
       summary: "Create service account"
@@ -1591,9 +1535,7 @@ service TenancyService {
   // GetServiceAccount retrieves a service account.
   rpc GetServiceAccount(GetServiceAccountRequest) returns (GetServiceAccountResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["service_account_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["service_account_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "getServiceAccount"
       summary: "Get service account"
@@ -1604,9 +1546,7 @@ service TenancyService {
 
   // UpdateServiceAccount updates an existing service account.
   rpc UpdateServiceAccount(UpdateServiceAccountRequest) returns (UpdateServiceAccountResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["service_account_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["service_account_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "updateServiceAccount"
       summary: "Update service account"
@@ -1618,9 +1558,7 @@ service TenancyService {
   // ListServiceAccount retrieves all service accounts for a partition.
   rpc ListServiceAccount(ListServiceAccountRequest) returns (stream ListServiceAccountResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["service_account_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["service_account_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "listServiceAccounts"
       summary: "List service accounts"
@@ -1631,9 +1569,7 @@ service TenancyService {
 
   // RemoveServiceAccount deregisters a service account.
   rpc RemoveServiceAccount(RemoveServiceAccountRequest) returns (RemoveServiceAccountResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["service_account_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["service_account_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "removeServiceAccount"
       summary: "Remove service account"
@@ -1644,9 +1580,7 @@ service TenancyService {
 
   // CreateClient registers an OAuth2 client for a partition or service account.
   rpc CreateClient(CreateClientRequest) returns (CreateClientResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["client_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["client_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "createClient"
       summary: "Create OAuth2 client"
@@ -1658,9 +1592,7 @@ service TenancyService {
   // GetClient retrieves an OAuth2 client by ID or client_id.
   rpc GetClient(GetClientRequest) returns (GetClientResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["client_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["client_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "getClient"
       summary: "Get OAuth2 client"
@@ -1672,9 +1604,7 @@ service TenancyService {
   // ListClient retrieves all OAuth2 clients for a partition or service account.
   rpc ListClient(ListClientRequest) returns (stream ListClientResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["client_view"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["client_view"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "listClients"
       summary: "List OAuth2 clients"
@@ -1685,9 +1615,7 @@ service TenancyService {
 
   // UpdateClient updates an existing OAuth2 client.
   rpc UpdateClient(UpdateClientRequest) returns (UpdateClientResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["client_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["client_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "updateClient"
       summary: "Update OAuth2 client"
@@ -1698,9 +1626,7 @@ service TenancyService {
 
   // RemoveClient deletes an OAuth2 client.
   rpc RemoveClient(RemoveClientRequest) returns (RemoveClientResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["client_manage"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["client_manage"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "removeClient"
       summary: "Remove OAuth2 client"
@@ -1712,9 +1638,7 @@ service TenancyService {
   // ListServiceNamespaces returns all registered service permission namespaces.
   rpc ListServiceNamespaces(ListServiceNamespacesRequest) returns (ListServiceNamespacesResponse) {
     option idempotency_level = NO_SIDE_EFFECTS;
-    option (common.v1.method_permissions) = {
-      permissions: ["permission_grant"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["permission_grant"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "listServiceNamespaces"
       summary: "List service namespaces"
@@ -1725,9 +1649,7 @@ service TenancyService {
 
   // GrantPermission grants a specific permission to a profile in a service namespace.
   rpc GrantPermission(GrantPermissionRequest) returns (GrantPermissionResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["permission_grant"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["permission_grant"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "grantPermission"
       summary: "Grant permission"
@@ -1738,9 +1660,7 @@ service TenancyService {
 
   // RevokePermission revokes a specific permission from a profile in a service namespace.
   rpc RevokePermission(RevokePermissionRequest) returns (RevokePermissionResponse) {
-    option (common.v1.method_permissions) = {
-      permissions: ["permission_grant"]
-    };
+    option (common.v1.method_permissions) = {permissions: ["permission_grant"]};
     option (gnostic.openapi.v3.operation) = {
       operation_id: "revokePermission"
       summary: "Revoke permission"

--- a/proto/tenancy/tenancy/v2/auth_contract.proto
+++ b/proto/tenancy/tenancy/v2/auth_contract.proto
@@ -43,30 +43,48 @@ enum AuthorizationPolicyStatus {
 message OAuthClientConfiguration {
   repeated string grant_types = 1 [(buf.validate.field).repeated = {
     unique: true
-    items: {string: {in: ["authorization_code", "client_credentials", "refresh_token"]}}
+    items: {
+      string: {
+        in: [
+          "authorization_code",
+          "client_credentials",
+          "refresh_token"
+        ]
+      }
+    }
   }];
   repeated string response_types = 2 [(buf.validate.field).repeated = {
     unique: true
-    items: {string: {in: ["code", "token"]}}
+    items: {
+      string: {
+        in: [
+          "code",
+          "token"
+        ]
+      }
+    }
   }];
   repeated string redirect_uris = 3;
   string scopes = 4;
-  repeated string resource_recipients = 5 [
-    (buf.validate.field).repeated = {
-      min_items: 1
-      unique: true
-      items: {
-        string: {
-          uri: true
-          pattern: "^https://[^/?#]+/[^?#]+$"
-        }
+  repeated string resource_recipients = 5 [(buf.validate.field).repeated = {
+    min_items: 1
+    unique: true
+    items: {
+      string: {
+        uri: true
+        pattern: "^https://[^/?#]+/[^?#]+$"
       }
     }
-  ];
+  }];
   string token_endpoint_auth_method = 6 [
     (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
     (buf.validate.field).string = {
-      in: ["none", "client_secret_basic", "client_secret_post", "private_key_jwt"]
+      in: [
+        "none",
+        "client_secret_basic",
+        "client_secret_post",
+        "private_key_jwt"
+      ]
     }
   ];
   google.protobuf.Struct properties = 7;
@@ -74,10 +92,21 @@ message OAuthClientConfiguration {
 
 message OAuthClient {
   string id = 1 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
-  string name = 2 [(buf.validate.field).string = {min_len: 3, max_len: 100}];
-  string client_id = 3 [(buf.validate.field).string = {min_len: 3, max_len: 100}];
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 3
+    max_len: 100
+  }];
+  string client_id = 3 [(buf.validate.field).string = {
+    min_len: 3
+    max_len: 100
+  }];
   string type = 4 [(buf.validate.field).string = {
-    in: ["public", "confidential", "internal", "external"]
+    in: [
+      "public",
+      "confidential",
+      "internal",
+      "external"
+    ]
   }];
   OAuthClientConfiguration configuration = 5;
   common.v1.STATE state = 6;
@@ -123,8 +152,16 @@ message ServiceAccount {
   string tenant_id = 2 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
   string partition_id = 3 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
   string profile_id = 4 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
-  string name = 5 [(buf.validate.field).string = {min_len: 3, max_len: 100}];
-  string type = 6 [(buf.validate.field).string = {in: ["internal", "external"]}];
+  string name = 5 [(buf.validate.field).string = {
+    min_len: 3
+    max_len: 100
+  }];
+  string type = 6 [(buf.validate.field).string = {
+    in: [
+      "internal",
+      "external"
+    ]
+  }];
   OAuthClient oauth_client = 7;
   ServiceAuthorizationPolicy authorization_policy = 8;
   google.protobuf.Struct public_keys = 9;
@@ -135,8 +172,16 @@ message ServiceAccount {
 
 message CreateOAuthClientRequest {
   string partition_id = 1 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
-  string name = 2 [(buf.validate.field).string = {min_len: 3, max_len: 100}];
-  string type = 3 [(buf.validate.field).string = {in: ["public", "confidential"]}];
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 3
+    max_len: 100
+  }];
+  string type = 3 [(buf.validate.field).string = {
+    in: [
+      "public",
+      "confidential"
+    ]
+  }];
   OAuthClientConfiguration configuration = 4 [(buf.validate.field).required = true];
 }
 
@@ -149,7 +194,10 @@ message GetOAuthClientRequest {
   oneof selector {
     option (buf.validate.oneof).required = true;
     string id = 1 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
-    string client_id = 2 [(buf.validate.field).string = {min_len: 3, max_len: 100}];
+    string client_id = 2 [(buf.validate.field).string = {
+      min_len: 3
+      max_len: 100
+    }];
   }
 }
 
@@ -172,7 +220,13 @@ message ListOAuthClientsResponse {
 
 message UpdateOAuthClientRequest {
   string id = 1 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
-  string name = 2 [(buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE, (buf.validate.field).string = {min_len: 3, max_len: 100}];
+  string name = 2 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string = {
+      min_len: 3
+      max_len: 100
+    }
+  ];
   OAuthClientConfiguration configuration = 3;
   google.protobuf.FieldMask update_mask = 4 [(buf.validate.field).required = true];
 }
@@ -192,8 +246,16 @@ message RemoveOAuthClientResponse {
 message CreateServiceAccountRequest {
   string partition_id = 1 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
   string profile_id = 2 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
-  string name = 3 [(buf.validate.field).string = {min_len: 3, max_len: 100}];
-  string type = 4 [(buf.validate.field).string = {in: ["internal", "external"]}];
+  string name = 3 [(buf.validate.field).string = {
+    min_len: 3
+    max_len: 100
+  }];
+  string type = 4 [(buf.validate.field).string = {
+    in: [
+      "internal",
+      "external"
+    ]
+  }];
   OAuthClientConfiguration oauth_client = 5 [(buf.validate.field).required = true];
   ServiceAuthorizationPolicyInput authorization_policy = 6 [(buf.validate.field).required = true];
   google.protobuf.Struct public_keys = 7;
@@ -209,7 +271,10 @@ message GetServiceAccountRequest {
   oneof selector {
     option (buf.validate.oneof).required = true;
     string id = 1 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
-    string client_id = 2 [(buf.validate.field).string = {min_len: 3, max_len: 100}];
+    string client_id = 2 [(buf.validate.field).string = {
+      min_len: 3
+      max_len: 100
+    }];
   }
 }
 
@@ -228,8 +293,22 @@ message ListServiceAccountsResponse {
 
 message UpdateServiceAccountRequest {
   string id = 1 [(buf.validate.field).string.pattern = "[0-9a-z_-]{3,50}"];
-  string name = 2 [(buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE, (buf.validate.field).string = {min_len: 3, max_len: 100}];
-  string type = 3 [(buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE, (buf.validate.field).string = {in: ["internal", "external"]}];
+  string name = 2 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string = {
+      min_len: 3
+      max_len: 100
+    }
+  ];
+  string type = 3 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string = {
+      in: [
+        "internal",
+        "external"
+      ]
+    }
+  ];
   OAuthClientConfiguration oauth_client = 4;
   ServiceAuthorizationPolicyInput authorization_policy = 5;
   google.protobuf.Struct public_keys = 6;
@@ -260,7 +339,12 @@ message ReconcileServiceAccountAuthorizationResponse {
 service AuthContractService {
   option (common.v1.service_permissions) = {
     namespace: "service_tenancy"
-    permissions: ["service_account_view", "service_account_manage", "client_view", "client_manage"]
+    permissions: [
+      "service_account_view",
+      "service_account_manage",
+      "client_view",
+      "client_manage"
+    ]
   };
 
   rpc CreateOAuthClient(CreateOAuthClientRequest) returns (CreateOAuthClientResponse) {


### PR DESCRIPTION
## Summary
Apply the current Buf canonical formatter to the complete tenancy module.

This unblocks the release workflow `buf format -d --exit-code` gate so the already-reviewed tenancy.v2 contract can be pushed to BSR.

## Validation
- buf format -d --exit-code
- buf lint

Refs #733