### PR TITLE
fix(auth,tenancy): enforce tenancy pairs and harden login rate limits

### DIFF
--- a/apps/default/service/handlers/init_server.go
+++ b/apps/default/service/handlers/init_server.go
@@ -90,8 +90,7 @@ type AuthServer struct {
 
 	defaultHydraCli hydra.Hydra
 
-	// Rate limiter cache and config for login attempts
-	rateLimitICache      cache.Cache[string, RateLimitEntry]
+	// Rate limit config for login attempts (counters live in cacheMan)
 	loginRateLimitConfig RateLimitConfig
 
 	// Localization manager for i18n support

--- a/apps/default/service/handlers/login_step_2_google_fedcm_test.go
+++ b/apps/default/service/handlers/login_step_2_google_fedcm_test.go
@@ -17,9 +17,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
+	authconfig "github.com/antinvestor/service-authentication/apps/default/config"
 	"github.com/antinvestor/service-authentication/apps/default/service/telemetry"
+	"github.com/pitabwire/frame/v2/cache"
+	"github.com/stretchr/testify/require"
 )
 
 // These tests cover the input-validation perimeter of the Google FedCM
@@ -47,13 +48,20 @@ func newGoogleFedCMRequest(t *testing.T, body any, applyHeaders func(*http.Reque
 
 // fedcmEndpointHarness returns the minimal AuthServer surface needed to
 // exercise the endpoint's early-return paths. Steady-state assumes:
-//   - no rate-limit cache → CheckLoginRateLimit auto-allows
+//   - in-memory rate-limit cache so CheckLoginRateLimit is fail-closed-safe
 //   - noop analytics (telemetry.New with empty key) so emit calls don't panic
 //   - no LoginEventRepo so any test that needs the cache lookup would
 //     crash; tests must short-circuit before that.
 func fedcmEndpointHarness() *AuthServer {
+	cacheMan := cache.NewManager()
+	cacheMan.AddCache("defaultCache", cache.NewInMemoryCache())
 	return &AuthServer{
 		analytics: telemetry.New(context.Background(), "", ""),
+		config: &authconfig.AuthenticationConfig{
+			CacheName: "defaultCache",
+		},
+		cacheMan:             cacheMan,
+		loginRateLimitConfig: DefaultLoginRateLimitConfig(),
 	}
 }
 

--- a/apps/default/service/handlers/login_step_4_consent.go
+++ b/apps/default/service/handlers/login_step_4_consent.go
@@ -270,9 +270,14 @@ func (h *AuthServer) buildServiceAccountConsentClaims(ctx context.Context, conse
 		return nil, fmt.Errorf("failed to create login event: %w", createErr)
 	}
 
+	tenantID, partitionID := NormalizeTenancyPair(sa.GetTenantId(), sa.GetPartitionId())
+	if !ValidTenancyPair(tenantID, partitionID) {
+		return nil, ErrIncompleteTenancyPair
+	}
+
 	return map[string]any{
-		"tenant_id":      sa.GetTenantId(),
-		"partition_id":   sa.GetPartitionId(),
+		"tenant_id":      tenantID,
+		"partition_id":   partitionID,
 		"access_id":      accessObj.GetId(),
 		"roles":          roles,
 		"profile_id":     subjectID,
@@ -386,19 +391,30 @@ func (h *AuthServer) buildUserTokenClaims(
 		log.WithError(err).Debug("failed to persist roles in login event properties")
 	}
 
-	return BuildUserTokenClaims(loginEvent, subjectID, deviceObj.GetId(), roles), nil
+	return BuildUserTokenClaims(loginEvent, subjectID, deviceObj.GetId(), roles)
 }
 
 // BuildUserTokenClaims returns the map of claims inserted into user-facing
 // access and ID tokens at consent time. It is exported so the FedCM headless
 // driver can reuse the exact same shape.
 //
+// tenant_id and partition_id are required as a pair — incomplete tenancy
+// context fails closed rather than minting a partial token.
+//
 // The returned map must contain only string keys and JSON-serialisable values
 // because Hydra places it verbatim into AccessTokenExtras / IdTokenExtras.
-func BuildUserTokenClaims(loginEvent *models.LoginEvent, subjectID, deviceID string, roles []string) map[string]any {
+func BuildUserTokenClaims(loginEvent *models.LoginEvent, subjectID, deviceID string, roles []string) (map[string]any, error) {
+	if loginEvent == nil {
+		return nil, fmt.Errorf("login event is required")
+	}
+	tenantID, partitionID := NormalizeTenancyPair(loginEvent.GetTenantID(), loginEvent.GetPartitionID())
+	if !ValidTenancyPair(tenantID, partitionID) {
+		return nil, ErrIncompleteTenancyPair
+	}
+
 	return map[string]any{
-		"tenant_id":         loginEvent.GetTenantID(),
-		"partition_id":      loginEvent.GetPartitionID(),
+		"tenant_id":         tenantID,
+		"partition_id":      partitionID,
 		"access_id":         loginEvent.GetAccessID(),
 		"contact_id":        loginEvent.GetContactID(),
 		"session_id":        loginEvent.GetID(),
@@ -407,7 +423,7 @@ func BuildUserTokenClaims(loginEvent *models.LoginEvent, subjectID, deviceID str
 		"roles":             roles,
 		"device_id":         deviceID,
 		"profile_id":        subjectID,
-	}
+	}, nil
 }
 
 // extractLoginEventID extracts the login event ID from the consent context.

--- a/apps/default/service/handlers/login_step_4_consent_claims_test.go
+++ b/apps/default/service/handlers/login_step_4_consent_claims_test.go
@@ -37,7 +37,8 @@ func TestBuildUserTokenClaims_IncludesAllRequiredKeys(t *testing.T) {
 	ev.TenantID = "tenant_1"
 	ev.PartitionID = "part_1"
 
-	claims := handlers.BuildUserTokenClaims(ev, "prof_1", "dev_1", []string{"user"})
+	claims, err := handlers.BuildUserTokenClaims(ev, "prof_1", "dev_1", []string{"user"})
+	require.NoError(t, err)
 
 	require.Equal(t, "tenant_1", claims["tenant_id"])
 	require.Equal(t, "part_1", claims["partition_id"])
@@ -48,4 +49,25 @@ func TestBuildUserTokenClaims_IncludesAllRequiredKeys(t *testing.T) {
 	require.Equal(t, "contact_1", claims["contact_id"])
 	require.Equal(t, "access_1", claims["access_id"])
 	require.Equal(t, []string{"user"}, claims["roles"])
+}
+
+func TestBuildUserTokenClaims_RejectsIncompleteTenancyPair(t *testing.T) {
+	ev := &models.LoginEvent{
+		ProfileID: "prof_1",
+		AccessID:  "access_1",
+	}
+	ev.BaseModel = data.BaseModel{}
+	ev.ID = "login_evt_1"
+	ev.TenantID = "tenant_1"
+	// partition_id intentionally missing
+
+	claims, err := handlers.BuildUserTokenClaims(ev, "prof_1", "dev_1", []string{"user"})
+	require.ErrorIs(t, err, handlers.ErrIncompleteTenancyPair)
+	require.Nil(t, claims)
+
+	ev.TenantID = ""
+	ev.PartitionID = "part_1"
+	claims, err = handlers.BuildUserTokenClaims(ev, "prof_1", "dev_1", []string{"user"})
+	require.ErrorIs(t, err, handlers.ErrIncompleteTenancyPair)
+	require.Nil(t, claims)
 }

--- a/apps/default/service/handlers/oauth_token_facade.go
+++ b/apps/default/service/handlers/oauth_token_facade.go
@@ -343,7 +343,10 @@ func (h *AuthServer) handleNativeTokenExchange(ctx context.Context, r *http.Requ
 	if len(roles) == 0 {
 		roles = []string{"user"}
 	}
-	claims := BuildUserTokenClaims(loginEvent, profileID, deviceID, roles)
+	claims, err := BuildUserTokenClaims(loginEvent, profileID, deviceID, roles)
+	if err != nil {
+		return nil, oauthErr(http.StatusInternalServerError, "server_error", "incomplete tenancy claims")
+	}
 	scopes := tokenScopes(hydraClient.GetScope())
 	nonce := strings.TrimSpace(form.Get("nonce"))
 

--- a/apps/default/service/handlers/rate_limiter.go
+++ b/apps/default/service/handlers/rate_limiter.go
@@ -18,22 +18,23 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"time"
 
 	"github.com/pitabwire/frame/v2/cache"
 	"github.com/pitabwire/util"
 )
 
-// Rate limit cache key prefix - uses alphanumeric and underscore (NATS-safe)
-const rateLimitCachePrefix = "login_rl_ip_"
+// Rate limit cache key prefix - uses alphanumeric and underscore (NATS-safe).
+const rateLimitCachePrefix = "login_rl_"
 
-// RateLimitConfig holds configuration for rate limiting
+// RateLimitConfig holds configuration for rate limiting.
 type RateLimitConfig struct {
 	MaxAttempts int           // Maximum attempts allowed
 	Window      time.Duration // Time window for rate limiting
 }
 
-// DefaultLoginRateLimitConfig returns the default rate limit config for login attempts
+// DefaultLoginRateLimitConfig returns the default rate limit config for login attempts.
 func DefaultLoginRateLimitConfig() RateLimitConfig {
 	return RateLimitConfig{
 		MaxAttempts: 7,
@@ -41,14 +42,7 @@ func DefaultLoginRateLimitConfig() RateLimitConfig {
 	}
 }
 
-// RateLimitEntry tracks attempts for a single key
-type RateLimitEntry struct {
-	Attempts  int       `json:"attempts"`
-	FirstAt   time.Time `json:"first_at"`
-	ExpiresAt time.Time `json:"expires_at"`
-}
-
-// RateLimitResult contains the result of a rate limit check
+// RateLimitResult contains the result of a rate limit check.
 type RateLimitResult struct {
 	Allowed       bool
 	AttemptsUsed  int
@@ -57,130 +51,147 @@ type RateLimitResult struct {
 	RetryAfterSec int
 }
 
-// hashIP creates a SHA256 hash of the IP address for privacy
+// hashIP creates a SHA256 hash of the rate-limit key (IP or compound key) for privacy.
 func hashIP(ip string) string {
 	hash := sha256.Sum256([]byte(ip))
 	return hex.EncodeToString(hash[:])
 }
 
-// rateLimitCacheKey generates a cache key for rate limiting by IP
-func rateLimitCacheKey(ip string) string {
-	return rateLimitCachePrefix + hashIP(ip)
-}
-
-// rateLimitCache returns the generic cache for rate limit entries
-func (h *AuthServer) rateLimitCache() cache.Cache[string, RateLimitEntry] {
-	if h.rateLimitICache == nil {
-		if h.cacheMan == nil {
-			return nil
-		}
-		rCache, ok := h.cacheMan.GetRawCache(h.config.CacheName)
-		if !ok {
-			return nil
-		}
-
-		h.rateLimitICache = cache.NewGenericCache[string, RateLimitEntry](rCache, func(k string) string {
-			return k
-		})
+// rateLimitBucketKey builds a fixed-window counter key for the given identity and time.
+func rateLimitBucketKey(key string, window time.Duration, now time.Time) string {
+	windowSecs := int64(window.Seconds())
+	if windowSecs <= 0 {
+		windowSecs = int64(time.Hour.Seconds())
 	}
-	return h.rateLimitICache
+	bucket := now.Unix() / windowSecs
+	return fmt.Sprintf("%s%s:%d", rateLimitCachePrefix, hashIP(key), bucket)
 }
 
-// CheckLoginRateLimit checks rate limits for the given IP address
-// Returns the result indicating if the request is allowed
-func (h *AuthServer) CheckLoginRateLimit(ctx context.Context, ip string) RateLimitResult {
+func (h *AuthServer) rateLimitConfig() RateLimitConfig {
+	cfg := h.loginRateLimitConfig
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = DefaultLoginRateLimitConfig().MaxAttempts
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = DefaultLoginRateLimitConfig().Window
+	}
+	return cfg
+}
+
+func (h *AuthServer) rawRateLimitCache() cache.RawCache {
+	if h == nil || h.cacheMan == nil || h.config == nil {
+		return nil
+	}
+	name := h.config.CacheName
+	if name == "" {
+		name = "defaultCache"
+	}
+	raw, ok := h.cacheMan.GetRawCache(name)
+	if !ok {
+		return nil
+	}
+	return raw
+}
+
+func denyRateLimitResult(cfg RateLimitConfig, retryAfter time.Duration) RateLimitResult {
+	if retryAfter < 0 {
+		retryAfter = 0
+	}
+	return RateLimitResult{
+		Allowed:       false,
+		AttemptsUsed:  cfg.MaxAttempts,
+		AttemptsLeft:  0,
+		RetryAfter:    retryAfter,
+		RetryAfterSec: int(retryAfter.Seconds()),
+	}
+}
+
+func windowRetryAfter(window time.Duration, now time.Time) time.Duration {
+	windowSecs := int64(window.Seconds())
+	if windowSecs <= 0 {
+		windowSecs = int64(time.Hour.Seconds())
+	}
+	endOfWindow := time.Unix((now.Unix()/windowSecs+1)*windowSecs, 0).UTC()
+	retryAfter := endOfWindow.Sub(now)
+	if retryAfter < 0 {
+		return 0
+	}
+	return retryAfter
+}
+
+// CheckLoginRateLimit checks rate limits for the given key (IP or compound identity).
+//
+// Semantics:
+//   - Atomic fixed-window counter via cache.Increment (safe under concurrency)
+//   - Fail-closed when the cache is unavailable or increment fails — login
+//     surfaces must not become unbounded under infrastructure faults
+func (h *AuthServer) CheckLoginRateLimit(ctx context.Context, key string) RateLimitResult {
 	log := util.Log(ctx)
-	now := time.Now()
+	cfg := h.rateLimitConfig()
+	now := time.Now().UTC()
+	retryAfter := windowRetryAfter(cfg.Window, now)
 
-	cacheInst := h.rateLimitCache()
-	if cacheInst == nil {
-		// Cache not available, allow request but log warning
-		log.Warn("rate limit cache not available, allowing request")
-		return RateLimitResult{
-			Allowed:      true,
-			AttemptsUsed: 0,
-			AttemptsLeft: h.loginRateLimitConfig.MaxAttempts,
-		}
+	raw := h.rawRateLimitCache()
+	if raw == nil {
+		log.Error("rate limit cache not available, denying request")
+		return denyRateLimitResult(cfg, retryAfter)
 	}
 
-	cacheKey := rateLimitCacheKey(ip)
-	entry, found, err := cacheInst.Get(ctx, cacheKey)
+	bucketKey := rateLimitBucketKey(key, cfg.Window, now)
+	count, err := raw.Increment(ctx, bucketKey, 1)
 	if err != nil {
-		log.WithError(err).Warn("rate limit cache read error, allowing request")
-		return RateLimitResult{
-			Allowed:      true,
-			AttemptsUsed: 0,
-			AttemptsLeft: h.loginRateLimitConfig.MaxAttempts,
+		log.WithError(err).Error("rate limit increment failed, denying request")
+		return denyRateLimitResult(cfg, retryAfter)
+	}
+
+	// Best-effort TTL so backends that support it reclaim the bucket.
+	// Backends without per-key TTL still isolate counts by window id in the key.
+	if count == 1 {
+		if expErr := raw.Expire(ctx, bucketKey, cfg.Window+time.Second); expErr != nil {
+			log.WithError(expErr).Debug("rate limit bucket expire failed")
 		}
 	}
 
-	// If entry doesn't exist or has expired, create a new one
-	if !found || now.After(entry.ExpiresAt) {
-		newEntry := RateLimitEntry{
-			Attempts:  1,
-			FirstAt:   now,
-			ExpiresAt: now.Add(h.loginRateLimitConfig.Window),
-		}
-
-		if setErr := cacheInst.Set(ctx, cacheKey, newEntry, h.loginRateLimitConfig.Window); setErr != nil {
-			log.WithError(setErr).Warn("failed to set rate limit entry in cache")
-		}
-
-		return RateLimitResult{
-			Allowed:      true,
-			AttemptsUsed: 1,
-			AttemptsLeft: h.loginRateLimitConfig.MaxAttempts - 1,
-		}
-	}
-
-	// Check if limit exceeded
-	if entry.Attempts >= h.loginRateLimitConfig.MaxAttempts {
-		retryAfter := entry.ExpiresAt.Sub(now)
+	if count > int64(cfg.MaxAttempts) {
 		log.WithFields(map[string]any{
-			"ip_hash":       hashIP(ip)[:16] + "...",
-			"attempts":      entry.Attempts,
+			"key_hash":      hashIP(key)[:16] + "...",
+			"attempts":      count,
 			"retry_after_s": int(retryAfter.Seconds()),
-		}).Warn("login rate limit exceeded for IP")
+		}).Warn("login rate limit exceeded")
 
 		return RateLimitResult{
 			Allowed:       false,
-			AttemptsUsed:  entry.Attempts,
+			AttemptsUsed:  int(count),
 			AttemptsLeft:  0,
 			RetryAfter:    retryAfter,
 			RetryAfterSec: int(retryAfter.Seconds()),
 		}
 	}
 
-	// Increment counter
-	entry.Attempts++
-	ttlRemaining := entry.ExpiresAt.Sub(now)
-	if setErr := cacheInst.Set(ctx, cacheKey, entry, ttlRemaining); setErr != nil {
-		log.WithError(setErr).Warn("failed to update rate limit entry in cache")
-	}
-
 	return RateLimitResult{
 		Allowed:      true,
-		AttemptsUsed: entry.Attempts,
-		AttemptsLeft: h.loginRateLimitConfig.MaxAttempts - entry.Attempts,
+		AttemptsUsed: int(count),
+		AttemptsLeft: cfg.MaxAttempts - int(count),
 	}
 }
 
-// ResetLoginRateLimit resets rate limits after successful login for the given IP
-func (h *AuthServer) ResetLoginRateLimit(ctx context.Context, ip string) {
-	cacheInst := h.rateLimitCache()
-	if cacheInst == nil {
+// ResetLoginRateLimit clears the current window counter after successful auth.
+func (h *AuthServer) ResetLoginRateLimit(ctx context.Context, key string) {
+	raw := h.rawRateLimitCache()
+	if raw == nil {
 		return
 	}
 
-	cacheKey := rateLimitCacheKey(ip)
-	if err := cacheInst.Delete(ctx, cacheKey); err != nil {
-		util.Log(ctx).WithError(err).Debug("failed to delete rate limit entry from cache")
+	cfg := h.rateLimitConfig()
+	bucketKey := rateLimitBucketKey(key, cfg.Window, time.Now().UTC())
+	if err := raw.Delete(ctx, bucketKey); err != nil {
+		util.Log(ctx).WithError(err).Debug("failed to delete rate limit bucket from cache")
 	}
 }
 
 // ResetAllLoginRateLimits is a no-op for cache-based rate limiting
-// as cache entries will naturally expire. This is kept for test compatibility.
+// as cache entries will naturally expire. Kept for test compatibility.
 func (h *AuthServer) ResetAllLoginRateLimits() {
-	// Cache entries expire naturally based on TTL.
-	// For testing purposes, individual entries can be reset via ResetLoginRateLimit.
+	// Cache entries expire naturally based on TTL / window id rotation.
+	// For testing, reset individual keys via ResetLoginRateLimit.
 }

--- a/apps/default/service/handlers/rate_limiter_test.go
+++ b/apps/default/service/handlers/rate_limiter_test.go
@@ -15,9 +15,14 @@
 package handlers
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
+	authconfig "github.com/antinvestor/service-authentication/apps/default/config"
+	"github.com/pitabwire/frame/v2/cache"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -42,27 +47,17 @@ func (s *RateLimiterTestSuite) TestHashIP_Length() {
 	s.Len(hash, 64, "SHA256 hex should be 64 chars")
 }
 
-func (s *RateLimiterTestSuite) TestRateLimitCacheKey() {
-	key := rateLimitCacheKey("192.168.1.1")
+func (s *RateLimiterTestSuite) TestRateLimitBucketKey() {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	key := rateLimitBucketKey("192.168.1.1", time.Hour, now)
 	s.Contains(key, rateLimitCachePrefix)
-	s.Len(key, len(rateLimitCachePrefix)+64)
+	s.Contains(key, ":")
 }
 
 func (s *RateLimiterTestSuite) TestDefaultLoginRateLimitConfig() {
 	cfg := DefaultLoginRateLimitConfig()
 	s.Equal(7, cfg.MaxAttempts)
 	s.Equal(time.Hour, cfg.Window)
-}
-
-func (s *RateLimiterTestSuite) TestRateLimitEntry_Fields() {
-	now := time.Now()
-	entry := RateLimitEntry{
-		Attempts:  3,
-		FirstAt:   now,
-		ExpiresAt: now.Add(time.Hour),
-	}
-	s.Equal(3, entry.Attempts)
-	s.Equal(now, entry.FirstAt)
 }
 
 func (s *RateLimiterTestSuite) TestRateLimitResult_Fields() {
@@ -80,4 +75,112 @@ func (s *RateLimiterTestSuite) TestRateLimitResult_Fields() {
 
 func TestRateLimiter(t *testing.T) {
 	suite.Run(t, new(RateLimiterTestSuite))
+}
+
+func newRateLimitTestServer(t *testing.T, maxAttempts int) *AuthServer {
+	t.Helper()
+	cacheMan := cache.NewManager()
+	cacheMan.AddCache("defaultCache", cache.NewInMemoryCache())
+	return &AuthServer{
+		config: &authconfig.AuthenticationConfig{
+			CacheName: "defaultCache",
+		},
+		cacheMan: cacheMan,
+		loginRateLimitConfig: RateLimitConfig{
+			MaxAttempts: maxAttempts,
+			Window:      time.Hour,
+		},
+	}
+}
+
+func TestCheckLoginRateLimit_AllowsUntilMaxThenDenies(t *testing.T) {
+	t.Parallel()
+	h := newRateLimitTestServer(t, 3)
+	ctx := context.Background()
+	ip := "203.0.113.10"
+
+	for i := 1; i <= 3; i++ {
+		result := h.CheckLoginRateLimit(ctx, ip)
+		require.True(t, result.Allowed, "attempt %d should be allowed", i)
+		require.Equal(t, i, result.AttemptsUsed)
+		require.Equal(t, 3-i, result.AttemptsLeft)
+	}
+
+	denied := h.CheckLoginRateLimit(ctx, ip)
+	require.False(t, denied.Allowed)
+	require.Equal(t, 0, denied.AttemptsLeft)
+	require.Greater(t, denied.RetryAfterSec, 0)
+}
+
+func TestCheckLoginRateLimit_ResetClearsWindow(t *testing.T) {
+	t.Parallel()
+	h := newRateLimitTestServer(t, 2)
+	ctx := context.Background()
+	ip := "203.0.113.11"
+
+	require.True(t, h.CheckLoginRateLimit(ctx, ip).Allowed)
+	require.True(t, h.CheckLoginRateLimit(ctx, ip).Allowed)
+	require.False(t, h.CheckLoginRateLimit(ctx, ip).Allowed)
+
+	h.ResetLoginRateLimit(ctx, ip)
+
+	result := h.CheckLoginRateLimit(ctx, ip)
+	require.True(t, result.Allowed)
+	require.Equal(t, 1, result.AttemptsUsed)
+}
+
+func TestCheckLoginRateLimit_FailClosedWithoutCache(t *testing.T) {
+	t.Parallel()
+	h := &AuthServer{
+		loginRateLimitConfig: DefaultLoginRateLimitConfig(),
+	}
+	result := h.CheckLoginRateLimit(context.Background(), "203.0.113.12")
+	require.False(t, result.Allowed, "missing cache must deny, not fail open")
+}
+
+func TestCheckLoginRateLimit_IsolatesKeys(t *testing.T) {
+	t.Parallel()
+	h := newRateLimitTestServer(t, 1)
+	ctx := context.Background()
+
+	require.True(t, h.CheckLoginRateLimit(ctx, "203.0.113.20").Allowed)
+	require.False(t, h.CheckLoginRateLimit(ctx, "203.0.113.20").Allowed)
+	require.True(t, h.CheckLoginRateLimit(ctx, "203.0.113.21").Allowed,
+		"a different IP must have an independent budget")
+}
+
+func TestCheckLoginRateLimit_ConcurrentIncrementsDoNotBypassLimit(t *testing.T) {
+	t.Parallel()
+	const maxAttempts = 20
+	const workers = 50
+
+	h := newRateLimitTestServer(t, maxAttempts)
+	ctx := context.Background()
+	ip := "203.0.113.30"
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		allowed int
+		denied  int
+	)
+
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			result := h.CheckLoginRateLimit(ctx, ip)
+			mu.Lock()
+			if result.Allowed {
+				allowed++
+			} else {
+				denied++
+			}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	require.Equal(t, maxAttempts, allowed, "exactly MaxAttempts should succeed under contention")
+	require.Equal(t, workers-maxAttempts, denied)
 }

--- a/apps/default/service/handlers/tenancy_access.go
+++ b/apps/default/service/handlers/tenancy_access.go
@@ -599,12 +599,12 @@ func (h *AuthServer) ensureLoginEventTenancyAccess(
 		loginEvent.AccessID = accessObj.GetId()
 		changed["access_id"] = struct{}{}
 	}
-	if loginEvent.PartitionID != accessPartition.GetId() {
+	// Tenant and partition are always updated as a pair so login events never
+	// hold a split tenancy context after access resolution.
+	if loginEvent.PartitionID != accessPartition.GetId() || loginEvent.TenantID != accessPartition.GetTenantId() {
 		loginEvent.PartitionID = accessPartition.GetId()
-		changed["partition_id"] = struct{}{}
-	}
-	if loginEvent.TenantID != accessPartition.GetTenantId() {
 		loginEvent.TenantID = accessPartition.GetTenantId()
+		changed["partition_id"] = struct{}{}
 		changed["tenant_id"] = struct{}{}
 	}
 

--- a/apps/default/service/handlers/tenancy_pair.go
+++ b/apps/default/service/handlers/tenancy_pair.go
@@ -1,0 +1,46 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrIncompleteTenancyPair is returned when tenant_id and partition_id are not
+// both present. Token issuance and enrichment treat them as a single unit of
+// tenancy context — never emit or accept one without the other.
+var ErrIncompleteTenancyPair = errors.New("tenant_id and partition_id must both be set")
+
+// NormalizeTenancyPair trims tenant and partition identifiers.
+func NormalizeTenancyPair(tenantID, partitionID string) (string, string) {
+	return strings.TrimSpace(tenantID), strings.TrimSpace(partitionID)
+}
+
+// ValidTenancyPair reports whether both tenant_id and partition_id are non-empty.
+func ValidTenancyPair(tenantID, partitionID string) bool {
+	tenantID, partitionID = NormalizeTenancyPair(tenantID, partitionID)
+	return tenantID != "" && partitionID != ""
+}
+
+// TenancyPairFromClaims extracts tenant_id and partition_id from a claims map.
+func TenancyPairFromClaims(claims map[string]any) (tenantID, partitionID string) {
+	return claimString(claims, "tenant_id"), claimString(claims, "partition_id")
+}
+
+// ClaimsHaveTenancyPair reports whether claims carry a complete tenancy pair.
+func ClaimsHaveTenancyPair(claims map[string]any) bool {
+	return ValidTenancyPair(TenancyPairFromClaims(claims))
+}

--- a/apps/default/service/handlers/tenancy_pair_test.go
+++ b/apps/default/service/handlers/tenancy_pair_test.go
@@ -1,0 +1,62 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidTenancyPair(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		tenantID    string
+		partitionID string
+		want        bool
+	}{
+		{name: "both set", tenantID: "t1", partitionID: "p1", want: true},
+		{name: "trimmed both set", tenantID: " t1 ", partitionID: " p1 ", want: true},
+		{name: "only tenant", tenantID: "t1", partitionID: "", want: false},
+		{name: "only partition", tenantID: "", partitionID: "p1", want: false},
+		{name: "both empty", tenantID: "", partitionID: "", want: false},
+		{name: "whitespace only", tenantID: "  ", partitionID: "  ", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, ValidTenancyPair(tc.tenantID, tc.partitionID))
+		})
+	}
+}
+
+func TestClaimsHaveTenancyPair(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, ClaimsHaveTenancyPair(map[string]any{
+		"tenant_id":    "t1",
+		"partition_id": "p1",
+	}))
+	require.False(t, ClaimsHaveTenancyPair(map[string]any{
+		"tenant_id": "t1",
+	}))
+	require.False(t, ClaimsHaveTenancyPair(map[string]any{
+		"partition_id": "p1",
+	}))
+	require.False(t, ClaimsHaveTenancyPair(nil))
+}

--- a/apps/default/service/handlers/webhook.go
+++ b/apps/default/service/handlers/webhook.go
@@ -17,6 +17,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -309,7 +310,11 @@ func extractNestedClaims(idTokenWrapper map[string]any) (map[string]any, map[str
 }
 
 // selectFinalClaims selects the best available claims from multiple sources.
-// Priority: access_token > ext.id_token_claims > ext (with tenant_id) > session.extra
+// Priority: access_token > ext.id_token_claims > ext (complete tenancy pair) > session.extra
+//
+// tenant_id and partition_id are always treated as a pair: a source that only
+// carries one of them is not preferred over a fuller source, and is never
+// considered "complete consent extras" on its own.
 func selectFinalClaims(accessTokenClaims, deepNestedClaims, extClaims, extraClaims map[string]any) map[string]any {
 	if len(accessTokenClaims) > 0 {
 		return accessTokenClaims
@@ -317,13 +322,11 @@ func selectFinalClaims(accessTokenClaims, deepNestedClaims, extClaims, extraClai
 	if len(deepNestedClaims) > 0 {
 		return deepNestedClaims
 	}
-	if len(extClaims) > 0 {
-		// Use ext claims if they contain our tenant_id claim, which is always
-		// present in consent-set extras (unlike contact_id which may be empty
-		// and omitted by Hydra's JSON serialisation for some flows).
-		if tenantID, _ := extClaims["tenant_id"].(string); tenantID != "" {
-			return extClaims
-		}
+	if len(extClaims) > 0 && ClaimsHaveTenancyPair(extClaims) {
+		// Consent-set extras always carry the full tenancy pair (unlike
+		// contact_id which may be empty and omitted by Hydra's JSON
+		// serialisation for some flows).
+		return extClaims
 	}
 	if len(extraClaims) > 0 {
 		return extraClaims
@@ -389,10 +392,18 @@ func buildServiceAccountClaims(
 	sa *serviceAccountAuthContext,
 	accessID string,
 	roles []string,
-) map[string]any {
+) (map[string]any, error) {
+	if sa == nil {
+		return nil, errors.New("service account context is required")
+	}
+	tenantID, partitionID := NormalizeTenancyPair(sa.TenantID, sa.PartitionID)
+	if !ValidTenancyPair(tenantID, partitionID) {
+		return nil, ErrIncompleteTenancyPair
+	}
+
 	claims := map[string]any{
-		"tenant_id":      sa.TenantID,
-		"partition_id":   sa.PartitionID,
+		"tenant_id":      tenantID,
+		"partition_id":   partitionID,
 		"roles":          roles,
 		"profile_id":     sa.ProfileID,
 		"session_id":     loginEventID,
@@ -404,7 +415,7 @@ func buildServiceAccountClaims(
 	if accessID != "" {
 		claims["access_id"] = accessID
 	}
-	return claims
+	return claims, nil
 }
 
 // extractSessionAccessTokenClaims extracts the access_token claims from the session object.
@@ -464,8 +475,15 @@ func loginEventRoles(loginEvent *models.LoginEvent) []string {
 }
 
 func missingRequiredUserClaims(claims map[string]any) []string {
-	required := []string{"tenant_id", "partition_id", "access_id", "session_id", "profile_id"}
-	missing := make([]string, 0, len(required))
+	required := []string{"access_id", "session_id", "profile_id"}
+	missing := make([]string, 0, len(required)+2)
+
+	// Tenancy is atomic: either both tenant_id and partition_id are present,
+	// or both are reported missing so partial pairs never pass validation.
+	if !ClaimsHaveTenancyPair(claims) {
+		missing = append(missing, "tenant_id", "partition_id")
+	}
+
 	for _, key := range required {
 		if claimString(claims, key) == "" {
 			missing = append(missing, key)
@@ -671,7 +689,11 @@ func (h *AuthServer) handleServiceAccountEnrichment(ctx context.Context, rw http
 		accessID = claimString(sessionClaims, "access_id")
 	}
 
-	claims := buildServiceAccountClaims(loginEvent.GetID(), sa, accessID, roles)
+	claims, claimsErr := buildServiceAccountClaims(loginEvent.GetID(), sa, accessID, roles)
+	if claimsErr != nil {
+		log.WithError(claimsErr).Error("service account claims incomplete")
+		return h.writeWebhookError(rw, "incomplete tenancy claims")
+	}
 	h.recordTokenWebhookTrace(ctx, loginEvent, tokenType, grantType, "service_account", grantedScopes)
 
 	log.WithFields(map[string]any{
@@ -796,10 +818,14 @@ func (h *AuthServer) handleUserTokenEnrichment(ctx context.Context, rw http.Resp
 		return h.writeWebhookError(rw, "missing user claims in consent session")
 	}
 
-	// If the session claims contain non-user roles (system_internal/system_external),
+	// If the session claims contain non-user roles (internal/external),
 	// pass them through directly. These tokens were set server-side during consent
-	// and do not require login event lookup.
+	// and do not require login event lookup — but the tenancy pair is still required.
 	if isNonUserRole(finalClaims["roles"]) {
+		if !ClaimsHaveTenancyPair(finalClaims) {
+			log.Warn("token enrichment rejected: non-user roles without complete tenancy pair")
+			return h.writeWebhookError(rw, "incomplete tenancy claims")
+		}
 		log.Debug("non-user role detected in session claims - passing through without login event lookup")
 		return writeTokenHookResponse(rw, finalClaims)
 	}

--- a/apps/default/service/handlers/webhook_helpers_test.go
+++ b/apps/default/service/handlers/webhook_helpers_test.go
@@ -253,7 +253,11 @@ func (s *WebhookHelpersTestSuite) TestExtractNestedClaims_Nil() {
 func (s *WebhookHelpersTestSuite) TestSelectFinalClaims_Priority() {
 	at := map[string]any{"from": "access_token"}
 	deep := map[string]any{"from": "deep"}
-	ext := map[string]any{"tenant_id": "t-1", "from": "ext"}
+	ext := map[string]any{
+		"tenant_id":    "t-1",
+		"partition_id": "p-1",
+		"from":         "ext",
+	}
 	extra := map[string]any{"from": "extra"}
 
 	s.Equal(at, selectFinalClaims(at, deep, ext, extra))
@@ -267,8 +271,12 @@ func (s *WebhookHelpersTestSuite) TestSelectFinalClaims_ExtWithoutTenantID() {
 	ext := map[string]any{"other": "val"} // no tenant_id
 	extra := map[string]any{"from": "extra"}
 
-	// ext without tenant_id should be skipped (tenant_id is always set by consent)
+	// ext without a complete tenancy pair should be skipped
 	s.Equal(extra, selectFinalClaims(nil, nil, ext, extra))
+
+	// ext with only tenant_id (partial pair) is not preferred over extra
+	partialExt := map[string]any{"tenant_id": "t-only"}
+	s.Equal(extra, selectFinalClaims(nil, nil, partialExt, extra))
 }
 
 // --- writeTokenHookResponse ---
@@ -314,11 +322,25 @@ func (s *WebhookHelpersTestSuite) TestMissingRequiredUserClaims_Incomplete() {
 		"tenant_id": "t",
 	}
 	missing := missingRequiredUserClaims(claims)
+	// Partial tenancy pairs report both members missing — they are atomic.
+	s.Contains(missing, "tenant_id")
 	s.Contains(missing, "partition_id")
 	s.Contains(missing, "access_id")
 	s.Contains(missing, "session_id")
 	s.Contains(missing, "profile_id")
-	s.NotContains(missing, "tenant_id")
+}
+
+func (s *WebhookHelpersTestSuite) TestMissingRequiredUserClaims_PartialPartitionOnly() {
+	claims := map[string]any{
+		"partition_id": "p",
+		"access_id":    "a",
+		"session_id":   "s",
+		"profile_id":   "pr",
+	}
+	missing := missingRequiredUserClaims(claims)
+	s.Contains(missing, "tenant_id")
+	s.Contains(missing, "partition_id")
+	s.NotContains(missing, "access_id")
 }
 
 // --- buildClaimsFromLoginEvent ---
@@ -337,16 +359,29 @@ func (s *WebhookHelpersTestSuite) TestBuildClaimsFromLoginEvent() {
 }
 
 func (s *WebhookHelpersTestSuite) TestBuildServiceAccountClaimsIncludesStableIdentity() {
-	claims := buildServiceAccountClaims("event-1", &serviceAccountAuthContext{
+	claims, err := buildServiceAccountClaims("event-1", &serviceAccountAuthContext{
 		ServiceAccountID: "service-account-1",
 		TenantID:         "tenant-1",
 		PartitionID:      "partition-1",
 		ProfileID:        "profile-1",
 	}, "access-1", []string{"internal"})
+	s.Require().NoError(err)
 
 	ext, ok := claims["ext"].(map[string]any)
 	s.Require().True(ok)
 	s.Equal("service-account-1", ext["service_account_id"])
+	s.Equal("tenant-1", claims["tenant_id"])
+	s.Equal("partition-1", claims["partition_id"])
+}
+
+func (s *WebhookHelpersTestSuite) TestBuildServiceAccountClaims_RejectsIncompleteTenancyPair() {
+	_, err := buildServiceAccountClaims("event-1", &serviceAccountAuthContext{
+		ServiceAccountID: "service-account-1",
+		TenantID:         "tenant-1",
+		// PartitionID missing
+		ProfileID: "profile-1",
+	}, "access-1", []string{"internal"})
+	s.ErrorIs(err, ErrIncompleteTenancyPair)
 }
 
 // --- extractSessionAccessTokenClaims ---

--- a/apps/default/service/repository/login_event.go
+++ b/apps/default/service/repository/login_event.go
@@ -274,7 +274,7 @@ func (r *loginEventRepository) Search(
 		r.WorkManager(),
 		query,
 		func(ctx context.Context, query *data.SearchQuery) ([]*models.LoginEvent, error) {
-			return data.SearchFunc[*models.LoginEvent](
+			return datastore.SearchFunc[*models.LoginEvent](
 				ctx,
 				scopeLoginEventQuery(ctx, r.Pool().DB(ctx, true)),
 				query,

--- a/apps/default/service/repository/login_event.go
+++ b/apps/default/service/repository/login_event.go
@@ -274,7 +274,7 @@ func (r *loginEventRepository) Search(
 		r.WorkManager(),
 		query,
 		func(ctx context.Context, query *data.SearchQuery) ([]*models.LoginEvent, error) {
-			return datastore.SearchFunc[*models.LoginEvent](
+			return data.SearchFunc[*models.LoginEvent](
 				ctx,
 				scopeLoginEventQuery(ctx, r.Pool().DB(ctx, true)),
 				query,

--- a/apps/tenancy/service/business/access.go
+++ b/apps/tenancy/service/business/access.go
@@ -230,12 +230,29 @@ func (ab *accessBusiness) CreateAccess(
 
 	logger.Debug("creating access record")
 
-	partition, err := ab.partitionRepo.GetByID(ctx, request.GetPartitionId())
+	partitionID := ""
+	profileID := ""
+	if request != nil {
+		partitionID = request.GetPartitionId()
+		profileID = request.GetProfileId()
+	}
+	if partitionID == "" {
+		return nil, fmt.Errorf("partition_id is required")
+	}
+	if profileID == "" {
+		return nil, fmt.Errorf("profile_id is required")
+	}
+
+	partition, err := ab.partitionRepo.GetByID(ctx, partitionID)
 	if err != nil {
 		return nil, err
 	}
+	// Access records must carry a complete tenancy pair derived from the partition.
+	if partition.TenantID == "" || partition.GetID() == "" {
+		return nil, fmt.Errorf("partition has incomplete tenancy context")
+	}
 
-	access, err := ab.accessRepo.GetByPartitionAndProfile(ctx, partition.GetID(), request.GetProfileId())
+	access, err := ab.accessRepo.GetByPartitionAndProfile(ctx, partition.GetID(), profileID)
 	if err != nil {
 		if !data.ErrorIsNoRows(err) {
 			return nil, err
@@ -246,7 +263,7 @@ func (ab *accessBusiness) CreateAccess(
 	}
 
 	access = &models.Access{
-		ProfileID: request.GetProfileId(),
+		ProfileID: profileID,
 		BaseModel: data.BaseModel{
 			TenantID:    partition.TenantID,
 			PartitionID: partition.GetID(),
@@ -258,10 +275,11 @@ func (ab *accessBusiness) CreateAccess(
 		return nil, err
 	}
 
-	// Emit event to write tenancy_access#member tuple asynchronously
+	// Emit event to write tenancy_access#member tuple asynchronously.
+	// Path is always tenant_id/partition_id as a pair.
+	tenancyPath := fmt.Sprintf("%s/%s", partition.TenantID, partition.GetID())
 	if ab.eventsMan != nil {
-		tenancyPath := fmt.Sprintf("%s/%s", partition.TenantID, partition.GetID())
-		accessTuple := authz.BuildAccessTuple(tenancyPath, request.GetProfileId())
+		accessTuple := authz.BuildAccessTuple(tenancyPath, profileID)
 		payload := events.TuplesToPayload([]security.RelationTuple{accessTuple})
 		if emitErr := ab.eventsMan.Emit(ctx, events.EventKeyAuthzTupleWrite, payload); emitErr != nil {
 			util.Log(ctx).WithError(emitErr).Warn("failed to emit tenancy_access tuple write event")
@@ -274,7 +292,6 @@ func (ab *accessBusiness) CreateAccess(
 		logger.WithError(defaultErr).Warn("failed to query default partition roles")
 	}
 	if len(defaultRoles) > 0 {
-		tenancyPath := fmt.Sprintf("%s/%s", partition.TenantID, partition.GetID())
 		for _, role := range defaultRoles {
 			accessRole := &models.AccessRole{
 				AccessID:        access.GetID(),
@@ -285,7 +302,7 @@ func (ab *accessBusiness) CreateAccess(
 				continue
 			}
 			if ab.eventsMan != nil {
-				tuples := authz.BuildRoleTuples(tenancyPath, request.GetProfileId(), role.Name, ab.registeredNamespaces(ctx))
+				tuples := authz.BuildRoleTuples(tenancyPath, profileID, role.Name, ab.registeredNamespaces(ctx))
 				payload := events.TuplesToPayload(tuples)
 				if emitErr := ab.eventsMan.Emit(ctx, events.EventKeyAuthzTupleWrite, payload); emitErr != nil {
 					logger.WithError(emitErr).Warn("failed to emit default role tuple write")

--- a/apps/tenancy/service/business/auth_contract_v2.go
+++ b/apps/tenancy/service/business/auth_contract_v2.go
@@ -277,9 +277,27 @@ func (b *authContractBusiness) CreateServiceAccount(
 	ctx context.Context,
 	request *tenancyv2.CreateServiceAccountRequest,
 ) (*tenancyv2.CreateServiceAccountResponse, error) {
+	if request == nil {
+		return nil, errors.New("request is required")
+	}
+	if strings.TrimSpace(request.GetPartitionId()) == "" {
+		return nil, errors.New("partition_id is required")
+	}
+	if strings.TrimSpace(request.GetProfileId()) == "" {
+		return nil, errors.New("profile_id is required")
+	}
+	if strings.TrimSpace(request.GetName()) == "" {
+		return nil, errors.New("service account name is required")
+	}
+
 	partition, err := b.partitionRepo.GetByID(ctx, request.GetPartitionId())
 	if err != nil {
 		return nil, fmt.Errorf("target partition not found: %w", err)
+	}
+	// SA rows and their OAuth clients always inherit tenant_id + partition_id
+	// from the target partition as a pair.
+	if partition.TenantID == "" || partition.GetID() == "" {
+		return nil, errors.New("partition has incomplete tenancy context")
 	}
 	if request.GetType() != "internal" && request.GetType() != "external" {
 		return nil, errors.New("service account type must be internal or external")

--- a/apps/tenancy/service/business/business_integration_test.go
+++ b/apps/tenancy/service/business/business_integration_test.go
@@ -197,12 +197,61 @@ func (s *BusinessTestSuite) TestCreateServiceAccountV2SeparatesRecipientsAndGran
 
 	s.Require().NoError(err)
 	s.NotEmpty(result.GetClientSecret())
+	s.Equal(partition.TenantID, result.GetData().GetTenantId())
+	s.Equal(partition.GetID(), result.GetData().GetPartitionId())
 	s.Equal([]string{"https://api.example.test/profile"}, result.GetData().GetOauthClient().GetConfiguration().GetResourceRecipients())
 	policy, err := deps.AuthorizationPolicyRepo.GetByServiceAccountID(ctx, result.GetData().GetId())
 	s.Require().NoError(err)
 	s.Require().Len(policy.Grants, 1)
 	s.Equal("service_profile", policy.Grants[0].Namespace)
 	s.Equal([]string{"profile_view"}, policy.Grants[0].Permissions)
+}
+
+func (s *BusinessTestSuite) TestCreateServiceAccountV2_RequiresIdentityFields() {
+	ctx := s.SuiteCtx
+	deps := s.SuiteDeps
+	partition := s.setupTenantAndPartition()
+	ctx = s.WithAuthClaims(ctx, partition.TenantID, partition.GetID(), util.IDString())
+
+	base := func() *tenancyv2.CreateServiceAccountRequest {
+		return &tenancyv2.CreateServiceAccountRequest{
+			PartitionId: partition.GetID(),
+			ProfileId:   util.IDString(),
+			Name:        "sa-name",
+			Type:        "internal",
+			OauthClient: &tenancyv2.OAuthClientConfiguration{
+				GrantTypes:              []string{"client_credentials"},
+				ResourceRecipients:      []string{"https://api.example.test/profile"},
+				TokenEndpointAuthMethod: "client_secret_post",
+			},
+			AuthorizationPolicy: &tenancyv2.ServiceAuthorizationPolicyInput{
+				SchemaVersion: models.AuthorizationPolicySchemaVersion,
+				Grants: []*tenancyv2.ServiceAuthorizationGrant{{
+					Namespace:   "service_profile",
+					Permissions: []string{"profile_view"},
+					Scope:       tenancyv2.AuthorizationScope_AUTHORIZATION_SCOPE_PARTITION_ONLY,
+				}},
+			},
+		}
+	}
+
+	missingPartition := base()
+	missingPartition.PartitionId = ""
+	_, err := deps.AuthContractBusiness.CreateServiceAccount(ctx, missingPartition)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "partition_id")
+
+	missingProfile := base()
+	missingProfile.ProfileId = ""
+	_, err = deps.AuthContractBusiness.CreateServiceAccount(ctx, missingProfile)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "profile_id")
+
+	missingName := base()
+	missingName.Name = "  "
+	_, err = deps.AuthContractBusiness.CreateServiceAccount(ctx, missingName)
+	s.Require().Error(err)
+	s.Contains(err.Error(), "name")
 }
 
 func (s *BusinessTestSuite) TestAuthorizationSchemaFailureRemainsPendingAndFailsReconciliation() {
@@ -275,6 +324,25 @@ func (s *BusinessTestSuite) TestCreateTenant() {
 	s.Require().Equal("Test Tenant", resp.Name)
 	s.Require().Equal("A test tenant", resp.Description)
 	s.Require().Equal(tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_PRODUCTION, resp.GetEnvironment())
+}
+
+func (s *BusinessTestSuite) TestCreateTenant_RequiresNameAndEnvironment() {
+	ctx := s.SuiteCtx
+	deps := s.SuiteDeps
+	ctx = s.WithAuthClaims(ctx, util.IDString(), util.IDString(), util.IDString())
+
+	_, err := deps.TenantBusiness.CreateTenant(ctx, &tenancyv1.CreateTenantRequest{
+		Name:        "  ",
+		Environment: tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_PRODUCTION,
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "name")
+
+	_, err = deps.TenantBusiness.CreateTenant(ctx, &tenancyv1.CreateTenantRequest{
+		Name: "Valid Name",
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "environment")
 }
 
 func (s *BusinessTestSuite) TestGetTenant() {
@@ -435,8 +503,56 @@ func (s *BusinessTestSuite) TestCreatePartition() {
 	s.Require().NoError(err)
 	s.NotEmpty(resp.Id)
 	s.Equal("Partition A", resp.Name)
+	s.Equal(tenant.GetID(), resp.GetTenantId(), "partition must belong to the target tenant")
 	s.Equal(false, resp.GetProperties().AsMap()[partitionpolicy.PropertyAllowAutoAccess])
 	s.Equal("https://members.example.com/apply", resp.GetProperties().AsMap()[partitionpolicy.PropertyAccessRequestURI])
+
+	// Stored row must be self-scoped: partition_id == id for RLS child resources.
+	stored, err := deps.PartitionRepo.GetByID(security.SkipTenancyChecksOnClaims(ctx), resp.GetId())
+	s.Require().NoError(err)
+	s.Equal(tenant.GetID(), stored.TenantID)
+	s.Equal(stored.GetID(), stored.PartitionID, "partition_id must self-reference the partition id")
+}
+
+func (s *BusinessTestSuite) TestCreatePartition_RequiresNameAndTenant() {
+	ctx := s.SuiteCtx
+	deps := s.SuiteDeps
+	tenant := s.createTestTenant("CP Validation")
+	ctx = s.WithAuthClaims(ctx, tenant.GetID(), tenant.GetID(), util.IDString())
+
+	_, err := deps.PartitionBusiness.CreatePartition(ctx, &tenancyv1.CreatePartitionRequest{
+		TenantId: tenant.GetID(),
+		Name:     "  ",
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "name")
+
+	_, err = deps.PartitionBusiness.CreatePartition(ctx, &tenancyv1.CreatePartitionRequest{
+		Name: "orphan",
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "tenant_id")
+}
+
+func (s *BusinessTestSuite) TestCreatePartition_ParentMustSameTenant() {
+	ctx := s.SuiteCtx
+	deps := s.SuiteDeps
+
+	tenantA := s.createTestTenant("Parent A")
+	tenantB := s.createTestTenant("Parent B")
+	partitionB := s.createTestPartition(tenantB.GetID())
+
+	// System path so create can resolve parent across tenants for the negative check;
+	// CreatePartition still rejects when parent.TenantID != target tenant.
+	ctx = security.SkipTenancyChecksOnClaims(ctx)
+
+	_, err := deps.PartitionBusiness.CreatePartition(ctx, &tenancyv1.CreatePartitionRequest{
+		TenantId: tenantA.GetID(),
+		ParentId: partitionB.GetID(),
+		Name:     "cross-tenant-child",
+	})
+	s.Require().Error(err)
+	s.Contains(err.Error(), "same tenant")
 }
 
 func (s *BusinessTestSuite) TestCreatePartition_InvalidTenant() {
@@ -726,6 +842,31 @@ func (s *BusinessTestSuite) TestCreateAccess() {
 	resp, err := deps.AccessBusiness.CreateAccess(ctx, s.newCreateAccessReq(partition.GetID(), profileID))
 	s.Require().NoError(err)
 	s.NotEmpty(resp.GetId())
+	s.Equal(partition.GetID(), resp.GetPartition().GetId())
+	s.Equal(tenant.GetID(), resp.GetPartition().GetTenantId())
+
+	// Access row must carry the full tenancy pair from the partition.
+	stored, err := deps.AccessRepo.GetByID(ctx, resp.GetId())
+	s.Require().NoError(err)
+	s.Equal(tenant.GetID(), stored.TenantID)
+	s.Equal(partition.GetID(), stored.PartitionID)
+	s.Equal(profileID, stored.ProfileID)
+}
+
+func (s *BusinessTestSuite) TestCreateAccess_RequiresPartitionAndProfile() {
+	ctx := s.SuiteCtx
+	deps := s.SuiteDeps
+	tenant := s.createTestTenant("CA Val")
+	partition := s.createTestPartition(tenant.GetID())
+	ctx = s.WithAuthClaims(ctx, tenant.GetID(), partition.GetID(), util.IDString())
+
+	_, err := deps.AccessBusiness.CreateAccess(ctx, s.newCreateAccessReq(partition.GetID(), ""))
+	s.Require().Error(err)
+	s.Contains(err.Error(), "profile_id")
+
+	_, err = deps.AccessBusiness.CreateAccess(ctx, s.newCreateAccessReq("", util.IDString()))
+	s.Require().Error(err)
+	s.Contains(err.Error(), "partition_id")
 }
 
 func (s *BusinessTestSuite) TestCreateAccess_Idempotent() {

--- a/apps/tenancy/service/business/partition.go
+++ b/apps/tenancy/service/business/partition.go
@@ -201,9 +201,30 @@ func (pb *partitionBusiness) GetPartitionParents(ctx context.Context, request *t
 func (pb *partitionBusiness) CreatePartition(
 	ctx context.Context,
 	request *tenancyv1.CreatePartitionRequest) (*tenancyv1.PartitionObject, error) {
-	tenant, err := pb.tenantRepo.GetByID(ctx, request.GetTenantId())
+	tenantID := strings.TrimSpace(request.GetTenantId())
+	if tenantID == "" {
+		return nil, fmt.Errorf("tenant_id is required")
+	}
+	if strings.TrimSpace(request.GetName()) == "" {
+		return nil, fmt.Errorf("partition name is required")
+	}
+
+	tenant, err := pb.tenantRepo.GetByID(ctx, tenantID)
 	if err != nil {
 		return nil, err
+	}
+
+	parentID := strings.TrimSpace(request.GetParentId())
+	if parentID != "" {
+		// Parent lookup uses the caller's tenancy scope. Cross-tenant parents
+		// either 404 under RLS or fail the explicit tenant match below.
+		parent, parentErr := pb.partitionRepo.GetByID(ctx, parentID)
+		if parentErr != nil {
+			return nil, fmt.Errorf("parent partition not found: %w", parentErr)
+		}
+		if parent.TenantID != tenant.GetID() {
+			return nil, fmt.Errorf("parent partition must belong to the same tenant")
+		}
 	}
 
 	reqProperties := request.GetProperties().AsMap()
@@ -214,7 +235,7 @@ func (pb *partitionBusiness) CreatePartition(
 	delete(reqProperties, partitionpolicy.PropertyAllowAutoAccessSetup)
 
 	partition := &models.Partition{
-		ParentID:    request.GetParentId(),
+		ParentID:    parentID,
 		Name:        request.GetName(),
 		Description: request.GetDescription(),
 		Domain:      domain,
@@ -223,8 +244,11 @@ func (pb *partitionBusiness) CreatePartition(
 	partition.SetAllowAutoAccess(allowAutoAccess)
 
 	partition.GenID(ctx)
+	// Tenant + partition are stamped together. Partitions are self-scoped for
+	// RLS: partition_id equals the partition's own id so child resources
+	// (access, roles, clients, service accounts) can share that key.
 	partition.TenantID = tenant.GetID()
-	partition.PartitionID = tenant.PartitionID
+	partition.PartitionID = partition.GetID()
 
 	// Creating a partition is an administrative write into the target
 	// tenant's scope: the row is stamped with the tenant being extended,

--- a/apps/tenancy/service/business/tenant.go
+++ b/apps/tenancy/service/business/tenant.go
@@ -17,6 +17,7 @@ package business
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	tenancyv1 "buf.build/gen/go/antinvestor/tenancy/protocolbuffers/go/tenancy/v1"
 	"github.com/antinvestor/service-authentication/apps/tenancy/service/models"
@@ -81,13 +82,20 @@ func (t *tenantBusiness) CreateTenant(
 	ctx context.Context,
 	request *tenancyv1.CreateTenantRequest,
 ) (*tenancyv1.TenantObject, error) {
+	if request == nil {
+		return nil, fmt.Errorf("request is required")
+	}
+	if strings.TrimSpace(request.GetName()) == "" {
+		return nil, fmt.Errorf("tenant name is required")
+	}
+
 	environment := tenantenv.FromProto(request.GetEnvironment())
 	if environment == "" {
 		return nil, fmt.Errorf("tenant environment is required")
 	}
 
 	tenantModel := &models.Tenant{
-		Name:        request.GetName(),
+		Name:        strings.TrimSpace(request.GetName()),
 		Description: request.GetDescription(),
 		Environment: environment,
 		Properties:  request.GetProperties().AsMap(),

--- a/apps/tenancy/tests/tenant_isolation_test.go
+++ b/apps/tenancy/tests/tenant_isolation_test.go
@@ -112,3 +112,64 @@ func (suite *TenantIsolationTestSuite) TestAccess_CrossTenantReadsReturnNothing(
 	require.NoError(t, err)
 	assert.Len(t, allList, 1)
 }
+
+func (suite *TenantIsolationTestSuite) TestServiceAccount_CrossTenantReadsReturnNothing() {
+	t := suite.T()
+	ctx, _, deps := suite.CreateService(t, definition.NewDependancyOption("sa_isolation", util.RandomAlphaNumericString(8), nil))
+	saRepo := deps.ServiceAccountRepo
+
+	ctxA := suite.WithAuthClaims(ctx, "tenant-iso-a", "partition-iso-a", "profile-a")
+	ctxB := suite.WithAuthClaims(ctx, "tenant-iso-b", "partition-iso-b", "profile-b")
+
+	sa := &models.ServiceAccount{
+		Name:      "tenant-a-bot",
+		ProfileID: "profile-iso-a",
+		ClientID:  util.IDString(),
+		Type:      "internal",
+	}
+	sa.GenID(ctxA)
+	require.NoError(t, saRepo.Create(ctxA, sa))
+	require.Equal(t, "tenant-iso-a", sa.TenantID)
+	require.Equal(t, "partition-iso-a", sa.PartitionID)
+
+	own, err := saRepo.GetByID(ctxA, sa.GetID())
+	require.NoError(t, err)
+	require.Equal(t, sa.GetID(), own.GetID())
+
+	_, err = saRepo.GetByID(ctxB, sa.GetID())
+	require.Error(t, err, "cross-tenant GetByID must not return another tenant's service account")
+
+	count, err := saRepo.CountByPartitionID(ctxB, "partition-iso-a")
+	require.NoError(t, err)
+	assert.Zero(t, count, "cross-tenant count must not include tenant A's service accounts")
+}
+
+func (suite *TenantIsolationTestSuite) TestClient_CrossTenantReadsReturnNothing() {
+	t := suite.T()
+	ctx, _, deps := suite.CreateService(t, definition.NewDependancyOption("client_isolation", util.RandomAlphaNumericString(8), nil))
+	clientRepo := deps.ClientRepo
+
+	ctxA := suite.WithAuthClaims(ctx, "tenant-iso-a", "partition-iso-a", "profile-a")
+	ctxB := suite.WithAuthClaims(ctx, "tenant-iso-b", "partition-iso-b", "profile-b")
+
+	client := &models.Client{
+		Name:     "tenant-a-client",
+		ClientID: util.IDString(),
+		Type:     "public",
+	}
+	client.GenID(ctxA)
+	require.NoError(t, clientRepo.Create(ctxA, client))
+	require.Equal(t, "tenant-iso-a", client.TenantID)
+	require.Equal(t, "partition-iso-a", client.PartitionID)
+
+	own, err := clientRepo.GetByID(ctxA, client.GetID())
+	require.NoError(t, err)
+	require.Equal(t, client.GetID(), own.GetID())
+
+	_, err = clientRepo.GetByID(ctxB, client.GetID())
+	require.Error(t, err, "cross-tenant GetByID must not return another tenant's OAuth client")
+
+	count, err := clientRepo.CountByPartitionID(ctxB, "partition-iso-a")
+	require.NoError(t, err)
+	assert.Zero(t, count, "cross-tenant count must not include tenant A's clients")
+}

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame/v2 v2.0.2
+	github.com/pitabwire/frame/v2 v2.0.1
 	github.com/pitabwire/util v0.9.1
 	github.com/posthog/posthog-go v1.17.5
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.0.2 h1:j0oLy6O0wSip6yOmagpV917mHk2rStdFAaVwk5ENaeQ=
-github.com/pitabwire/frame/v2 v2.0.2/go.mod h1:Ncs1D/SsQW2LEMWwpJYHkBSjIA3czWEbasTD6ffVzQM=
+github.com/pitabwire/frame/v2 v2.0.1 h1:mM82TJrG2tsOHsw44Py2ESMijoh8p/7Btmby74nDaag=
+github.com/pitabwire/frame/v2 v2.0.1/go.mod h1:PKjmTugGW5HBEwF/KiFQ8mjJtI5/+LE9E2xcxdO4kEY=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=

--- a/pkg/tenantenv/environment_test.go
+++ b/pkg/tenantenv/environment_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tenantenv_test
+
+import (
+	"testing"
+
+	tenancyv1 "buf.build/gen/go/antinvestor/tenancy/protocolbuffers/go/tenancy/v1"
+	"github.com/antinvestor/service-authentication/pkg/tenantenv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormaliseAndIsValid(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, tenantenv.Production, tenantenv.Normalise(" Production "))
+	require.True(t, tenantenv.IsValid("staging"))
+	require.True(t, tenantenv.IsValid("PRODUCTION"))
+	require.False(t, tenantenv.IsValid("dev"))
+	require.False(t, tenantenv.IsValid(""))
+}
+
+func TestProtoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, tenantenv.Production, tenantenv.FromProto(tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_PRODUCTION))
+	require.Equal(t, tenantenv.Staging, tenantenv.FromProto(tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_STAGING))
+	require.Empty(t, tenantenv.FromProto(tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_UNSPECIFIED))
+
+	require.Equal(t, tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_PRODUCTION, tenantenv.ToProto("production"))
+	require.Equal(t, tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_STAGING, tenantenv.ToProto("staging"))
+	require.Equal(t, tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_UNSPECIFIED, tenantenv.ToProto("other"))
+}
+
+func TestParseToProto(t *testing.T) {
+	t.Parallel()
+
+	got, err := tenantenv.ParseToProto("production")
+	require.NoError(t, err)
+	require.Equal(t, tenancyv1.TenantEnvironment_TENANT_ENVIRONMENT_PRODUCTION, got)
+
+	_, err = tenantenv.ParseToProto("qa")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Hardens authentication and tenancy so multi-tenant identity is consistent and login abuse is harder:

- Treat `tenant_id` and `partition_id` as an **atomic pair** across token claims (consent, webhook, native exchange) and tenancy provisioning
- Login rate limiting is **atomic** (`cache.Increment`) and **fail-closed** when cache is unavailable
- `CreatePartition` is **self-scoped** for RLS (`partition_id = id`) and rejects cross-tenant parents
- Stricter validation on access / tenant / service-account create
- Expanded unit, business, and RLS isolation tests

## Test plan

- [x] `go test` focused auth handler unit tests (claims, rate limit, webhooks) including `-race`
- [x] `go test ./apps/tenancy/... -timeout 15m` (business, handlers, repository, isolation)
- [x] `go test ./pkg/tenantenv/`
- [ ] CI green on this PR

## Release notes

- Token minting/enrichment no longer accepts partial tenancy claims
- Login rate limit no longer fails open under cache outages
- New partitions are correctly self-scoped for row-level security