### PR TITLE
fix(tenancy): auto-bootstrap service bot tenancy access on startup

### DIFF
--- a/apps/tenancy/cmd/main.go
+++ b/apps/tenancy/cmd/main.go
@@ -109,8 +109,6 @@ func main() {
 
 	// Bootstrap root super-user authorization after migration only.
 	// This writes Keto tuples for migration-seeded root owners/admins.
-	// Regular pods skip this — tuples persist in Keto and don't need
-	// re-provisioning on every restart.
 	if isMigration {
 		if bootstrapErr := business.EnsureRootAuthorization(ctx, business.RootAuthorizationDeps{
 			AccessRepo:           partSrv.AccessRepo,
@@ -122,6 +120,25 @@ func main() {
 			util.Log(ctx).WithError(bootstrapErr).Fatal("root authorization bootstrap failed")
 		}
 	}
+
+	// Service-bot Plane-1 access must self-heal on every start. Without
+	// tenancy_access#service grants (and parent→child inheritance), internal
+	// services fail with "cannot service on tenancy_access:<tenant>/<partition>"
+	// during user login when the request carries a non-root partition.
+	if botErr := business.EnsureServiceBotTenancyAccess(ctx, business.ServiceBotTenancyDeps{
+		ServiceAccountRepo: partSrv.ServiceAccountRepo,
+		PartitionRepo:      partSrv.PartitionRepo,
+		Authorizer:         auth,
+	}); botErr != nil {
+		// Non-fatal on regular pods so a temporary Keto outage does not brick
+		// the API; migration still fails closed so deploys don't go green
+		// without authz.
+		if isMigration {
+			util.Log(ctx).WithError(botErr).Fatal("service bot tenancy access bootstrap failed")
+		}
+		util.Log(ctx).WithError(botErr).Error("service bot tenancy access bootstrap failed; will retry on next restart")
+	}
+
 	if reconcileErr := policySync.ReconcilePending(ctx); reconcileErr != nil {
 		util.Log(ctx).WithError(reconcileErr).Fatal("authorization policy startup reconciliation failed")
 	}

--- a/apps/tenancy/service/business/bootstrap_service_bots.go
+++ b/apps/tenancy/service/business/bootstrap_service_bots.go
@@ -1,0 +1,204 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package business
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/antinvestor/service-authentication/apps/tenancy/service/authz"
+	"github.com/antinvestor/service-authentication/apps/tenancy/service/models"
+	"github.com/antinvestor/service-authentication/apps/tenancy/service/repository"
+	"github.com/pitabwire/frame/v2/security"
+	"github.com/pitabwire/util"
+)
+
+// ServiceBotTenancyDeps bundles repositories needed to provision Plane-1
+// service access for internal service accounts.
+type ServiceBotTenancyDeps struct {
+	ServiceAccountRepo repository.ServiceAccountRepository
+	PartitionRepo      repository.PartitionRepository
+	Authorizer         security.Authorizer
+}
+
+// EnsureServiceBotTenancyAccess writes the Keto tuples that let internal
+// service bots operate across every tenant/partition:
+//
+//  1. tenancy_access:<tenant>/<partition>#service ← profile_user:<sa.profile_id>
+//     for every service account × every partition (including root)
+//  2. tenancy_access:<child>#service ← tenancy_access:<parent>#service
+//     for every parent→child partition edge (inheritance for future partitions)
+//
+// Cross-tenant product partitions (e.g. opportunities) are not descendants of
+// the platform root path, so inheritance alone is insufficient — we grant
+// explicit service access on each known partition.
+//
+// Without these grants, service-authentication fails Plane-1 checks when a
+// login sets request tenancy to a product partition:
+//
+//	permission_denied: cannot service on tenancy_access:<tenant>/<partition>
+//
+// Idempotent and safe to run on every tenancy pod start.
+func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDeps) error {
+	logger := util.Log(ctx).WithField("component", "service_bot_tenancy_bootstrap")
+
+	if deps.Authorizer == nil {
+		return fmt.Errorf("service bot bootstrap: authorizer is required")
+	}
+	if deps.ServiceAccountRepo == nil || deps.PartitionRepo == nil {
+		return fmt.Errorf("service bot bootstrap: service account and partition repositories are required")
+	}
+
+	ctx = security.SkipTenancyChecksOnClaims(ctx)
+
+	accounts, err := deps.ServiceAccountRepo.ListAll(ctx)
+	if err != nil {
+		return fmt.Errorf("service bot bootstrap: list service accounts: %w", err)
+	}
+	partitions, err := deps.PartitionRepo.ListAll(ctx)
+	if err != nil {
+		return fmt.Errorf("service bot bootstrap: list partitions: %w", err)
+	}
+
+	profiles, paths := collectServiceBotProfilesAndPaths(accounts, partitions)
+	tuples := buildServiceBotTenancyTuples(profiles, paths, partitions)
+
+	if len(tuples) == 0 {
+		logger.Warn("no service bot tenancy tuples to write")
+		return nil
+	}
+
+	if writeErr := deps.Authorizer.WriteTuples(ctx, tuples); writeErr != nil {
+		return fmt.Errorf("service bot bootstrap: write %d tuples: %w", len(tuples), writeErr)
+	}
+
+	logger.WithFields(map[string]any{
+		"service_accounts": len(accounts),
+		"bot_profiles":     len(profiles),
+		"partition_paths":  len(paths),
+		"tuples_written":   len(tuples),
+	}).Info("service bot tenancy access bootstrap complete")
+	return nil
+}
+
+func collectServiceBotProfilesAndPaths(
+	accounts []*models.ServiceAccount,
+	partitions []*models.Partition,
+) (profiles map[string]struct{}, paths map[string]struct{}) {
+	paths = map[string]struct{}{
+		fmt.Sprintf("%s/%s", authz.RootTenantID, authz.RootPartitionID): {},
+	}
+	for _, p := range partitions {
+		if p == nil || p.ID == "" {
+			continue
+		}
+		tenantID := strings.TrimSpace(p.TenantID)
+		if tenantID == "" {
+			continue
+		}
+		paths[fmt.Sprintf("%s/%s", tenantID, p.ID)] = struct{}{}
+	}
+
+	profiles = make(map[string]struct{}, len(accounts))
+	for _, sa := range accounts {
+		if sa == nil {
+			continue
+		}
+		profileID := strings.TrimSpace(sa.ProfileID)
+		if profileID == "" {
+			continue
+		}
+		profiles[profileID] = struct{}{}
+		tenantID := strings.TrimSpace(sa.TenantID)
+		partitionID := strings.TrimSpace(sa.PartitionID)
+		if tenantID != "" && partitionID != "" {
+			paths[fmt.Sprintf("%s/%s", tenantID, partitionID)] = struct{}{}
+		}
+	}
+	return profiles, paths
+}
+
+func buildServiceBotTenancyTuples(
+	profiles map[string]struct{},
+	paths map[string]struct{},
+	partitions []*models.Partition,
+) []security.RelationTuple {
+	tuples := make([]security.RelationTuple, 0, len(profiles)*len(paths)+len(partitions))
+
+	for profileID := range profiles {
+		for path := range paths {
+			tuples = append(tuples, authz.BuildServiceAccessTuple(path, profileID))
+		}
+	}
+
+	byID := make(map[string]*models.Partition, len(partitions))
+	for _, p := range partitions {
+		if p != nil && p.ID != "" {
+			byID[p.ID] = p
+		}
+	}
+
+	seenEdges := make(map[string]struct{}, len(partitions))
+	for _, child := range partitions {
+		parentPath, childPath, ok := partitionServiceInheritanceEdge(child, byID)
+		if !ok {
+			continue
+		}
+		edgeKey := parentPath + "->" + childPath
+		if _, exists := seenEdges[edgeKey]; exists {
+			continue
+		}
+		seenEdges[edgeKey] = struct{}{}
+		tuples = append(tuples, authz.BuildServicePartitionInheritanceTuple(parentPath, childPath))
+	}
+	return tuples
+}
+
+func partitionServiceInheritanceEdge(
+	child *models.Partition,
+	byID map[string]*models.Partition,
+) (parentPath, childPath string, ok bool) {
+	if child == nil || child.ID == "" {
+		return "", "", false
+	}
+	parentID := strings.TrimSpace(child.ParentID)
+	if parentID == "" {
+		return "", "", false
+	}
+
+	parent, found := byID[parentID]
+	if !found || parent == nil {
+		parent = &models.Partition{}
+		parent.ID = parentID
+		if parentID == authz.RootPartitionID {
+			parent.TenantID = authz.RootTenantID
+		} else {
+			parent.TenantID = child.TenantID
+		}
+	}
+
+	parentTenant := strings.TrimSpace(parent.TenantID)
+	if parentTenant == "" {
+		parentTenant = strings.TrimSpace(child.TenantID)
+	}
+	childTenant := strings.TrimSpace(child.TenantID)
+	if parentTenant == "" || childTenant == "" {
+		return "", "", false
+	}
+	return fmt.Sprintf("%s/%s", parentTenant, parent.ID),
+		fmt.Sprintf("%s/%s", childTenant, child.ID),
+		true
+}

--- a/apps/tenancy/service/business/bootstrap_service_bots_test.go
+++ b/apps/tenancy/service/business/bootstrap_service_bots_test.go
@@ -1,0 +1,45 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package business
+
+import (
+	"testing"
+
+	"github.com/antinvestor/service-authentication/apps/tenancy/service/authz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceBotAccessTupleShapes(t *testing.T) {
+	t.Parallel()
+
+	saProfile := "d75qclkpf2t1uum8ij40"
+	rootPath := authz.RootTenantID + "/" + authz.RootPartitionID
+	childPath := "d7gi6lkpf2t67dlsqre0/d7gi6lkpf2t67dlsqreg"
+
+	t1 := authz.BuildServiceAccessTuple(rootPath, saProfile)
+	require.Equal(t, authz.NamespaceTenancyAccess, t1.Object.Namespace)
+	require.Equal(t, rootPath, t1.Object.ID)
+	require.Equal(t, authz.RoleService, t1.Relation)
+	require.Equal(t, authz.NamespaceProfile, t1.Subject.Namespace)
+	require.Equal(t, saProfile, t1.Subject.ID)
+
+	t2 := authz.BuildServicePartitionInheritanceTuple(rootPath, childPath)
+	require.Equal(t, authz.NamespaceTenancyAccess, t2.Object.Namespace)
+	require.Equal(t, childPath, t2.Object.ID)
+	require.Equal(t, authz.RoleService, t2.Relation)
+	require.Equal(t, authz.NamespaceTenancyAccess, t2.Subject.Namespace)
+	require.Equal(t, rootPath, t2.Subject.ID)
+	require.Equal(t, authz.RoleService, t2.Subject.Relation)
+}

--- a/apps/tenancy/service/repository/interfaces.go
+++ b/apps/tenancy/service/repository/interfaces.go
@@ -32,6 +32,8 @@ type PartitionRepository interface {
 	GetChildren(ctx context.Context, id string) ([]*models.Partition, error)
 	GetParents(ctx context.Context, id string) ([]*models.Partition, error)
 	CountByTenantID(ctx context.Context, tenantID string) (int64, error)
+	// ListAll returns every partition (used by authz bootstrap).
+	ListAll(ctx context.Context) ([]*models.Partition, error)
 }
 type PartitionRoleRepository interface {
 	datastore.BaseRepository[*models.PartitionRole]
@@ -82,6 +84,8 @@ type ServiceAccountRepository interface {
 	GetByClientID(ctx context.Context, clientID string) (*models.ServiceAccount, error)
 	GetByClientRef(ctx context.Context, clientRef string) (*models.ServiceAccount, error)
 	ListByPartition(ctx context.Context, partitionID string) ([]*models.ServiceAccount, error)
+	// ListAll returns every service account (used by authz bootstrap).
+	ListAll(ctx context.Context) ([]*models.ServiceAccount, error)
 	CountByPartitionID(ctx context.Context, partitionID string) (int64, error)
 }
 

--- a/apps/tenancy/service/repository/partitions.go
+++ b/apps/tenancy/service/repository/partitions.go
@@ -72,6 +72,12 @@ func (pr *partitionRepository) GetChildren(ctx context.Context, id string) ([]*m
 	return childPartition, err
 }
 
+func (pr *partitionRepository) ListAll(ctx context.Context) ([]*models.Partition, error) {
+	var partitions []*models.Partition
+	err := pr.Pool().DB(ctx, true).Find(&partitions).Error
+	return partitions, err
+}
+
 func (pr *partitionRepository) Delete(ctx context.Context, id string) error {
 	var partition models.Partition
 	if err := pr.Pool().DB(ctx, true).First(&partition, "id = ?", id).Error; err != nil {

--- a/apps/tenancy/service/repository/service_account.go
+++ b/apps/tenancy/service/repository/service_account.go
@@ -94,6 +94,15 @@ func (r *serviceAccountRepository) ListByPartition(
 	return accounts, nil
 }
 
+func (r *serviceAccountRepository) ListAll(ctx context.Context) ([]*models.ServiceAccount, error) {
+	var accounts []*models.ServiceAccount
+	err := r.Pool().DB(ctx, true).Find(&accounts).Error
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
 func (r *serviceAccountRepository) CountByPartitionID(ctx context.Context, partitionID string) (int64, error) {
 	var count int64
 	err := r.Pool().DB(ctx, true).Model(&models.ServiceAccount{}).Where("partition_id = ?", partitionID).Count(&count).Error


### PR DESCRIPTION
## Summary

Fixes: `profile lookup failed: permission_denied: service-authentication cannot service on tenancy_access:<opportunities>`

### Cause
Login sets request tenancy to the product partition. Profile Plane-1 requires `tenancy_access#service` for the auth service bot on that path. Tuples were missing after greenfield/keto drift.

### Fix
`EnsureServiceBotTenancyAccess` runs on **every tenancy pod start**:
1. Grant `service` for every SA profile on every partition path
2. Write parent→child service inheritance

## Test plan
- [ ] Deploy tenancy image from this tag
- [ ] Logs show `service bot tenancy access bootstrap complete`
- [ ] Google login past profile lookup