### PR TITLE
fix(authz): keep profile_id as the acting principal for ReBAC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,16 @@ This is a multi-tenant OAuth2/OpenID Connect authentication service built on **O
 - **Multi-tenancy** with tenant/partition isolation
 - **Device tracking** for session management
 
+## Identity model (do not drift)
+
+| Concept | Meaning |
+|---------|---------|
+| **`profile_id`** | **Acting principal.** Permissions (Keto) are always granted to profiles (users or bot SAs). |
+| **`client_id`** | OAuth2 client used at login / token issuance; identifies which **partition** the flow belongs to. **Not** a Keto subject. |
+| **JWT `sub`** | Wire claim; may equal `client_id` on machine tokens. Authorization uses `profile_id` via Frame `GetProfileID()`. |
+
+Full write-up: [`docs/IDENTITY_AND_AUTHORIZATION.md`](docs/IDENTITY_AND_AUTHORIZATION.md).
+
 ## Architecture
 
 ```

--- a/apps/default/service/handlers/webhook.go
+++ b/apps/default/service/handlers/webhook.go
@@ -347,15 +347,34 @@ func writeTokenHookResponse(rw http.ResponseWriter, claims map[string]any) error
 	return json.NewEncoder(rw).Encode(hookResponse)
 }
 
-// writeTokenHookResponseWithSubject writes a token enrichment response that also
-// overrides the JWT sub claim. For client_credentials grants Hydra sets sub to
-// the client_id; this allows the webhook to correct it to the profile_id.
+// writeTokenHookResponseWithSubject writes a token enrichment response.
+//
+// Important (Hydra v2+): Ory Hydra cannot override the JWT "sub" claim from the
+// token hook for any grant type — including client_credentials. For machine
+// tokens, sub remains the OAuth2 client_id. The optional top-level "subject"
+// field is accepted for forward compatibility but is ignored by Hydra today.
+//
+// Therefore:
+//   - Access-token claims carry profile_id / tenant_id / roles / etc.
+//   - Keto Plane-1/2 subjects for service accounts MUST use client_id (JWT sub),
+//     not profile_id. See apps/tenancy SA sync + service bot bootstrap.
+//
+// The subject argument is still recorded as the intended logical identity
+// (profile_id) for logs and any future Hydra support.
 func writeTokenHookResponseWithSubject(rw http.ResponseWriter, claims map[string]any, subject string) error {
+	if claims != nil && subject != "" {
+		// Ensure profile_id is always present in token extras even if callers
+		// forget to put it in claims — it is the durable SA identity for audit.
+		if _, ok := claims["profile_id"]; !ok {
+			claims["profile_id"] = subject
+		}
+	}
 	hookResponse := map[string]any{
 		"session": map[string]any{
 			"access_token": claims,
 			"id_token":     claims,
 		},
+		// Hydra ignores this today; kept for documentation/forward-compat.
 		"subject": subject,
 	}
 	rw.Header().Set("Content-Type", "application/json")

--- a/apps/default/service/handlers/webhook.go
+++ b/apps/default/service/handlers/webhook.go
@@ -349,32 +349,29 @@ func writeTokenHookResponse(rw http.ResponseWriter, claims map[string]any) error
 
 // writeTokenHookResponseWithSubject writes a token enrichment response.
 //
-// Important (Hydra v2+): Ory Hydra cannot override the JWT "sub" claim from the
-// token hook for any grant type — including client_credentials. For machine
-// tokens, sub remains the OAuth2 client_id. The optional top-level "subject"
-// field is accepted for forward compatibility but is ignored by Hydra today.
+// Identity (see docs/IDENTITY_AND_AUTHORIZATION.md):
 //
-// Therefore:
-//   - Access-token claims carry profile_id / tenant_id / roles / etc.
-//   - Keto Plane-1/2 subjects for service accounts MUST use client_id (JWT sub),
-//     not profile_id. See apps/tenancy SA sync + service bot bootstrap.
+//   - profile_id is the acting principal for authorization (Keto subjects).
+//   - client_id identifies the OAuth2 client / partition at issuance only.
 //
-// The subject argument is still recorded as the intended logical identity
-// (profile_id) for logs and any future Hydra support.
+// Hydra note: for client_credentials, JWT "sub" often remains the OAuth2
+// client_id — Hydra does not honour a token-hook subject override. That is
+// fine: profile_id is always written into access_token (and id_token) extras,
+// and Frame's GetProfileID / ReBAC checkers prefer profile_id over JWT sub.
+//
+// The subject argument is the profile_id (bot profile for service accounts).
 func writeTokenHookResponseWithSubject(rw http.ResponseWriter, claims map[string]any, subject string) error {
 	if claims != nil && subject != "" {
-		// Ensure profile_id is always present in token extras even if callers
-		// forget to put it in claims — it is the durable SA identity for audit.
-		if _, ok := claims["profile_id"]; !ok {
-			claims["profile_id"] = subject
-		}
+		// profile_id must always be present — it is the authorization actor.
+		claims["profile_id"] = subject
 	}
 	hookResponse := map[string]any{
 		"session": map[string]any{
 			"access_token": claims,
 			"id_token":     claims,
 		},
-		// Hydra ignores this today; kept for documentation/forward-compat.
+		// Best-effort: some Hydra versions may accept this; profile_id claim is
+		// the authoritative actor identity either way.
 		"subject": subject,
 	}
 	rw.Header().Set("Content-Type", "application/json")

--- a/apps/tenancy/service/business/bootstrap_service_bots.go
+++ b/apps/tenancy/service/business/bootstrap_service_bots.go
@@ -35,21 +35,32 @@ type ServiceBotTenancyDeps struct {
 }
 
 // EnsureServiceBotTenancyAccess writes the Keto tuples that let internal
-// service bots operate across every tenant/partition:
+// service bots operate across every tenant/partition.
 //
-//  1. tenancy_access:<tenant>/<partition>#service ← profile_user:<sa.profile_id>
+// Identity model (critical):
+//
+//	Ory Hydra cannot override the JWT "sub" claim for client_credentials tokens
+//	(sub is always the OAuth2 client_id). Frame's TenancyAccessChecker checks
+//	Keto with subject_id = JWT sub. Therefore SA Plane-1 subjects MUST be the
+//	Hydra client_id (e.g. "service-authentication"), not the profile_id.
+//
+// Tuples written:
+//
+//  1. tenancy_access:<tenant>/<partition>#service ← <sa.client_id>
 //     for every service account × every partition (including root)
 //  2. tenancy_access:<child>#service ← tenancy_access:<parent>#service
 //     for every parent→child partition edge (inheritance for future partitions)
+//
+// Profile_id is dual-written as a secondary subject when present so any
+// caller that still checks profile identity continues to work.
 //
 // Cross-tenant product partitions (e.g. opportunities) are not descendants of
 // the platform root path, so inheritance alone is insufficient — we grant
 // explicit service access on each known partition.
 //
-// Without these grants, service-authentication fails Plane-1 checks when a
-// login sets request tenancy to a product partition:
+// Without these grants, service-authentication fails Plane-1 checks:
 //
-//	permission_denied: cannot service on tenancy_access:<tenant>/<partition>
+//	permission_denied: service-authentication cannot service on tenancy_access:…
 //
 // Idempotent and safe to run on every tenancy pod start.
 func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDeps) error {
@@ -73,8 +84,8 @@ func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDe
 		return fmt.Errorf("service bot bootstrap: list partitions: %w", err)
 	}
 
-	profiles, paths := collectServiceBotProfilesAndPaths(accounts, partitions)
-	tuples := buildServiceBotTenancyTuples(profiles, paths, partitions)
+	subjects, paths := collectServiceBotSubjectsAndPaths(accounts, partitions)
+	tuples := buildServiceBotTenancyTuples(subjects, paths, partitions)
 
 	if len(tuples) == 0 {
 		logger.Warn("no service bot tenancy tuples to write")
@@ -87,17 +98,32 @@ func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDe
 
 	logger.WithFields(map[string]any{
 		"service_accounts": len(accounts),
-		"bot_profiles":     len(profiles),
+		"bot_subjects":     len(subjects),
 		"partition_paths":  len(paths),
 		"tuples_written":   len(tuples),
 	}).Info("service bot tenancy access bootstrap complete")
 	return nil
 }
 
-func collectServiceBotProfilesAndPaths(
+// serviceAccountKetoSubject returns the identity used in Keto checks for a
+// service account. Hydra sets JWT sub to the OAuth2 client_id for
+// client_credentials grants and does not allow the token hook to override it,
+// so client_id is the primary subject. Profile_id is a fallback when client_id
+// has not been denormalised yet.
+func serviceAccountKetoSubject(sa *models.ServiceAccount) string {
+	if sa == nil {
+		return ""
+	}
+	if clientID := strings.TrimSpace(sa.ClientID); clientID != "" {
+		return clientID
+	}
+	return strings.TrimSpace(sa.ProfileID)
+}
+
+func collectServiceBotSubjectsAndPaths(
 	accounts []*models.ServiceAccount,
 	partitions []*models.Partition,
-) (profiles map[string]struct{}, paths map[string]struct{}) {
+) (subjects map[string]struct{}, paths map[string]struct{}) {
 	paths = map[string]struct{}{
 		fmt.Sprintf("%s/%s", authz.RootTenantID, authz.RootPartitionID): {},
 	}
@@ -112,35 +138,39 @@ func collectServiceBotProfilesAndPaths(
 		paths[fmt.Sprintf("%s/%s", tenantID, p.ID)] = struct{}{}
 	}
 
-	profiles = make(map[string]struct{}, len(accounts))
+	subjects = make(map[string]struct{}, len(accounts)*2)
 	for _, sa := range accounts {
 		if sa == nil {
 			continue
 		}
-		profileID := strings.TrimSpace(sa.ProfileID)
-		if profileID == "" {
-			continue
+		// Primary: JWT sub (client_id). Secondary: profile_id for dual-write.
+		for _, subject := range []string{
+			strings.TrimSpace(sa.ClientID),
+			strings.TrimSpace(sa.ProfileID),
+		} {
+			if subject != "" {
+				subjects[subject] = struct{}{}
+			}
 		}
-		profiles[profileID] = struct{}{}
 		tenantID := strings.TrimSpace(sa.TenantID)
 		partitionID := strings.TrimSpace(sa.PartitionID)
 		if tenantID != "" && partitionID != "" {
 			paths[fmt.Sprintf("%s/%s", tenantID, partitionID)] = struct{}{}
 		}
 	}
-	return profiles, paths
+	return subjects, paths
 }
 
 func buildServiceBotTenancyTuples(
-	profiles map[string]struct{},
+	subjects map[string]struct{},
 	paths map[string]struct{},
 	partitions []*models.Partition,
 ) []security.RelationTuple {
-	tuples := make([]security.RelationTuple, 0, len(profiles)*len(paths)+len(partitions))
+	tuples := make([]security.RelationTuple, 0, len(subjects)*len(paths)+len(partitions))
 
-	for profileID := range profiles {
+	for subject := range subjects {
 		for path := range paths {
-			tuples = append(tuples, authz.BuildServiceAccessTuple(path, profileID))
+			tuples = append(tuples, authz.BuildServiceAccessTuple(path, subject))
 		}
 	}
 

--- a/apps/tenancy/service/business/bootstrap_service_bots.go
+++ b/apps/tenancy/service/business/bootstrap_service_bots.go
@@ -37,30 +37,22 @@ type ServiceBotTenancyDeps struct {
 // EnsureServiceBotTenancyAccess writes the Keto tuples that let internal
 // service bots operate across every tenant/partition.
 //
-// Identity model (critical):
+// Identity model (see docs/IDENTITY_AND_AUTHORIZATION.md):
 //
-//	Ory Hydra cannot override the JWT "sub" claim for client_credentials tokens
-//	(sub is always the OAuth2 client_id). Frame's TenancyAccessChecker checks
-//	Keto with subject_id = JWT sub. Therefore SA Plane-1 subjects MUST be the
-//	Hydra client_id (e.g. "service-authentication"), not the profile_id.
+//	Permissions are always granted to profile_id. The service account's
+//	bot profile is the actor. OAuth2 client_id only identifies the client /
+//	partition used at token issuance — it is never a Keto subject.
 //
 // Tuples written:
 //
-//  1. tenancy_access:<tenant>/<partition>#service ← <sa.client_id>
+//  1. tenancy_access:<tenant>/<partition>#service ← <sa.profile_id>
 //     for every service account × every partition (including root)
 //  2. tenancy_access:<child>#service ← tenancy_access:<parent>#service
 //     for every parent→child partition edge (inheritance for future partitions)
 //
-// Profile_id is dual-written as a secondary subject when present so any
-// caller that still checks profile identity continues to work.
-//
 // Cross-tenant product partitions (e.g. opportunities) are not descendants of
 // the platform root path, so inheritance alone is insufficient — we grant
 // explicit service access on each known partition.
-//
-// Without these grants, service-authentication fails Plane-1 checks:
-//
-//	permission_denied: service-authentication cannot service on tenancy_access:…
 //
 // Idempotent and safe to run on every tenancy pod start.
 func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDeps) error {
@@ -84,8 +76,8 @@ func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDe
 		return fmt.Errorf("service bot bootstrap: list partitions: %w", err)
 	}
 
-	subjects, paths := collectServiceBotSubjectsAndPaths(accounts, partitions)
-	tuples := buildServiceBotTenancyTuples(subjects, paths, partitions)
+	profiles, paths := collectServiceBotProfilesAndPaths(accounts, partitions)
+	tuples := buildServiceBotTenancyTuples(profiles, paths, partitions)
 
 	if len(tuples) == 0 {
 		logger.Warn("no service bot tenancy tuples to write")
@@ -98,32 +90,17 @@ func EnsureServiceBotTenancyAccess(ctx context.Context, deps ServiceBotTenancyDe
 
 	logger.WithFields(map[string]any{
 		"service_accounts": len(accounts),
-		"bot_subjects":     len(subjects),
+		"bot_profiles":     len(profiles),
 		"partition_paths":  len(paths),
 		"tuples_written":   len(tuples),
 	}).Info("service bot tenancy access bootstrap complete")
 	return nil
 }
 
-// serviceAccountKetoSubject returns the identity used in Keto checks for a
-// service account. Hydra sets JWT sub to the OAuth2 client_id for
-// client_credentials grants and does not allow the token hook to override it,
-// so client_id is the primary subject. Profile_id is a fallback when client_id
-// has not been denormalised yet.
-func serviceAccountKetoSubject(sa *models.ServiceAccount) string {
-	if sa == nil {
-		return ""
-	}
-	if clientID := strings.TrimSpace(sa.ClientID); clientID != "" {
-		return clientID
-	}
-	return strings.TrimSpace(sa.ProfileID)
-}
-
-func collectServiceBotSubjectsAndPaths(
+func collectServiceBotProfilesAndPaths(
 	accounts []*models.ServiceAccount,
 	partitions []*models.Partition,
-) (subjects map[string]struct{}, paths map[string]struct{}) {
+) (profiles map[string]struct{}, paths map[string]struct{}) {
 	paths = map[string]struct{}{
 		fmt.Sprintf("%s/%s", authz.RootTenantID, authz.RootPartitionID): {},
 	}
@@ -138,39 +115,36 @@ func collectServiceBotSubjectsAndPaths(
 		paths[fmt.Sprintf("%s/%s", tenantID, p.ID)] = struct{}{}
 	}
 
-	subjects = make(map[string]struct{}, len(accounts)*2)
+	profiles = make(map[string]struct{}, len(accounts))
 	for _, sa := range accounts {
 		if sa == nil {
 			continue
 		}
-		// Primary: JWT sub (client_id). Secondary: profile_id for dual-write.
-		for _, subject := range []string{
-			strings.TrimSpace(sa.ClientID),
-			strings.TrimSpace(sa.ProfileID),
-		} {
-			if subject != "" {
-				subjects[subject] = struct{}{}
-			}
+		// Keto actor is always the bot profile — never client_id.
+		profileID := strings.TrimSpace(sa.ProfileID)
+		if profileID == "" {
+			continue
 		}
+		profiles[profileID] = struct{}{}
 		tenantID := strings.TrimSpace(sa.TenantID)
 		partitionID := strings.TrimSpace(sa.PartitionID)
 		if tenantID != "" && partitionID != "" {
 			paths[fmt.Sprintf("%s/%s", tenantID, partitionID)] = struct{}{}
 		}
 	}
-	return subjects, paths
+	return profiles, paths
 }
 
 func buildServiceBotTenancyTuples(
-	subjects map[string]struct{},
+	profiles map[string]struct{},
 	paths map[string]struct{},
 	partitions []*models.Partition,
 ) []security.RelationTuple {
-	tuples := make([]security.RelationTuple, 0, len(subjects)*len(paths)+len(partitions))
+	tuples := make([]security.RelationTuple, 0, len(profiles)*len(paths)+len(partitions))
 
-	for subject := range subjects {
+	for profileID := range profiles {
 		for path := range paths {
-			tuples = append(tuples, authz.BuildServiceAccessTuple(path, subject))
+			tuples = append(tuples, authz.BuildServiceAccessTuple(path, profileID))
 		}
 	}
 

--- a/apps/tenancy/service/business/bootstrap_service_bots_test.go
+++ b/apps/tenancy/service/business/bootstrap_service_bots_test.go
@@ -22,53 +22,39 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestServiceAccountKetoSubjectPrefersClientID(t *testing.T) {
-	t.Parallel()
-
-	require.Equal(t, "service-authentication", serviceAccountKetoSubject(&models.ServiceAccount{
-		ClientID:  "service-authentication",
-		ProfileID: "d75qclkpf2t1uum8ij40",
-	}))
-	require.Equal(t, "d75qclkpf2t1uum8ij40", serviceAccountKetoSubject(&models.ServiceAccount{
-		ProfileID: "d75qclkpf2t1uum8ij40",
-	}))
-	require.Equal(t, "", serviceAccountKetoSubject(nil))
-	require.Equal(t, "", serviceAccountKetoSubject(&models.ServiceAccount{}))
-}
-
-func TestCollectServiceBotSubjectsIncludesClientAndProfile(t *testing.T) {
+func TestCollectServiceBotProfilesUsesProfileIDNotClientID(t *testing.T) {
 	t.Parallel()
 
 	accounts := []*models.ServiceAccount{
 		{ClientID: "service-authentication", ProfileID: "d75qclkpf2t1uum8ij40"},
 		{ClientID: "service-profile", ProfileID: "d75qclkpf2t1uum8ij4g"},
-		{ProfileID: "orphan-profile-only"},
+		{ClientID: "orphan-client-only"}, // no profile → skipped
 		nil,
 	}
-	subjects, paths := collectServiceBotSubjectsAndPaths(accounts, nil)
+	profiles, paths := collectServiceBotProfilesAndPaths(accounts, nil)
 
-	require.Contains(t, subjects, "service-authentication")
-	require.Contains(t, subjects, "d75qclkpf2t1uum8ij40")
-	require.Contains(t, subjects, "service-profile")
-	require.Contains(t, subjects, "d75qclkpf2t1uum8ij4g")
-	require.Contains(t, subjects, "orphan-profile-only")
+	require.Contains(t, profiles, "d75qclkpf2t1uum8ij40")
+	require.Contains(t, profiles, "d75qclkpf2t1uum8ij4g")
+	require.NotContains(t, profiles, "service-authentication")
+	require.NotContains(t, profiles, "service-profile")
+	require.NotContains(t, profiles, "orphan-client-only")
 	require.Contains(t, paths, authz.RootTenantID+"/"+authz.RootPartitionID)
 }
 
 func TestServiceBotAccessTupleShapes(t *testing.T) {
 	t.Parallel()
 
-	// JWT sub for client_credentials is the OAuth2 client_id.
-	saSubject := "service-authentication"
+	// Keto subject is always the bot profile_id.
+	saProfile := "d75qclkpf2t1uum8ij40"
 	rootPath := authz.RootTenantID + "/" + authz.RootPartitionID
 	childPath := "d7gi6lkpf2t67dlsqre0/d7gi6lkpf2t67dlsqreg"
 
-	t1 := authz.BuildServiceAccessTuple(rootPath, saSubject)
+	t1 := authz.BuildServiceAccessTuple(rootPath, saProfile)
 	require.Equal(t, authz.NamespaceTenancyAccess, t1.Object.Namespace)
 	require.Equal(t, rootPath, t1.Object.ID)
 	require.Equal(t, authz.RoleService, t1.Relation)
 	require.Equal(t, authz.NamespaceProfile, t1.Subject.Namespace)
-	require.Equal(t, saSubject, t1.Subject.ID)
+	require.Equal(t, saProfile, t1.Subject.ID)
 
 	t2 := authz.BuildServicePartitionInheritanceTuple(rootPath, childPath)
 	require.Equal(t, authz.NamespaceTenancyAccess, t2.Object.Namespace)
@@ -77,17 +63,4 @@ func TestServiceBotAccessTupleShapes(t *testing.T) {
 	require.Equal(t, authz.NamespaceTenancyAccess, t2.Subject.Namespace)
 	require.Equal(t, rootPath, t2.Subject.ID)
 	require.Equal(t, authz.RoleService, t2.Subject.Relation)
-}
-
-func TestBuildServiceBotTenancyTuplesUsesClientSubjects(t *testing.T) {
-	t.Parallel()
-
-	subjects := map[string]struct{}{"service-authentication": {}}
-	paths := map[string]struct{}{
-		authz.RootTenantID + "/" + authz.RootPartitionID: {},
-	}
-	tuples := buildServiceBotTenancyTuples(subjects, paths, nil)
-	require.Len(t, tuples, 1)
-	require.Equal(t, "service-authentication", tuples[0].Subject.ID)
-	require.Equal(t, authz.RoleService, tuples[0].Relation)
 }

--- a/apps/tenancy/service/business/bootstrap_service_bots_test.go
+++ b/apps/tenancy/service/business/bootstrap_service_bots_test.go
@@ -18,22 +18,57 @@ import (
 	"testing"
 
 	"github.com/antinvestor/service-authentication/apps/tenancy/service/authz"
+	"github.com/antinvestor/service-authentication/apps/tenancy/service/models"
 	"github.com/stretchr/testify/require"
 )
+
+func TestServiceAccountKetoSubjectPrefersClientID(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "service-authentication", serviceAccountKetoSubject(&models.ServiceAccount{
+		ClientID:  "service-authentication",
+		ProfileID: "d75qclkpf2t1uum8ij40",
+	}))
+	require.Equal(t, "d75qclkpf2t1uum8ij40", serviceAccountKetoSubject(&models.ServiceAccount{
+		ProfileID: "d75qclkpf2t1uum8ij40",
+	}))
+	require.Equal(t, "", serviceAccountKetoSubject(nil))
+	require.Equal(t, "", serviceAccountKetoSubject(&models.ServiceAccount{}))
+}
+
+func TestCollectServiceBotSubjectsIncludesClientAndProfile(t *testing.T) {
+	t.Parallel()
+
+	accounts := []*models.ServiceAccount{
+		{ClientID: "service-authentication", ProfileID: "d75qclkpf2t1uum8ij40"},
+		{ClientID: "service-profile", ProfileID: "d75qclkpf2t1uum8ij4g"},
+		{ProfileID: "orphan-profile-only"},
+		nil,
+	}
+	subjects, paths := collectServiceBotSubjectsAndPaths(accounts, nil)
+
+	require.Contains(t, subjects, "service-authentication")
+	require.Contains(t, subjects, "d75qclkpf2t1uum8ij40")
+	require.Contains(t, subjects, "service-profile")
+	require.Contains(t, subjects, "d75qclkpf2t1uum8ij4g")
+	require.Contains(t, subjects, "orphan-profile-only")
+	require.Contains(t, paths, authz.RootTenantID+"/"+authz.RootPartitionID)
+}
 
 func TestServiceBotAccessTupleShapes(t *testing.T) {
 	t.Parallel()
 
-	saProfile := "d75qclkpf2t1uum8ij40"
+	// JWT sub for client_credentials is the OAuth2 client_id.
+	saSubject := "service-authentication"
 	rootPath := authz.RootTenantID + "/" + authz.RootPartitionID
 	childPath := "d7gi6lkpf2t67dlsqre0/d7gi6lkpf2t67dlsqreg"
 
-	t1 := authz.BuildServiceAccessTuple(rootPath, saProfile)
+	t1 := authz.BuildServiceAccessTuple(rootPath, saSubject)
 	require.Equal(t, authz.NamespaceTenancyAccess, t1.Object.Namespace)
 	require.Equal(t, rootPath, t1.Object.ID)
 	require.Equal(t, authz.RoleService, t1.Relation)
 	require.Equal(t, authz.NamespaceProfile, t1.Subject.Namespace)
-	require.Equal(t, saProfile, t1.Subject.ID)
+	require.Equal(t, saSubject, t1.Subject.ID)
 
 	t2 := authz.BuildServicePartitionInheritanceTuple(rootPath, childPath)
 	require.Equal(t, authz.NamespaceTenancyAccess, t2.Object.Namespace)
@@ -42,4 +77,17 @@ func TestServiceBotAccessTupleShapes(t *testing.T) {
 	require.Equal(t, authz.NamespaceTenancyAccess, t2.Subject.Namespace)
 	require.Equal(t, rootPath, t2.Subject.ID)
 	require.Equal(t, authz.RoleService, t2.Subject.Relation)
+}
+
+func TestBuildServiceBotTenancyTuplesUsesClientSubjects(t *testing.T) {
+	t.Parallel()
+
+	subjects := map[string]struct{}{"service-authentication": {}}
+	paths := map[string]struct{}{
+		authz.RootTenantID + "/" + authz.RootPartitionID: {},
+	}
+	tuples := buildServiceBotTenancyTuples(subjects, paths, nil)
+	require.Len(t, tuples, 1)
+	require.Equal(t, "service-authentication", tuples[0].Subject.ID)
+	require.Equal(t, authz.RoleService, tuples[0].Relation)
 }

--- a/apps/tenancy/service/events/authz_service_account_sync.go
+++ b/apps/tenancy/service/events/authz_service_account_sync.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	commonv1 "buf.build/gen/go/antinvestor/common/protocolbuffers/go/common/v1"
@@ -370,6 +371,18 @@ func (e *AuthzServiceAccountSyncEvent) desiredTuples(
 	partitionsByID := make(map[string]*models.Partition, len(tree))
 	partitionsByID[basePartition.ID] = basePartition
 
+	// Keto subject must match JWT "sub". Hydra sets sub=client_id for
+	// client_credentials and does not allow the token hook to override it.
+	// Frame checks subject_id = JWT sub, so grants keyed only by profile_id
+	// never match production service-account tokens.
+	subjectID := strings.TrimSpace(sa.ClientID)
+	if subjectID == "" {
+		subjectID = strings.TrimSpace(sa.ProfileID)
+	}
+	if subjectID == "" {
+		return nil, fmt.Errorf("service account %s has empty client_id and profile_id", sa.ID)
+	}
+
 	desiredRelations := make([]security.RelationTuple, 0)
 	for _, grant := range grants {
 		resolved, resolveErr := authz.ResolveServiceGrants(
@@ -394,7 +407,7 @@ func (e *AuthzServiceAccountSyncEvent) desiredTuples(
 			tenancyPath := fmt.Sprintf("%s/%s", partition.TenantID, partition.ID)
 			desiredRelations = append(desiredRelations, authz.BuildServicePermissionTuples(
 				tenancyPath,
-				sa.ProfileID,
+				subjectID,
 				grant.Namespace,
 				resolved[grant.Namespace],
 			)...)
@@ -403,7 +416,7 @@ func (e *AuthzServiceAccountSyncEvent) desiredTuples(
 
 	for _, partition := range partitionsByID {
 		tenancyPath := fmt.Sprintf("%s/%s", partition.TenantID, partition.ID)
-		desiredRelations = append(desiredRelations, authz.BuildServiceAccessTuple(tenancyPath, sa.ProfileID))
+		desiredRelations = append(desiredRelations, authz.BuildServiceAccessTuple(tenancyPath, subjectID))
 	}
 	authz.SortRelationTuples(desiredRelations)
 

--- a/apps/tenancy/service/events/authz_service_account_sync.go
+++ b/apps/tenancy/service/events/authz_service_account_sync.go
@@ -371,16 +371,12 @@ func (e *AuthzServiceAccountSyncEvent) desiredTuples(
 	partitionsByID := make(map[string]*models.Partition, len(tree))
 	partitionsByID[basePartition.ID] = basePartition
 
-	// Keto subject must match JWT "sub". Hydra sets sub=client_id for
-	// client_credentials and does not allow the token hook to override it.
-	// Frame checks subject_id = JWT sub, so grants keyed only by profile_id
-	// never match production service-account tokens.
-	subjectID := strings.TrimSpace(sa.ClientID)
-	if subjectID == "" {
-		subjectID = strings.TrimSpace(sa.ProfileID)
-	}
-	if subjectID == "" {
-		return nil, fmt.Errorf("service account %s has empty client_id and profile_id", sa.ID)
+	// Actor for all Keto grants is the service account's bot profile.
+	// client_id identifies the OAuth client / partition at token issuance only.
+	// See docs/IDENTITY_AND_AUTHORIZATION.md.
+	profileID := strings.TrimSpace(sa.ProfileID)
+	if profileID == "" {
+		return nil, fmt.Errorf("service account %s has empty profile_id", sa.ID)
 	}
 
 	desiredRelations := make([]security.RelationTuple, 0)
@@ -407,7 +403,7 @@ func (e *AuthzServiceAccountSyncEvent) desiredTuples(
 			tenancyPath := fmt.Sprintf("%s/%s", partition.TenantID, partition.ID)
 			desiredRelations = append(desiredRelations, authz.BuildServicePermissionTuples(
 				tenancyPath,
-				subjectID,
+				profileID,
 				grant.Namespace,
 				resolved[grant.Namespace],
 			)...)
@@ -416,7 +412,7 @@ func (e *AuthzServiceAccountSyncEvent) desiredTuples(
 
 	for _, partition := range partitionsByID {
 		tenancyPath := fmt.Sprintf("%s/%s", partition.TenantID, partition.ID)
-		desiredRelations = append(desiredRelations, authz.BuildServiceAccessTuple(tenancyPath, subjectID))
+		desiredRelations = append(desiredRelations, authz.BuildServiceAccessTuple(tenancyPath, profileID))
 	}
 	authz.SortRelationTuples(desiredRelations)
 

--- a/docs/IDENTITY_AND_AUTHORIZATION.md
+++ b/docs/IDENTITY_AND_AUTHORIZATION.md
@@ -1,0 +1,76 @@
+# Identity and Authorization Model
+
+**Canonical reference.** Prefer this document over ad-hoc comments when reasoning
+about who is acting, what `client_id` means, and how Keto grants are keyed.
+
+## Do not conflate these identifiers
+
+| Identifier | What it is | Used for | **Not** used for |
+|------------|------------|----------|------------------|
+| **`profile_id`** | The **acting principal** (person or bot profile) | Keto subjects on all authorization planes; audit of “who did this” | Naming OAuth clients |
+| **`client_id`** | OAuth2 client (often the partition’s public client, or a service account’s machine client) | Login / token issuance; resolving which **partition** the flow belongs to; Hydra client admin | Keto relation subjects; “who is requesting a resource” |
+| **JWT `sub`** | OAuth2 subject claim | Wire-level JWT field | Sole authority for ReBAC when `profile_id` is present |
+
+### Rules
+
+1. **Permissions are granted against `profile_id`.**  
+   Users and service accounts both act as profiles. Service accounts have a bot
+   `profile_id`; that profile is the Keto subject for Plane 1 (`tenancy_access`)
+   and Plane 2 (`granted_*` in service namespaces).
+
+2. **`client_id` is for login and partition binding.**  
+   During authorization-code or client-credentials flows, `client_id` tells us
+   which OAuth client (and thus which partition / tenancy path) the token is
+   for. It is **not** the actor requesting profile, tenancy, or other resources.
+
+3. **JWT `sub` may differ from `profile_id` for machine tokens.**  
+   Ory Hydra sets `sub` to the OAuth2 `client_id` for `client_credentials` and
+   does not reliably allow the token hook to override `sub`. The token hook
+   **must** still put `profile_id` in access-token claims. Frame resolves the
+   actor via `GetProfileID()` (prefers `profile_id` claim over JWT `sub`).
+
+4. **Never write Keto grants with `client_id` as the subject** “because JWT sub
+   is the client_id.” That confuses OAuth client identity with the acting
+   profile and will drift every time Hydra’s `sub` behaviour changes.
+
+## End-to-end paths
+
+### User (authorization code)
+
+1. User authenticates; consent sets JWT `sub` = user `profile_id`.
+2. Claims include `tenant_id`, `partition_id` from the **RP client** (`client_id`).
+3. ReBAC checks: subject = `profile_id`, object path = `tenant_id/partition_id`.
+
+### Service account (client_credentials)
+
+1. Service authenticates as OAuth client (`client_id` = e.g. `service-authentication`).
+2. Token webhook loads Hydra client metadata → bot `profile_id`, tenancy, roles.
+3. Access token claims include `profile_id` (actor), `tenant_id`, `partition_id`, `roles`.
+4. JWT `sub` may still be `client_id` (Hydra). Frame `GetProfileID()` uses claim.
+5. Keto grants for that bot were written as subject = **`profile_id`**.
+
+## Where grants are written
+
+| Mechanism | Subject |
+|-----------|---------|
+| `AuthzServiceAccountSyncEvent` | `sa.ProfileID` |
+| `EnsureServiceBotTenancyAccess` (bootstrap) | `sa.ProfileID` |
+| User access / roles | user `profile_id` |
+
+## Debugging checklist
+
+1. Is the error subject a **client_id** (e.g. `service-authentication`)?  
+   → Frame version may still be using JWT `sub` instead of `profile_id`.  
+   → Upgrade frame; do **not** re-key Keto to client_id.
+2. Does the access token carry `profile_id` (top-level or under `ext`)?  
+   → Fix token enrichment if missing.
+3. Does Keto have `#service` / `granted_*` for that **profile_id** on the path?  
+   → Run SA policy sync / service-bot bootstrap; check audiences.
+
+## Related code
+
+- Frame: `security.AuthenticationClaims.GetProfileID`, tenancy/function checkers
+- Token hook: `writeTokenHookResponseWithSubject` (always sets `profile_id`)
+- SA sync: `apps/tenancy/service/events/authz_service_account_sync.go`
+- Bot bootstrap: `apps/tenancy/service/business/bootstrap_service_bots.go`
+- Overview: `CLAUDE.md`, `docs/TOKEN_ENRICHMENT.md`

--- a/docs/TOKEN_ENRICHMENT.md
+++ b/docs/TOKEN_ENRICHMENT.md
@@ -73,23 +73,30 @@ These claims represent the session that created the token family and **should no
 
 ### 2. Identity Claims (Stable)
 
-These identify the user and rarely change:
+These identify the **acting principal**. Authorization (Keto) is always keyed by
+`profile_id`, never by OAuth `client_id`. See
+[`IDENTITY_AND_AUTHORIZATION.md`](IDENTITY_AND_AUTHORIZATION.md).
 
 | Claim | Description |
 |-------|-------------|
-| `profile_id` | User's profile identifier |
+| `profile_id` | **Actor** — user or service-account bot profile. Required on every access token. |
 | `profile_contact` | User's contact (currently same as profile_id) |
+
+For service accounts, Hydra may leave JWT `sub` as the OAuth `client_id`. The
+token hook still sets `profile_id` in session extras; Frame `GetProfileID()`
+prefers that claim for ReBAC.
 
 ### 3. Tenancy Claims (Client-Bound)
 
-These are determined by the OAuth2 client, not the user:
+These are determined by the OAuth2 **client** used at issuance (login or
+client_credentials), not by re-deriving identity from `client_id` at authz time:
 
 | Claim | Description |
 |-------|-------------|
 | `tenant_id` | Tenant the client belongs to |
-| `partition_id` | Partition (same as client_id) |
+| `partition_id` | Partition bound to the client |
 
-**Note:** These are stable for a given client. A client doesn't change tenants.
+**Note:** `client_id` is for partition resolution during login/token issuance only.
 
 ### 4. Authorization Claims (Could Be Dynamic)
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame/v2 v2.0.3
+	github.com/pitabwire/frame/v2 v2.0.4
 	github.com/pitabwire/util v0.9.1
 	github.com/posthog/posthog-go v1.17.5
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.0.3 h1:OHgpmx1rb9uhiIKGF8dA774ViTL4+YtWyV+6gamX1BU=
-github.com/pitabwire/frame/v2 v2.0.3/go.mod h1:Ncs1D/SsQW2LEMWwpJYHkBSjIA3czWEbasTD6ffVzQM=
+github.com/pitabwire/frame/v2 v2.0.4 h1:TO/CHFbtjig7ZLW7jwghsOwUKV6rc6GpJ7SXvVLzcgo=
+github.com/pitabwire/frame/v2 v2.0.4/go.mod h1:Ncs1D/SsQW2LEMWwpJYHkBSjIA3czWEbasTD6ffVzQM=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary
- **Correct model:** Keto subjects are always **`profile_id`**. OAuth **`client_id`** only identifies the client/partition at login and token issuance.
- Reverts the mistaken approach of keying SA grants by `client_id`.
- Documents the model in `docs/IDENTITY_AND_AUTHORIZATION.md`, `CLAUDE.md`, and `docs/TOKEN_ENRICHMENT.md`.
- Depends on **frame** [PR #680](https://github.com/pitabwire/frame/pull/680): `GetProfileID()` / ReBAC checkers prefer `profile_id` claim over JWT `sub`.

## Test plan
- [x] Unit tests: bootstrap collects profile_ids, never client_ids
- [ ] After frame v2.0.4 + deploy profile/auth/tenancy: Google social login succeeds