### PR TITLE
fix(auth): Google button OAuth-primary (FedCM hang)

### DIFF
--- a/apps/default/service/handlers/login_page_google_onetap_internal_test.go
+++ b/apps/default/service/handlers/login_page_google_onetap_internal_test.go
@@ -163,13 +163,14 @@ func TestGoogleFedCMScriptDoesNotAutoEscalateToOAuth(t *testing.T) {
 	require.NoError(t, err)
 
 	js := string(source)
-	require.Contains(t, js, `await runFlow(opts, "optional", "auto_prompt", "");`)
-	// Explicit click prefers FedCM button-mode account picker, then OAuth.
-	require.Contains(t, js, `"button"`)
-	require.Contains(t, js, "fedcm_google_fallback_to_oauth")
-	require.Contains(t, js, "oauthRedirectFallback")
+	// Auto-prompt is FedCM-only and non-blocking; explicit click is OAuth-primary.
+	require.Contains(t, js, `source: "auto_prompt"`)
+	require.Contains(t, js, "startGoogleOAuth")
+	require.Contains(t, js, `path: "oauth_primary"`)
 	require.Contains(t, js, `Accept: "application/json"`)
-	require.Contains(t, js, "bindFallbackTracking")
+	require.Contains(t, js, "isCompleteGoogleAuthorizeURL")
 	require.NotContains(t, js, "btn.click()")
 	require.NotContains(t, js, "fedcm_google_auto_escalate")
+	// Click must not await FedCM (that hung production buttons).
+	require.NotContains(t, js, `source: "click"`)
 }

--- a/apps/default/static/js/fedcm_google.js
+++ b/apps/default/static/js/fedcm_google.js
@@ -1,29 +1,35 @@
 // apps/default/static/js/fedcm_google.js
 //
-// Google sign-in on /s/login — account picker → logged in, minimal screens.
+// Google sign-in on /s/login.
 //
-// Preferred path (FedCM button mode):
-//   User clicks "Sign in with Google" → browser account picker → id_token →
-//   POST /s/social/google/fedcm-complete → redirect into Hydra → done.
-//   No full-page Google OAuth screens when FedCM works.
+// DESIGN (v2.0.4) — explicit click is OAuth-primary:
 //
-// Fallback (classic OAuth, only if FedCM unavailable/fails):
-//   JSON redirect to Google authorize with prompt=select_account so a signed-in
-//   Google session is usually just account pick → redirect back.
+//   Why not FedCM on click?
+//   Browser repro on production showed navigator.credentials.get() either
+//   hanging or erroring ("Not signed in with the identity provider") and
+//   never reaching /s/social/login. Users then saw broken Google error pages
+//   (e.g. missing response_type) or infinite spinner. Classic OAuth with a
+//   server-built authorize URL is the reliable path.
 //
-// Auto-prompt (optional mediation) still runs on page load for returning users
-// who already have a FedCM session (one-tap style).
+//   Click path:
+//     POST /s/social/login/{id}?provider=google  Accept: application/json
+//     → { redirect_url: "https://accounts.google.com/o/oauth2/v2/auth?...&response_type=code&prompt=select_account&..." }
+//     → window.location.assign(redirect_url)
 //
-// Hardened against:
-//   - Opaque cross-origin Location headers (JSON redirect_url instead)
-//   - Open-redirect (HTTPS + Google hosts / same-origin only)
-//   - Double-submit / in-flight races
+//   Auto-prompt path (optional, non-blocking):
+//     FedCM mediation:optional for returning users only. Never blocks the
+//     Google button. Never auto-escalates to multi-page OAuth.
+//
+// Server contract: ProviderLoginEndpointV2 returns JSON when Accept includes
+// application/json (avoids opaque cross-origin Location on 303→Google).
 (function () {
   "use strict";
 
   var GOOGLE_FEDCM_CONFIG = "https://accounts.google.com/gsi/fedcm.json";
   var COMPLETE_ENDPOINT = "/s/social/google/fedcm-complete";
-  var inFlight = false;
+  // Separate flags so auto-prompt cannot block explicit OAuth click.
+  var autoPromptInFlight = false;
+  var clickInFlight = false;
 
   function track(event, props) {
     try {
@@ -63,24 +69,39 @@
     }
   }
 
-  async function attemptGoogleFedCM(opts, mediation, mode) {
+  function isCompleteGoogleAuthorizeURL(raw) {
     try {
-      var provider = {
-        configURL: GOOGLE_FEDCM_CONFIG,
-        clientId: opts.clientId,
-        params: {nonce: opts.nonce},
-      };
-      // Button mode is the Sign-in-with-Google account picker UX (no full
-      // redirect pages). Passive browsers ignore unknown fields.
-      if (mode) {
-        provider.mode = mode;
+      var u = new URL(raw);
+      if (u.protocol !== "https:" || u.hostname !== "accounts.google.com") {
+        return false;
       }
+      // Required OAuth params — incomplete URLs produce Google's
+      // "Required parameter is missing: response_type" error page.
+      return (
+        u.searchParams.get("response_type") === "code" &&
+        !!u.searchParams.get("client_id") &&
+        !!u.searchParams.get("redirect_uri") &&
+        !!u.searchParams.get("scope")
+      );
+    } catch (_e) {
+      return false;
+    }
+  }
+
+  async function attemptGoogleFedCM(opts, mediation) {
+    try {
       var cred = await navigator.credentials.get({
         identity: {
           context: "signin",
-          providers: [provider],
+          providers: [
+            {
+              configURL: GOOGLE_FEDCM_CONFIG,
+              clientId: opts.clientId,
+              params: {nonce: opts.nonce},
+            },
+          ],
         },
-        mediation: mediation || "required",
+        mediation: mediation || "optional",
       });
       if (cred && typeof cred.token === "string" && cred.token.length > 0) {
         return cred.token;
@@ -105,10 +126,7 @@
           id_token: idToken,
         }),
       });
-      if (!res.ok) {
-        track("fedcm_google_server_status", { status: res.status });
-        return null;
-      }
+      if (!res.ok) return null;
       var body = await res.json();
       var redirect = body && body.redirect_url;
       if (isSafeRedirect(redirect)) return redirect;
@@ -118,106 +136,66 @@
     }
   }
 
-  async function runFlow(opts, mediation, source, mode) {
-    if (inFlight) return false;
-    inFlight = true;
+  // Silent/returning-user path only. Must never block the Google button.
+  async function autoPrompt(opts) {
+    if (!fedcmSupported() || autoPromptInFlight || clickInFlight) return;
+    autoPromptInFlight = true;
     try {
       track("fedcm_google_attempt", {
-        mediation: mediation,
-        source: source,
-        mode: mode || "",
+        mediation: "optional",
+        source: "auto_prompt",
         login_event_id: opts.loginEventId,
       });
-
-      var idToken = await attemptGoogleFedCM(opts, mediation, mode);
+      var idToken = await attemptGoogleFedCM(opts, "optional");
       if (!idToken) {
-        track("fedcm_google_no_token", {
-          mediation: mediation,
-          source: source,
-          mode: mode || "",
-        });
-        return false;
+        track("fedcm_google_no_token", { source: "auto_prompt" });
+        return;
       }
-
-      track("fedcm_google_token_received", {
-        mediation: mediation,
-        source: source,
-      });
-
       var redirect = await sendCompletion(opts, idToken);
       if (!redirect) {
-        track("fedcm_google_server_rejected", { source: source });
-        return false;
+        track("fedcm_google_server_rejected", { source: "auto_prompt" });
+        return;
       }
-
-      track("fedcm_google_redirect", { source: source });
+      track("fedcm_google_redirect", { source: "auto_prompt" });
       window.location.assign(redirect);
-      return true;
     } finally {
-      inFlight = false;
+      autoPromptInFlight = false;
     }
   }
 
-  function bindFallbackTracking() {
-    var forms = document.querySelectorAll("form[data-fedcm-google]");
-    forms.forEach(function (form) {
-      if (form.__stawiGoogleFallbackTracked) return;
-      form.__stawiGoogleFallbackTracked = true;
-      form.addEventListener("submit", function () {
-        track("sign_in_method_clicked", {
-          method: "google",
-          fedcm_supported: false,
-        });
-      });
-    });
-  }
-
-  // Classic OAuth via JSON {redirect_url} — used only when FedCM cannot
-  // complete. Server builds the full authorize URL (response_type=code +
-  // prompt=select_account).
-  async function oauthRedirectFallback(form) {
+  // Reliable OAuth start: JSON body with full authorize URL (includes
+  // response_type=code). Never rely on reading 303 Location to Google
+  // (opaque redirect — Location is not exposed to JS).
+  async function startGoogleOAuth(form) {
     var action = form.getAttribute("action") || "";
     if (!action) {
-      nativeFormPost(form);
-      return;
+      throw new Error("missing form action");
     }
-    try {
-      var res = await fetch(action, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          Accept: "application/json",
-        },
-      });
-      if (res.ok) {
-        var body = await res.json();
-        var redirect = body && body.redirect_url;
-        if (isSafeRedirect(redirect)) {
-          try {
-            var u = new URL(redirect);
-            if (!u.searchParams.get("response_type")) {
-              track("fedcm_google_oauth_missing_response_type");
-              nativeFormPost(form);
-              return;
-            }
-          } catch (_e) {
-            nativeFormPost(form);
-            return;
-          }
-          track("fedcm_google_oauth_json_redirect");
-          window.location.assign(redirect);
-          return;
-        }
-        track("fedcm_google_oauth_unsafe_redirect");
-      } else {
-        track("fedcm_google_oauth_http_error", { status: res.status });
-      }
-    } catch (err) {
-      track("fedcm_google_oauth_fetch_failed", {
-        message: err && err.message ? String(err.message) : "unknown",
-      });
+    var res = await fetch(action, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    if (!res.ok) {
+      var text = "";
+      try {
+        text = await res.text();
+      } catch (_e) {}
+      throw new Error("oauth_start_http_" + res.status + ":" + text.slice(0, 80));
     }
-    nativeFormPost(form);
+    var body = await res.json();
+    var redirect = body && body.redirect_url;
+    if (!isSafeRedirect(redirect) || !isCompleteGoogleAuthorizeURL(redirect)) {
+      track("fedcm_google_oauth_bad_redirect", {
+        has_url: !!redirect,
+        complete: redirect ? isCompleteGoogleAuthorizeURL(redirect) : false,
+      });
+      throw new Error("incomplete_google_authorize_url");
+    }
+    track("fedcm_google_oauth_json_redirect");
+    window.location.assign(redirect);
   }
 
   function nativeFormPost(form) {
@@ -248,42 +226,34 @@
     }
   }
 
-  function bindClick(opts) {
+  function bindClick() {
     var forms = document.querySelectorAll("form[data-fedcm-google]");
     forms.forEach(function (form) {
-      if (form.__stawiGoogleFedCMBound) return;
-      form.__stawiGoogleFedCMBound = true;
+      if (form.__stawiGoogleOAuthBound) return;
+      form.__stawiGoogleOAuthBound = true;
 
       form.addEventListener("submit", function (event) {
         event.preventDefault();
-        if (inFlight) {
-          track("fedcm_google_click_while_inflight");
-          return;
-        }
+        if (clickInFlight) return;
+        clickInFlight = true;
         track("sign_in_method_clicked", {
           method: "google",
+          path: "oauth_primary",
           fedcm_supported: fedcmSupported(),
         });
         setGoogleButtonBusy(form, true);
         (async function () {
           try {
-            // Button-mode FedCM = in-browser account picker, then done.
-            // Only if that fails do we open classic Google OAuth pages.
-            if (fedcmSupported()) {
-              var navigated = await runFlow(
-                opts,
-                "required",
-                "click",
-                "button"
-              );
-              if (navigated) return;
-              // Retry without mode for older browsers that reject mode:button.
-              navigated = await runFlow(opts, "required", "click_retry", "");
-              if (navigated) return;
-            }
-            track("fedcm_google_fallback_to_oauth");
-            await oauthRedirectFallback(form);
+            await startGoogleOAuth(form);
+          } catch (err) {
+            track("fedcm_google_oauth_failed", {
+              message: err && err.message ? String(err.message) : "unknown",
+            });
+            // Last resort: top-level form POST (browser follows 303).
+            nativeFormPost(form);
           } finally {
+            // If navigation succeeded this is a no-op; if not, re-enable.
+            clickInFlight = false;
             setGoogleButtonBusy(form, false);
           }
         })();
@@ -291,23 +261,16 @@
     });
   }
 
-  // Returning-user one-tap: silent/optional FedCM only — never auto-escalate
-  // to multi-page OAuth (that would surprise the user with new screens).
-  async function autoPrompt(opts) {
-    if (inFlight) return;
-    await runFlow(opts, "optional", "auto_prompt", "");
-  }
-
   function install(opts) {
     if (!opts || !opts.clientId || !opts.loginEventId) return;
-    if (!fedcmSupported()) {
+    // Always bind OAuth-primary click — works with or without FedCM support.
+    bindClick();
+    // Optional silent FedCM for returning users; never blocks the button.
+    if (fedcmSupported()) {
+      autoPrompt(opts);
+    } else {
       track("fedcm_unsupported", { provider: "google" });
-      bindFallbackTracking();
-      bindClick(opts);
-      return;
     }
-    bindClick(opts);
-    autoPrompt(opts);
   }
 
   window.stawiGoogleFedCM = { install: install };

--- a/apps/default/tmpl/auth_base.html
+++ b/apps/default/tmpl/auth_base.html
@@ -180,7 +180,7 @@
             "_lang": "{{ if .lang }}{{ .lang }}{{ else }}en{{ end }}"
         };
     </script>
-    <script src="/static/js/auth.js?v=2.0.3"></script>
+    <script src="/static/js/auth.js?v=2.0.4"></script>
 </body>
 </html>
 

--- a/apps/default/tmpl/login.html
+++ b/apps/default/tmpl/login.html
@@ -135,7 +135,7 @@
 </script>
 <script src="/static/js/posthog.js" defer></script>
 <script src="/static/js/fedcm.js" defer></script>
-{{if .enableGoogleLogin}}<script src="/static/js/fedcm_google.js?v=2.0.3" defer></script>{{end}}
+{{if .enableGoogleLogin}}<script src="/static/js/fedcm_google.js?v=2.0.4" defer></script>{{end}}
 <script>
   document.addEventListener("DOMContentLoaded", function () {
     // FedCM sign-in waterfall. The first-party probe (returning users with an


### PR DESCRIPTION
## Root cause (browser-reproved)
Clicking Sign in with Google on production left the button busy and never hit `/s/social/login`. Console: \`Not signed in with the identity provider\` ×N. FedCM \`credentials.get\` hung/failed; shared \`inFlight\` + await blocked the reliable OAuth path.

## Fix
- **Click → OAuth JSON** immediately (\`Accept: application/json\` → \`redirect_url\` with full params)
- Validate authorize URL has \`response_type=code\` before navigate
- FedCM only as **non-blocking auto-prompt** (cannot block the button)
- Separate \`clickInFlight\` / \`autoPromptInFlight\` flags

## Test plan
- [x] Unit tests
- [ ] Deploy: click Google → account chooser (not spinner, not response_type error)