### PR TITLE
fix(auth): disable Google FedCM — OAuth-only sign-in

### DIFF
--- a/apps/default/service/handlers/login_page_google_onetap_internal_test.go
+++ b/apps/default/service/handlers/login_page_google_onetap_internal_test.go
@@ -50,30 +50,28 @@ func baseLoginPayload() map[string]any {
 	}
 }
 
-func TestLoginPageWiresGoogleOneTapWhenEnabled(t *testing.T) {
+func TestLoginPageWiresGoogleOAuthWhenEnabled(t *testing.T) {
 	payload := baseLoginPayload()
 	payload["enableGoogleLogin"] = true
 
 	html := renderLoginPage(t, payload)
 
-	// The Google FedCM script is loaded and the install() call is present with
-	// the Google web client ID, the per-login nonce, and the login event id.
-	require.Contains(t, html, "/static/js/fedcm_google.js")
+	// Google OAuth script is loaded; install() binds the button with the
+	// Google web client ID (kept for config parity) and login event id.
+	require.Contains(t, html, "/static/js/fedcm_google.js?v=2.0.5")
 	require.Contains(t, html, "stawiGoogleFedCM.install")
 	require.Contains(t, html, "web-client.apps.googleusercontent.com")
-	require.Contains(t, html, "nonce-xyz")
 	require.Contains(t, html, "loginEventId: \"le-123\"")
 
-	// The Google form is FedCM-managed and still carries its OAuth-redirect
-	// fallback action so non-FedCM browsers keep working.
+	// Form posts to classic OAuth start (JSON redirect handled by JS).
 	require.Contains(t, html, "data-fedcm-google")
 	require.Contains(t, html, "/s/social/login/le-123?provider=google")
 
-	// The first-party FedCM probe still runs first (returning-user path).
+	// First-party FedCM probe still runs first (our IdP, not Google).
 	require.Contains(t, html, "stawiFedCM.probeAndComplete")
 }
 
-func TestLoginPageOmitsGoogleOneTapWhenDisabled(t *testing.T) {
+func TestLoginPageOmitsGoogleOAuthWhenDisabled(t *testing.T) {
 	payload := baseLoginPayload()
 	payload["enableGoogleLogin"] = false
 
@@ -89,10 +87,9 @@ func TestLoginPageOmitsGoogleOneTapWhenDisabled(t *testing.T) {
 	require.Contains(t, html, "stawiFedCM.probeAndComplete")
 }
 
-func TestLoginPageGoogleOneTapClientIDIsGoogleNotHydra(t *testing.T) {
-	// Regression guard: the FedCM clientId passed to Google must be the Google
-	// web client ID, never the Antinvestor/Hydra ClientID (which is used only
-	// for the first-party /fedcm/config.json probe).
+func TestLoginPageGoogleInstallClientIDIsGoogleNotHydra(t *testing.T) {
+	// Regression guard: install() clientId must be the Google web client ID,
+	// never the Hydra ClientID (used only for first-party /fedcm/config.json).
 	payload := baseLoginPayload()
 	payload["enableGoogleLogin"] = true
 	payload["GoogleClientID"] = "GOOGLE-AUD"
@@ -100,9 +97,6 @@ func TestLoginPageGoogleOneTapClientIDIsGoogleNotHydra(t *testing.T) {
 
 	html := renderLoginPage(t, payload)
 
-	// Scope to the Google install() call: its clientId must be the Google
-	// audience, not the Hydra client (which legitimately appears in the
-	// first-party probe elsewhere on the page).
 	idx := strings.Index(html, "stawiGoogleFedCM.install")
 	require.GreaterOrEqual(t, idx, 0, "google install call must be present")
 	installBlock := html[idx:]
@@ -157,20 +151,39 @@ func TestSetupLoginOptionsRequiresCompleteGoogleConfiguration(t *testing.T) {
 	}
 }
 
-func TestGoogleFedCMScriptDoesNotAutoEscalateToOAuth(t *testing.T) {
+func TestGoogleScriptIsOAuthOnlyNoFedCM(t *testing.T) {
 	path := filepath.Join("..", "..", "static", "js", "fedcm_google.js")
 	source, err := os.ReadFile(path)
 	require.NoError(t, err)
 
 	js := string(source)
-	// Auto-prompt is FedCM-only and non-blocking; explicit click is OAuth-primary.
-	require.Contains(t, js, `source: "auto_prompt"`)
+	// Pure OAuth: no Google FedCM runtime (strip comments before negative asserts).
+	codeOnly := stripJSComments(js)
+	require.NotContains(t, codeOnly, "navigator.credentials.get")
+	require.NotContains(t, codeOnly, "IdentityCredential")
+	require.NotContains(t, codeOnly, "auto_prompt")
+	require.NotContains(t, codeOnly, "gsi/fedcm.json")
+	require.NotContains(t, codeOnly, "fedcm-complete")
+	// Click path: JSON OAuth start with complete authorize URL validation.
 	require.Contains(t, js, "startGoogleOAuth")
-	require.Contains(t, js, `path: "oauth_primary"`)
+	require.Contains(t, js, `path: "oauth_only"`)
 	require.Contains(t, js, `Accept: "application/json"`)
 	require.Contains(t, js, "isCompleteGoogleAuthorizeURL")
-	require.NotContains(t, js, "btn.click()")
-	require.NotContains(t, js, "fedcm_google_auto_escalate")
-	// Click must not await FedCM (that hung production buttons).
-	require.NotContains(t, js, `source: "click"`)
+	require.Contains(t, codeOnly, "response_type")
+	require.NotContains(t, codeOnly, "btn.click()")
+	require.NotContains(t, codeOnly, "fedcm_google_auto_escalate")
+}
+
+// stripJSComments removes // line comments so negative assertions do not
+// match explanatory prose in the file header.
+func stripJSComments(src string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(src, "\n") {
+		if i := strings.Index(line, "//"); i >= 0 {
+			line = line[:i]
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String()
 }

--- a/apps/default/static/js/fedcm_google.js
+++ b/apps/default/static/js/fedcm_google.js
@@ -15,7 +15,7 @@
 //   → { redirect_url: "https://accounts.google.com/o/oauth2/v2/auth?...&response_type=code&..." }
 //   → window.location.assign(redirect_url)  (full-page navigation)
 //
-// No auto-prompt. No navigator.credentials.get() for Google.
+// No auto-prompt. No Google FedCM credential API on this page.
 // Server contract: ProviderLoginEndpointV2 returns JSON when Accept includes
 // application/json (avoids opaque cross-origin Location on 303→Google).
 (function () {

--- a/apps/default/static/js/fedcm_google.js
+++ b/apps/default/static/js/fedcm_google.js
@@ -1,34 +1,26 @@
 // apps/default/static/js/fedcm_google.js
 //
-// Google sign-in on /s/login.
+// Google sign-in on /s/login — classic OAuth only (v2.0.5).
 //
-// DESIGN (v2.0.4) — explicit click is OAuth-primary:
+// Why FedCM is disabled for Google:
+//   Production screencast (2026-07-10) showed Google's FedCM account picker
+//   ("Sign in to stawi.org with google.com") → "Verifying…" → popup to
+//   accounts.google.com/signin/oauth/error with
+//   "Required parameter is missing: response_type" (Error 400: invalid_request).
+//   That popup is Google's FedCM→OAuth escalation, not our authorize URL.
+//   Server-built OAuth (response_type=code + prompt=select_account) is reliable.
 //
-//   Why not FedCM on click?
-//   Browser repro on production showed navigator.credentials.get() either
-//   hanging or erroring ("Not signed in with the identity provider") and
-//   never reaching /s/social/login. Users then saw broken Google error pages
-//   (e.g. missing response_type) or infinite spinner. Classic OAuth with a
-//   server-built authorize URL is the reliable path.
+// Click path:
+//   POST /s/social/login/{id}?provider=google  Accept: application/json
+//   → { redirect_url: "https://accounts.google.com/o/oauth2/v2/auth?...&response_type=code&..." }
+//   → window.location.assign(redirect_url)  (full-page navigation)
 //
-//   Click path:
-//     POST /s/social/login/{id}?provider=google  Accept: application/json
-//     → { redirect_url: "https://accounts.google.com/o/oauth2/v2/auth?...&response_type=code&prompt=select_account&..." }
-//     → window.location.assign(redirect_url)
-//
-//   Auto-prompt path (optional, non-blocking):
-//     FedCM mediation:optional for returning users only. Never blocks the
-//     Google button. Never auto-escalates to multi-page OAuth.
-//
+// No auto-prompt. No navigator.credentials.get() for Google.
 // Server contract: ProviderLoginEndpointV2 returns JSON when Accept includes
 // application/json (avoids opaque cross-origin Location on 303→Google).
 (function () {
   "use strict";
 
-  var GOOGLE_FEDCM_CONFIG = "https://accounts.google.com/gsi/fedcm.json";
-  var COMPLETE_ENDPOINT = "/s/social/google/fedcm-complete";
-  // Separate flags so auto-prompt cannot block explicit OAuth click.
-  var autoPromptInFlight = false;
   var clickInFlight = false;
 
   function track(event, props) {
@@ -37,16 +29,6 @@
         window.stawiTrack(event, props || {});
       }
     } catch (_e) {}
-  }
-
-  function fedcmSupported() {
-    return (
-      typeof window !== "undefined" &&
-      "IdentityCredential" in window &&
-      navigator &&
-      navigator.credentials &&
-      typeof navigator.credentials.get === "function"
-    );
   }
 
   function isSafeRedirect(raw) {
@@ -88,81 +70,6 @@
     }
   }
 
-  async function attemptGoogleFedCM(opts, mediation) {
-    try {
-      var cred = await navigator.credentials.get({
-        identity: {
-          context: "signin",
-          providers: [
-            {
-              configURL: GOOGLE_FEDCM_CONFIG,
-              clientId: opts.clientId,
-              params: {nonce: opts.nonce},
-            },
-          ],
-        },
-        mediation: mediation || "optional",
-      });
-      if (cred && typeof cred.token === "string" && cred.token.length > 0) {
-        return cred.token;
-      }
-      return null;
-    } catch (_err) {
-      return null;
-    }
-  }
-
-  async function sendCompletion(opts, idToken) {
-    try {
-      var res = await fetch(COMPLETE_ENDPOINT, {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-        },
-        body: JSON.stringify({
-          login_event_id: opts.loginEventId,
-          id_token: idToken,
-        }),
-      });
-      if (!res.ok) return null;
-      var body = await res.json();
-      var redirect = body && body.redirect_url;
-      if (isSafeRedirect(redirect)) return redirect;
-      return null;
-    } catch (_err) {
-      return null;
-    }
-  }
-
-  // Silent/returning-user path only. Must never block the Google button.
-  async function autoPrompt(opts) {
-    if (!fedcmSupported() || autoPromptInFlight || clickInFlight) return;
-    autoPromptInFlight = true;
-    try {
-      track("fedcm_google_attempt", {
-        mediation: "optional",
-        source: "auto_prompt",
-        login_event_id: opts.loginEventId,
-      });
-      var idToken = await attemptGoogleFedCM(opts, "optional");
-      if (!idToken) {
-        track("fedcm_google_no_token", { source: "auto_prompt" });
-        return;
-      }
-      var redirect = await sendCompletion(opts, idToken);
-      if (!redirect) {
-        track("fedcm_google_server_rejected", { source: "auto_prompt" });
-        return;
-      }
-      track("fedcm_google_redirect", { source: "auto_prompt" });
-      window.location.assign(redirect);
-    } finally {
-      autoPromptInFlight = false;
-    }
-  }
-
   // Reliable OAuth start: JSON body with full authorize URL (includes
   // response_type=code). Never rely on reading 303 Location to Google
   // (opaque redirect — Location is not exposed to JS).
@@ -188,13 +95,13 @@
     var body = await res.json();
     var redirect = body && body.redirect_url;
     if (!isSafeRedirect(redirect) || !isCompleteGoogleAuthorizeURL(redirect)) {
-      track("fedcm_google_oauth_bad_redirect", {
+      track("google_oauth_bad_redirect", {
         has_url: !!redirect,
         complete: redirect ? isCompleteGoogleAuthorizeURL(redirect) : false,
       });
       throw new Error("incomplete_google_authorize_url");
     }
-    track("fedcm_google_oauth_json_redirect");
+    track("google_oauth_json_redirect");
     window.location.assign(redirect);
   }
 
@@ -238,15 +145,14 @@
         clickInFlight = true;
         track("sign_in_method_clicked", {
           method: "google",
-          path: "oauth_primary",
-          fedcm_supported: fedcmSupported(),
+          path: "oauth_only",
         });
         setGoogleButtonBusy(form, true);
         (async function () {
           try {
             await startGoogleOAuth(form);
           } catch (err) {
-            track("fedcm_google_oauth_failed", {
+            track("google_oauth_failed", {
               message: err && err.message ? String(err.message) : "unknown",
             });
             // Last resort: top-level form POST (browser follows 303).
@@ -261,16 +167,9 @@
     });
   }
 
-  function install(opts) {
-    if (!opts || !opts.clientId || !opts.loginEventId) return;
-    // Always bind OAuth-primary click — works with or without FedCM support.
+  function install(_opts) {
+    // OAuth-only: bind the Google button. No FedCM auto-prompt.
     bindClick();
-    // Optional silent FedCM for returning users; never blocks the button.
-    if (fedcmSupported()) {
-      autoPrompt(opts);
-    } else {
-      track("fedcm_unsupported", { provider: "google" });
-    }
   }
 
   window.stawiGoogleFedCM = { install: install };

--- a/apps/default/tmpl/login.html
+++ b/apps/default/tmpl/login.html
@@ -135,13 +135,13 @@
 </script>
 <script src="/static/js/posthog.js" defer></script>
 <script src="/static/js/fedcm.js" defer></script>
-{{if .enableGoogleLogin}}<script src="/static/js/fedcm_google.js?v=2.0.4" defer></script>{{end}}
+{{if .enableGoogleLogin}}<script src="/static/js/fedcm_google.js?v=2.0.5" defer></script>{{end}}
 <script>
   document.addEventListener("DOMContentLoaded", function () {
-    // FedCM sign-in waterfall. The first-party probe (returning users with an
-    // idp_session cookie) runs first; if it does not sign the user in, Google
-    // One Tap/FedCM is offered. They run sequentially so the browser never
-    // sees two concurrent navigator.credentials.get() calls.
+    // First-party FedCM probe only (returning users with an idp_session cookie
+    // for *our* IdP). Google FedCM/One Tap is intentionally not used: it
+    // opens a broken Google OAuth popup (missing response_type). Google sign-in
+    // is classic OAuth via fedcm_google.js (button click → server authorize URL).
     (async function () {
       var navigated = null;
       if (window.stawiFedCM && "{{ .ClientID }}" && "{{ .loginEventId }}") {
@@ -155,10 +155,7 @@
       }
       if (navigated) return;
       {{if .enableGoogleLogin}}
-      // Google One Tap/FedCM. install() binds the Google button for manual
-      // clicks (FedCM-first, native OAuth fallback) and auto-prompts the
-      // account chooser. clientId is the Google web client ID; nonce binds the
-      // returned id_token to this server-issued login event.
+      // Bind Google button → OAuth-only (no Google FedCM auto-prompt).
       if (window.stawiGoogleFedCM && "{{ .GoogleClientID }}" && "{{ .loginEventId }}") {
         window.stawiGoogleFedCM.install({
           clientId: "{{ .GoogleClientID }}",


### PR DESCRIPTION
## Summary

Production screencast of opportunities → Google login shows:

1. FedCM account picker: **Sign in to stawi.org with google.com**
2. **Verifying…**
3. Popup: `accounts.google.com/signin/oauth/error` — **Required parameter is missing: response_type** (Error 400: invalid_request)

That is Google's FedCM → OAuth escalation popup, not our server-built authorize URL. Live was on **v1.54.21** (FedCM-first + auto-prompt). Even **v1.54.22** (OAuth-primary click) still runs FedCM auto-prompt on page load, which is what the video hits.

### Fix
- Remove all Google FedCM (`navigator.credentials.get`, auto-prompt, complete endpoint from the click path)
- Google button → always classic OAuth via JSON `redirect_url` with `response_type=code`
- Cache-bust `fedcm_google.js?v=2.0.5`

### Expected UX after deploy
1. Click **Sign in with Google**
2. Full-page navigate to Google account chooser (`prompt=select_account`)
3. Return to accounts → consent → opportunities

No FedCM bubble, no broken Google error popup.

## Test plan
- [ ] Merge + tag `v1.54.23` + confirm image builds
- [ ] Unblock identity HelmRelease migration failure so Flux rolls the image
- [ ] Login page HTML references `fedcm_google.js?v=2.0.5`
- [ ] Hard refresh → no FedCM "Sign in to stawi.org with google.com" bubble on load
- [ ] Click Google → lands on `accounts.google.com/o/oauth2/v2/auth?...response_type=code...`
- [ ] Complete login back to opportunities