### PR TITLE
fix(deps): migrate to frame v2.0.2 (SearchFunc + test Run lifecycle)

### DIFF
--- a/apps/default/service/repository/login_event.go
+++ b/apps/default/service/repository/login_event.go
@@ -274,7 +274,9 @@ func (r *loginEventRepository) Search(
 		r.WorkManager(),
 		query,
 		func(ctx context.Context, query *data.SearchQuery) ([]*models.LoginEvent, error) {
-			return datastore.SearchFunc[*models.LoginEvent](
+			// Frame v2.0.2+ moved SearchFunc from datastore → data (shared query
+			// helper used by BaseRepository.Search as well).
+			return data.SearchFunc[*models.LoginEvent](
 				ctx,
 				scopeLoginEventQuery(ctx, r.Pool().DB(ctx, true)),
 				query,

--- a/apps/tenancy/tests/base_testsuite.go
+++ b/apps/tenancy/tests/base_testsuite.go
@@ -377,7 +377,15 @@ func (bs *BaseTestSuite) createServiceInternal(
 	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
 	rlsProv.Enable()
 
-	_ = svc.Run(ctx, "")
+	// Frame v2.0.2+ ignores nil driver exits in sendStopError, so NoopDriver
+	// no longer makes Run return immediately. Always run the service in a
+	// goroutine (same pattern as apps/default tests) and stop it in cleanup.
+	go func() {
+		_ = svc.Run(ctx, "")
+	}()
+	// Startups (event registration + queue subscribers) run inside initServer
+	// before ListenAndServe; give that path a beat before emitting work.
+	time.Sleep(200 * time.Millisecond)
 
 	// Sync seeded records to Hydra so SA credentials work for service-to-service auth.
 	// Must happen after migrations and before any OAuth2-authenticated calls.

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame/v2 v2.0.1
+	github.com/pitabwire/frame/v2 v2.0.2
 	github.com/pitabwire/util v0.9.1
 	github.com/posthog/posthog-go v1.17.5
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.0.1 h1:mM82TJrG2tsOHsw44Py2ESMijoh8p/7Btmby74nDaag=
-github.com/pitabwire/frame/v2 v2.0.1/go.mod h1:PKjmTugGW5HBEwF/KiFQ8mjJtI5/+LE9E2xcxdO4kEY=
+github.com/pitabwire/frame/v2 v2.0.2 h1:j0oLy6O0wSip6yOmagpV917mHk2rStdFAaVwk5ENaeQ=
+github.com/pitabwire/frame/v2 v2.0.2/go.mod h1:Ncs1D/SsQW2LEMWwpJYHkBSjIA3czWEbasTD6ffVzQM=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary

Properly adopt **frame v2.0.2** instead of pinning back to v2.0.1.

### Root cause of the earlier CI breakage
1. **SearchFunc was moved, not removed** — `datastore.SearchFunc` → `data.SearchFunc` (BaseRepository already uses the new path).
2. **Test hang** — v2.0.2 `sendStopError` ignores `nil`, so NoopDriver no longer makes `Run()` return immediately. Tenancy tests called `_ = svc.Run(ctx, "")` **synchronously**, which blocked suite setup until the 10m package timeout.

### Changes
- Bump `github.com/pitabwire/frame/v2` to **v2.0.2**
- Migrate login-event repository to `data.SearchFunc`
- Tenancy `base_testsuite`: run `svc.Run` in a goroutine (+ short startup wait)

### Test plan
- [x] `go build ./...`
- [x] `go test ./apps/tenancy/... ./apps/default/service/... ./pkg/...` (local, ~7.5m)
- [ ] CI green on this PR