### PR TITLE
fix(authz): key service-account Keto subjects by OAuth2 client_id

### DIFF
--- a/apps/default/service/handlers/webhook.go
+++ b/apps/default/service/handlers/webhook.go
@@ -347,15 +347,34 @@ func writeTokenHookResponse(rw http.ResponseWriter, claims map[string]any) error
 	return json.NewEncoder(rw).Encode(hookResponse)
 }
 
-// writeTokenHookResponseWithSubject writes a token enrichment response that also
-// overrides the JWT sub claim. For client_credentials grants Hydra sets sub to
-// the client_id; this allows the webhook to correct it to the profile_id.
+// writeTokenHookResponseWithSubject writes a token enrichment response.
+//
+// Important (Hydra v2+): Ory Hydra cannot override the JWT "sub" claim from the
+// token hook for any grant type — including client_credentials. For machine
+// tokens, sub remains the OAuth2 client_id. The optional top-level "subject"
+// field is accepted for forward compatibility but is ignored by Hydra today.
+//
+// Therefore:
+//   - Access-token claims carry profile_id / tenant_id / roles / etc.
+//   - Keto Plane-1/2 subjects for service accounts MUST use client_id (JWT sub),
+//     not profile_id. See apps/tenancy SA sync + service bot bootstrap.
+//
+// The subject argument is still recorded as the intended logical identity
+// (profile_id) for logs and any future Hydra support.
 func writeTokenHookResponseWithSubject(rw http.ResponseWriter, claims map[string]any, subject string) error {
+	if claims != nil && subject != "" {
+		// Ensure profile_id is always present in token extras even if callers
+		// forget to put it in claims — it is the durable SA identity for audit.
+		if _, ok := claims["profile_id"]; !ok {
+			claims["profile_id"] = subject
+		}
+	}
 	hookResponse := map[string]any{
 		"session": map[string]any{
 			"access_token": claims,
 			"id_token":     claims,
 		},
+		// Hydra ignores this today; kept for documentation/forward-compat.
 		"subject": subject,
 	}
 	rw.Header().Set("Content-Type", "application/json")

--- a/apps/tenancy/service/business/bootstrap_service_bots.go
+++ b/apps/tenancy/service/business/bootstrap_service_bots.go
@@ -35,21 +35,32 @@ type ServiceBotTenancyDeps struct {
 }
 
 // EnsureServiceBotTenancyAccess writes the Keto tuples that let internal
-// service bots operate across every tenant/partition:
+// service bots operate across every tenant/partition.
 //
-//  1. tenancy_access:<tenant>/<partition>#service ← profile_user:<sa.profile_id>
+// Identity model (critical):
+//
+//	Ory Hydra cannot override the JWT "sub" claim for client_credentials tokens
+//	(sub is always the OAuth2 client_id). Frame's TenancyAccessChecker checks
+//	Keto with subject_id = JWT sub. Therefore SA Plane-1 subjects MUST be the
+//	Hydra client_id (e.g. "service-authentication"), not the profile_id.
+//
+// Tuples written:
+//
+//  1. tenancy_access:<tenant>/<partition>#service ← <sa.client_id>
 //     for every service account × every partition (including root)
 //  2. tenancy_access:<child>#service ← tenancy_access:<parent>#service
 //     for every parent→child partition edge (inheritance for future partitions)
+//
+// Profile_id is dual-written as a secondary subject when present so any
+// caller that still checks profile identity continues to work.
 //
 // Cross-tenant product partitions (e.g. opportunities) are not descendants of
 // the platform root path, so inheritance alone is insufficient — we grant
 // explicit service access on each known partition.
 //
-// Without these grants, service-authentication fails Plane-1 checks when a
-// login sets request tenancy to a product partition:
+// Without these grants, service-authentication fails Plane-1 checks:
 //
-//	permission_denied: cannot service on tenancy_access:<tenant>/<partition>
+//	permission_denied: service-authentication cannot service on tenancy_access:…
 //
 // Idempotent and safe to run on every tenancy pod start.
 func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDeps) error {
@@ -73,8 +84,8 @@ func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDe
 		return fmt.Errorf("service bot bootstrap: list partitions: %w", err)
 	}
 
-	profiles, paths := collectServiceBotProfilesAndPaths(accounts, partitions)
-	tuples := buildServiceBotTenancyTuples(profiles, paths, partitions)
+	subjects, paths := collectServiceBotSubjectsAndPaths(accounts, partitions)
+	tuples := buildServiceBotTenancyTuples(subjects, paths, partitions)
 
 	if len(tuples) == 0 {
 		logger.Warn("no service bot tenancy tuples to write")
@@ -87,17 +98,32 @@ func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDe
 
 	logger.WithFields(map[string]any{
 		"service_accounts": len(accounts),
-		"bot_profiles":     len(profiles),
+		"bot_subjects":     len(subjects),
 		"partition_paths":  len(paths),
 		"tuples_written":   len(tuples),
 	}).Info("service bot tenancy access bootstrap complete")
 	return nil
 }
 
-func collectServiceBotProfilesAndPaths(
+// serviceAccountKetoSubject returns the identity used in Keto checks for a
+// service account. Hydra sets JWT sub to the OAuth2 client_id for
+// client_credentials grants and does not allow the token hook to override it,
+// so client_id is the primary subject. Profile_id is a fallback when client_id
+// has not been denormalised yet.
+func serviceAccountKetoSubject(sa *models.ServiceAccount) string {
+	if sa == nil {
+		return ""
+	}
+	if clientID := strings.TrimSpace(sa.ClientID); clientID != "" {
+		return clientID
+	}
+	return strings.TrimSpace(sa.ProfileID)
+}
+
+func collectServiceBotSubjectsAndPaths(
 	accounts []*models.ServiceAccount,
 	partitions []*models.Partition,
-) (profiles map[string]struct{}, paths map[string]struct{}) {
+) (subjects map[string]struct{}, paths map[string]struct{}) {
 	paths = map[string]struct{}{
 		fmt.Sprintf("%s/%s", authz.RootTenantID, authz.RootPartitionID): {},
 	}
@@ -112,35 +138,39 @@ func collectServiceBotProfilesAndPaths(
 		paths[fmt.Sprintf("%s/%s", tenantID, p.ID)] = struct{}{}
 	}
 
-	profiles = make(map[string]struct{}, len(accounts))
+	subjects = make(map[string]struct{}, len(accounts)*2)
 	for _, sa := range accounts {
 		if sa == nil {
 			continue
 		}
-		profileID := strings.TrimSpace(sa.ProfileID)
-		if profileID == "" {
-			continue
+		// Primary: JWT sub (client_id). Secondary: profile_id for dual-write.
+		for _, subject := range []string{
+			strings.TrimSpace(sa.ClientID),
+			strings.TrimSpace(sa.ProfileID),
+		} {
+			if subject != "" {
+				subjects[subject] = struct{}{}
+			}
 		}
-		profiles[profileID] = struct{}{}
 		tenantID := strings.TrimSpace(sa.TenantID)
 		partitionID := strings.TrimSpace(sa.PartitionID)
 		if tenantID != "" && partitionID != "" {
 			paths[fmt.Sprintf("%s/%s", tenantID, partitionID)] = struct{}{}
 		}
 	}
-	return profiles, paths
+	return subjects, paths
 }
 
 func buildServiceBotTenancyTuples(
-	profiles map[string]struct{},
+	subjects map[string]struct{},
 	paths map[string]struct{},
 	partitions []*models.Partition,
 ) []security.RelationTuple {
-	tuples := make([]security.RelationTuple, 0, len(profiles)*len(paths)+len(partitions))
+	tuples := make([]security.RelationTuple, 0, len(subjects)*len(paths)+len(partitions))
 
-	for profileID := range profiles {
+	for subject := range subjects {
 		for path := range paths {
-			tuples = append(tuples, authz.BuildServiceAccessTuple(path, profileID))
+			tuples = append(tuples, authz.BuildServiceAccessTuple(path, subject))
 		}
 	}
 

--- a/apps/tenancy/service/business/bootstrap_service_bots_test.go
+++ b/apps/tenancy/service/business/bootstrap_service_bots_test.go
@@ -18,22 +18,57 @@ import (
 	"testing"
 
 	"github.com/antinvestor/service-authentication/apps/tenancy/service/authz"
+	"github.com/antinvestor/service-authentication/apps/tenancy/service/models"
 	"github.com/stretchr/testify/require"
 )
+
+func TestServiceAccountKetoSubjectPrefersClientID(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "service-authentication", serviceAccountKetoSubject(&models.ServiceAccount{
+		ClientID:  "service-authentication",
+		ProfileID: "d75qclkpf2t1uum8ij40",
+	}))
+	require.Equal(t, "d75qclkpf2t1uum8ij40", serviceAccountKetoSubject(&models.ServiceAccount{
+		ProfileID: "d75qclkpf2t1uum8ij40",
+	}))
+	require.Equal(t, "", serviceAccountKetoSubject(nil))
+	require.Equal(t, "", serviceAccountKetoSubject(&models.ServiceAccount{}))
+}
+
+func TestCollectServiceBotSubjectsIncludesClientAndProfile(t *testing.T) {
+	t.Parallel()
+
+	accounts := []*models.ServiceAccount{
+		{ClientID: "service-authentication", ProfileID: "d75qclkpf2t1uum8ij40"},
+		{ClientID: "service-profile", ProfileID: "d75qclkpf2t1uum8ij4g"},
+		{ProfileID: "orphan-profile-only"},
+		nil,
+	}
+	subjects, paths := collectServiceBotSubjectsAndPaths(accounts, nil)
+
+	require.Contains(t, subjects, "service-authentication")
+	require.Contains(t, subjects, "d75qclkpf2t1uum8ij40")
+	require.Contains(t, subjects, "service-profile")
+	require.Contains(t, subjects, "d75qclkpf2t1uum8ij4g")
+	require.Contains(t, subjects, "orphan-profile-only")
+	require.Contains(t, paths, authz.RootTenantID+"/"+authz.RootPartitionID)
+}
 
 func TestServiceBotAccessTupleShapes(t *testing.T) {
 	t.Parallel()
 
-	saProfile := "d75qclkpf2t1uum8ij40"
+	// JWT sub for client_credentials is the OAuth2 client_id.
+	saSubject := "service-authentication"
 	rootPath := authz.RootTenantID + "/" + authz.RootPartitionID
 	childPath := "d7gi6lkpf2t67dlsqre0/d7gi6lkpf2t67dlsqreg"
 
-	t1 := authz.BuildServiceAccessTuple(rootPath, saProfile)
+	t1 := authz.BuildServiceAccessTuple(rootPath, saSubject)
 	require.Equal(t, authz.NamespaceTenancyAccess, t1.Object.Namespace)
 	require.Equal(t, rootPath, t1.Object.ID)
 	require.Equal(t, authz.RoleService, t1.Relation)
 	require.Equal(t, authz.NamespaceProfile, t1.Subject.Namespace)
-	require.Equal(t, saProfile, t1.Subject.ID)
+	require.Equal(t, saSubject, t1.Subject.ID)
 
 	t2 := authz.BuildServicePartitionInheritanceTuple(rootPath, childPath)
 	require.Equal(t, authz.NamespaceTenancyAccess, t2.Object.Namespace)
@@ -42,4 +77,17 @@ func TestServiceBotAccessTupleShapes(t *testing.T) {
 	require.Equal(t, authz.NamespaceTenancyAccess, t2.Subject.Namespace)
 	require.Equal(t, rootPath, t2.Subject.ID)
 	require.Equal(t, authz.RoleService, t2.Subject.Relation)
+}
+
+func TestBuildServiceBotTenancyTuplesUsesClientSubjects(t *testing.T) {
+	t.Parallel()
+
+	subjects := map[string]struct{}{"service-authentication": {}}
+	paths := map[string]struct{}{
+		authz.RootTenantID + "/" + authz.RootPartitionID: {},
+	}
+	tuples := buildServiceBotTenancyTuples(subjects, paths, nil)
+	require.Len(t, tuples, 1)
+	require.Equal(t, "service-authentication", tuples[0].Subject.ID)
+	require.Equal(t, authz.RoleService, tuples[0].Relation)
 }

--- a/apps/tenancy/service/events/authz_service_account_sync.go
+++ b/apps/tenancy/service/events/authz_service_account_sync.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
@@ -370,6 +371,18 @@ func (e *AuthzServiceAccountSyncEvent) desiredTuples(
 	partitionsByID := make(map[string]*models.Partition, len(tree))
 	partitionsByID[basePartition.ID] = basePartition
 
+	// Keto subject must match JWT "sub". Hydra sets sub=client_id for
+	// client_credentials and does not allow the token hook to override it.
+	// Frame checks subject_id = JWT sub, so grants keyed only by profile_id
+	// never match production service-account tokens.
+	subjectID := strings.TrimSpace(sa.ClientID)
+	if subjectID == "" {
+		subjectID = strings.TrimSpace(sa.ProfileID)
+	}
+	if subjectID == "" {
+		return nil, fmt.Errorf("service account %s has empty client_id and profile_id", sa.ID)
+	}
+
 	desiredRelations := make([]security.RelationTuple, 0)
 	for _, grant := range grants {
 		resolved, resolveErr := authz.ResolveServiceGrants(
@@ -394,7 +407,7 @@ func (e *AuthzServiceAccountSyncEvent) desiredTuples(
 			tenancyPath := fmt.Sprintf("%s/%s", partition.TenantID, partition.ID)
 			desiredRelations = append(desiredRelations, authz.BuildServicePermissionTuples(
 				tenancyPath,
-				sa.ProfileID,
+				subjectID,
 				grant.Namespace,
 				resolved[grant.Namespace],
 			)...)
@@ -403,7 +416,7 @@ func (e *AuthzServiceAccountSyncEvent) desiredTuples(
 
 	for _, partition := range partitionsByID {
 		tenancyPath := fmt.Sprintf("%s/%s", partition.TenantID, partition.ID)
-		desiredRelations = append(desiredRelations, authz.BuildServiceAccessTuple(tenancyPath, sa.ProfileID))
+		desiredRelations = append(desiredRelations, authz.BuildServiceAccessTuple(tenancyPath, subjectID))
 	}
 	authz.SortRelationTuples(desiredRelations)
 


### PR DESCRIPTION
## Summary
- **Root cause:** Ory Hydra cannot override JWT `sub` for `client_credentials` tokens. Production tokens have `sub=service-authentication` (client_id), while Keto grants were written for `profile_id` (`d75qclk…ij40`). Frame checks bare `subject_id = JWT sub`, so Plane-1 denied profile lookup during social login with: `service-authentication cannot service on tenancy_access:…`.
- **Production:** Wrote Plane-1 `#service` for all SA client_ids on root, plus Plane-2 profile/tenancy `granted_*` for `service-authentication`.
- **Code:** SA authorization sync and service-bot bootstrap now key subjects by `client_id` (JWT sub); bootstrap dual-writes `profile_id` for transition safety. Documented Hydra subject limitation in the token webhook.

## Test plan
- [x] Unit tests for bootstrap subject collection / client_id preference
- [x] Package compiles for handlers + events
- [x] Live Keto check: `service-authentication` → `tenancy_access` / `service_profile` / `service_tenancy` allowed on root
- [ ] Retry Google social login on opportunities → profile lookup succeeds
- [ ] After deploy, tenancy bootstrap logs `bot_subjects` including client_ids