### PR TITLE
fix(deps): frame v2.0.3 — drop Run goroutine workarounds

### DIFF
--- a/apps/default/tests/base_testsuite.go
+++ b/apps/default/tests/base_testsuite.go
@@ -327,8 +327,17 @@ func (bs *BaseTestSuite) CreateService(
 	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
 	rlsProv.Enable()
 
-	// WithNoopDriver: Run completes after startups finish (frame test-driver contract).
-	require.NoError(t, svc.Run(ctx, ""))
+	// Suite-level service (handler == nil) is the real HTTP listener Hydra
+	// redirects to, so it uses the production driver and Run blocks until
+	// Stop — start it in a goroutine. Per-test services use WithNoopDriver,
+	// which returns from Run after startups (frame v2.0.3+ test-driver contract).
+	if bs.handler == nil {
+		go func() {
+			_ = svc.Run(ctx, "")
+		}()
+	} else {
+		require.NoError(t, svc.Run(ctx, ""))
+	}
 	return security.SkipTenancyChecksOnClaims(ctx), authServer, depsBuilder
 }
 

--- a/apps/default/tests/base_testsuite.go
+++ b/apps/default/tests/base_testsuite.go
@@ -327,9 +327,8 @@ func (bs *BaseTestSuite) CreateService(
 	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
 	rlsProv.Enable()
 
-	go func() {
-		_ = svc.Run(ctx, "")
-	}()
+	// WithNoopDriver: Run completes after startups finish (frame test-driver contract).
+	require.NoError(t, svc.Run(ctx, ""))
 	return security.SkipTenancyChecksOnClaims(ctx), authServer, depsBuilder
 }
 

--- a/apps/tenancy/tests/base_testsuite.go
+++ b/apps/tenancy/tests/base_testsuite.go
@@ -377,15 +377,9 @@ func (bs *BaseTestSuite) createServiceInternal(
 	require.NoError(t, rlstest.GrantAll(ctx, testDS.String()))
 	rlsProv.Enable()
 
-	// Frame v2.0.2+ ignores nil driver exits in sendStopError, so NoopDriver
-	// no longer makes Run return immediately. Always run the service in a
-	// goroutine (same pattern as apps/default tests) and stop it in cleanup.
-	go func() {
-		_ = svc.Run(ctx, "")
-	}()
-	// Startups (event registration + queue subscribers) run inside initServer
-	// before ListenAndServe; give that path a beat before emitting work.
-	time.Sleep(200 * time.Millisecond)
+	// WithNoopDriver: Run completes after startups (events/queues) finish.
+	// No goroutine — that is the test-driver contract (frame v2.0.3+).
+	require.NoError(t, svc.Run(ctx, ""))
 
 	// Sync seeded records to Hydra so SA credentials work for service-to-service auth.
 	// Must happen after migrations and before any OAuth2-authenticated calls.

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame/v2 v2.0.2
+	github.com/pitabwire/frame/v2 v2.0.3
 	github.com/pitabwire/util v0.9.1
 	github.com/posthog/posthog-go v1.17.5
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.0.2 h1:j0oLy6O0wSip6yOmagpV917mHk2rStdFAaVwk5ENaeQ=
-github.com/pitabwire/frame/v2 v2.0.2/go.mod h1:Ncs1D/SsQW2LEMWwpJYHkBSjIA3czWEbasTD6ffVzQM=
+github.com/pitabwire/frame/v2 v2.0.3 h1:OHgpmx1rb9uhiIKGF8dA774ViTL4+YtWyV+6gamX1BU=
+github.com/pitabwire/frame/v2 v2.0.3/go.mod h1:Ncs1D/SsQW2LEMWwpJYHkBSjIA3czWEbasTD6ffVzQM=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary
- Bump `github.com/pitabwire/frame/v2` **v2.0.2 → v2.0.3**
- Remove `go func() { svc.Run(...) }()` workarounds in default + tenancy test suites
- Use the documented test-driver contract: `WithNoopDriver` + blocking `svc.Run`

## Why
v2.0.2 ignored nil in `sendStopError`, so NoopDriver never woke `Run` and suites hung. The correct fix is in frame ([pitabwire/frame#679](https://github.com/pitabwire/frame/pull/679) / v2.0.3), not ad-hoc goroutines in every service.

## Test plan
- [x] Local tenancy isolation + business suite with frame fix
- [ ] CI green