### PR TITLE
fix(auth): service-bot tenancy context for login profile S2S

### DIFF
--- a/apps/default/service/handlers/login_step_1_post.go
+++ b/apps/default/service/handlers/login_step_1_post.go
@@ -47,7 +47,9 @@ func (h *AuthServer) LoginEndpointSubmit(rw http.ResponseWriter, req *http.Reque
 		log.WithError(err).Error("cache lookup failed for login event")
 		return err
 	}
-	ctx = util.SetTenancy(ctx, loginEvt)
+	// Profile lookups/creates run as the service bot (JWT home tenancy).
+	// User-partition tenancy is applied only when needed for verification send.
+	ctx = serviceBotContext(ctx)
 
 	// Step 2: Handle contactDetail submission
 	contactDetail := req.FormValue("contactDetail")
@@ -133,8 +135,8 @@ func (h *AuthServer) LoginEndpointSubmit(rw http.ResponseWriter, req *http.Reque
 		profileID = existingProfile.GetId()
 	}
 
-	// Step 7: Create verification and send code
-	ctx = util.SetTenancy(ctx, loginEvt)
+	// Step 7: Create verification and send code (still service-bot Plane-1 path)
+	ctx = serviceBotContext(ctx)
 	resp, err := h.profileCli.CreateContactVerification(ctx, connect.NewRequest(&profilev1.CreateContactVerificationRequest{
 		Id:               util.IDString(),
 		ContactId:        contactID,

--- a/apps/default/service/handlers/login_step_2_google_fedcm.go
+++ b/apps/default/service/handlers/login_step_2_google_fedcm.go
@@ -164,7 +164,8 @@ func (h *AuthServer) FedCMGoogleCompleteEndpoint(w http.ResponseWriter, r *http.
 		}
 	}
 
-	ctx = util.SetTenancy(ctx, loginEvt)
+	// Service-bot context for profile S2S (see serviceBotContext docs).
+	ctx = serviceBotContext(ctx)
 
 	// Step 8: Run the shared profile-resolution + Hydra-acceptance path.
 	redirectURL, runErr := h.completeProviderLogin(ctx, r, loginEvt, user, googleProvider.Name())

--- a/apps/default/service/handlers/login_step_2_verification_post.go
+++ b/apps/default/service/handlers/login_step_2_verification_post.go
@@ -99,8 +99,8 @@ func (h *AuthServer) VerificationEndpointSubmit(rw http.ResponseWriter, req *htt
 		return err
 	}
 
-	// Step 3.5: Set tenancy context for profile service calls
-	ctx = util.SetTenancy(ctx, loginEvent)
+	// Step 3.5: Profile S2S uses service-bot JWT tenancy (Plane 1 service on home path).
+	ctx = serviceBotContext(ctx)
 
 	// Step 4: Verify the login credentials
 	profileID, err := h.verifyProfileLogin(ctx, loginEvent, verificationCode)
@@ -134,6 +134,8 @@ func (h *AuthServer) VerificationEndpointSubmit(rw http.ResponseWriter, req *htt
 		}
 	}
 
+	// Access provisioning targets the OAuth client's partition — restore user tenancy.
+	ctx = withUserLoginTenancy(ctx, loginEvent)
 	loginEvent, err = h.ensureLoginEventTenancyAccess(ctx, loginEvent, loginEvent.ClientID, profileID)
 	if err != nil {
 		log.WithError(err).Error("failed to ensure tenancy access for login event")

--- a/apps/default/service/handlers/login_step_2_verification_resend.go
+++ b/apps/default/service/handlers/login_step_2_verification_resend.go
@@ -137,8 +137,8 @@ func (h *AuthServer) VerificationResendEndpoint(rw http.ResponseWriter, req *htt
 		}
 	}
 
-	// Step 4: Generate new verification ID and send code
-	ctx = util.SetTenancy(ctx, loginEvent)
+	// Step 4: Generate new verification ID and send code (service-bot Plane-1)
+	ctx = serviceBotContext(ctx)
 	newVerificationID := util.IDString()
 
 	resp, err := h.profileCli.CreateContactVerification(ctx, connect.NewRequest(&profilev1.CreateContactVerificationRequest{

--- a/apps/default/service/handlers/login_step_2_via_providers_callback.go
+++ b/apps/default/service/handlers/login_step_2_via_providers_callback.go
@@ -133,10 +133,15 @@ func (h *AuthServer) ProviderCallbackEndpointV2(rw http.ResponseWriter, req *htt
 		}
 	}
 
-	ctx = util.SetTenancy(ctx, loginEvt)
+	// Keep service-bot JWT tenancy for outbound profile/device S2S calls.
+	// Setting login-event tenancy here rewrites Plane-1 checks onto the
+	// product partition and fails when the bot only has service on root.
+	ctx = serviceBotContext(ctx)
 	log.WithFields(map[string]any{
-		"client_id":   loginEvt.ClientID,
-		"duration_ms": time.Since(start).Milliseconds(),
+		"client_id":    loginEvt.ClientID,
+		"tenant_id":    loginEvt.TenantID,
+		"partition_id": loginEvt.PartitionID,
+		"duration_ms":  time.Since(start).Milliseconds(),
 	}).Debug("provider callback processed, completing user login")
 
 	// Step 7: Complete the login flow
@@ -186,6 +191,11 @@ func (h *AuthServer) completeProviderLogin(
 		"provider":       provider,
 		"login_event_id": loginEvt.GetID(),
 	})
+
+	// Identity S2S (profile) must run with the service bot's JWT home tenancy.
+	// User-partition secondary tenancy is re-applied later only if needed for
+	// access provisioning (consent / ensureLoginEventTenancyAccess).
+	ctx = serviceBotContext(ctx)
 
 	contactDetail := loggedInUser.Contact
 	if contactDetail == "" {
@@ -301,7 +311,10 @@ func (h *AuthServer) completeProviderLogin(
 		return "", fmt.Errorf("resolved profile has empty ID")
 	}
 
-	loginEvent, err = h.ensureLoginEventTenancyAccess(ctx, loginEvent, loginEvt.ClientID, profileID)
+	// Access provisioning may need the OAuth client partition; hydrate secondary
+	// tenancy only for this step (Plane-1 still falls back via Hydra metadata).
+	accessCtx := withUserLoginTenancy(ctx, loginEvent)
+	loginEvent, err = h.ensureLoginEventTenancyAccess(accessCtx, loginEvent, loginEvt.ClientID, profileID)
 	if err != nil {
 		log.WithError(err).Error("failed to ensure tenancy access for provider login")
 		return "", fmt.Errorf("provider login tenancy access failed: %w", err)

--- a/apps/default/service/handlers/service_bot_context.go
+++ b/apps/default/service/handlers/service_bot_context.go
@@ -1,0 +1,57 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"context"
+
+	"github.com/pitabwire/util"
+)
+
+// serviceBotContext returns a context for service-to-service calls made by the
+// authentication service bot during login orchestration.
+//
+// Why this exists (three authorization planes):
+//
+//  1. Plane 1 (tenancy_access): system_internal callers are checked with the
+//     "service" relation on claims.TenantID/PartitionID. Frame's
+//     ClaimsFromContext merges util.GetTenancy secondary claims for internal
+//     bots. If login code does util.SetTenancy(ctx, loginEvent) with the
+//     OAuth client's product partition, Plane 1 is evaluated on that path
+//     (e.g. opportunities). The bot typically only has service on its home
+//     (root) partition → permission_denied: cannot service on tenancy_access:…
+//
+//  2. Plane 2 (RPC / function permissions): remains enforced against the bot's
+//     JWT home path after clearing secondary tenancy.
+//
+//  3. Plane 3 (resource): not used on profile GetByContact/Create for login.
+//
+// Clearing secondary tenancy restores JWT home tenancy for outbound profile /
+// device / notification calls. Callers that need user-partition tenancy for
+// access provisioning should use withUserLoginTenancy after S2S identity work.
+func serviceBotContext(ctx context.Context) context.Context {
+	// nil TenancyInfo clears secondary claims so ClaimsFromContext uses JWT.
+	return util.SetTenancy(ctx, nil)
+}
+
+// withUserLoginTenancy sets secondary tenancy from the login event for
+// operations that must run in the OAuth client's partition (e.g. creating
+// Access rows). Prefer serviceBotContext for pure identity S2S lookups.
+func withUserLoginTenancy(ctx context.Context, tenancy util.TenancyInfo) context.Context {
+	if tenancy == nil {
+		return serviceBotContext(ctx)
+	}
+	return util.SetTenancy(ctx, tenancy)
+}

--- a/apps/default/service/handlers/service_bot_context_test.go
+++ b/apps/default/service/handlers/service_bot_context_test.go
@@ -1,0 +1,61 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/antinvestor/service-authentication/apps/default/service/models"
+	"github.com/pitabwire/frame/v2/data"
+	"github.com/pitabwire/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceBotContext_ClearsSecondaryTenancy(t *testing.T) {
+	t.Parallel()
+
+	evt := &models.LoginEvent{
+		BaseModel: data.BaseModel{
+			TenantID:    "d7gi6lkpf2t67dlsqre0",
+			PartitionID: "d7gi6lkpf2t67dlsqreg",
+		},
+	}
+	ctx := util.SetTenancy(context.Background(), evt)
+	require.NotNil(t, util.GetTenancy(ctx))
+	require.Equal(t, evt.GetPartitionID(), util.GetTenancy(ctx).GetPartitionID())
+
+	botCtx := serviceBotContext(ctx)
+	// Secondary tenancy must not survive; plane-1 checks use JWT home path.
+	require.Nil(t, util.GetTenancy(botCtx))
+}
+
+func TestWithUserLoginTenancy(t *testing.T) {
+	t.Parallel()
+
+	evt := &models.LoginEvent{
+		BaseModel: data.BaseModel{
+			TenantID:    "tenant-a",
+			PartitionID: "part-a",
+		},
+	}
+	ctx := withUserLoginTenancy(context.Background(), evt)
+	ti := util.GetTenancy(ctx)
+	require.NotNil(t, ti)
+	require.Equal(t, "tenant-a", ti.GetTenantID())
+	require.Equal(t, "part-a", ti.GetPartitionID())
+
+	require.Nil(t, util.GetTenancy(withUserLoginTenancy(context.Background(), nil)))
+}


### PR DESCRIPTION
## Summary

Fixes remaining Google login error:

`profile lookup failed: permission_denied: cannot service on tenancy_access:d7gi6lk…/d7gi6lk…`

### Three-plane analysis

| Plane | What went wrong | Fix |
|-------|-----------------|-----|
| **1 tenancy_access** | `SetTenancy(loginEvt)` rewrote system_internal claims to product partition before `profile.GetByContact` | `serviceBotContext` clears secondary tenancy so Plane-1 uses bot JWT home (root) |
| **2 RPC permissions** | Unchanged; still enforced on bot home path | — |
| **3 resource** | N/A for GetByContact | — |

### Foundation (already shipped)
- **v1.54.25** tenancy: `EnsureServiceBotTenancyAccess` on every start grants `#service` on all partitions
- **v1.54.24** auth: Hydra metadata fallback for login-event tenant/partition

Together: correct S2S context + self-healing Keto grants.

## Test plan
- [ ] Tag deploy auth **v1.54.26** + confirm tenancy **v1.54.25**
- [ ] opportunities Google login completes past SocialLoginCallbackEndpoint