### PR TITLE
docs(authz): JWT sub is always profile_id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,16 @@ This is a multi-tenant OAuth2/OpenID Connect authentication service built on **O
 
 ## Identity model (do not drift)
 
+**Invariant: `JWT sub === profile_id` always** (users and service accounts).
+
 | Concept | Meaning |
 |---------|---------|
-| **`profile_id`** | **Acting principal.** Permissions (Keto) are always granted to profiles (users or bot SAs). |
+| **`profile_id` / JWT `sub`** | **Acting principal.** Permissions (Keto) are always granted to profiles (users or bot SAs). |
 | **`client_id`** | OAuth2 client used at login / token issuance; identifies which **partition** the flow belongs to. **Not** a Keto subject. |
-| **JWT `sub`** | Wire claim; may equal `client_id` on machine tokens. Authorization uses `profile_id` via Frame `GetProfileID()`. |
 
-Full write-up: [`docs/IDENTITY_AND_AUTHORIZATION.md`](docs/IDENTITY_AND_AUTHORIZATION.md).
+Hydra may leave wire `sub=client_id` for `client_credentials`; Frame normalizes so
+in-process subject is always `profile_id`. Full write-up:
+[`docs/IDENTITY_AND_AUTHORIZATION.md`](docs/IDENTITY_AND_AUTHORIZATION.md).
 
 ## Architecture
 

--- a/apps/default/service/handlers/webhook.go
+++ b/apps/default/service/handlers/webhook.go
@@ -349,20 +349,21 @@ func writeTokenHookResponse(rw http.ResponseWriter, claims map[string]any) error
 
 // writeTokenHookResponseWithSubject writes a token enrichment response.
 //
-// Identity (see docs/IDENTITY_AND_AUTHORIZATION.md):
+// Platform invariant (docs/IDENTITY_AND_AUTHORIZATION.md):
 //
-//   - profile_id is the acting principal for authorization (Keto subjects).
-//   - client_id identifies the OAuth2 client / partition at issuance only.
+//	JWT sub === profile_id always.
 //
-// Hydra note: for client_credentials, JWT "sub" often remains the OAuth2
-// client_id — Hydra does not honour a token-hook subject override. That is
-// fine: profile_id is always written into access_token (and id_token) extras,
-// and Frame's GetProfileID / ReBAC checkers prefer profile_id over JWT sub.
+// subject must be the profile_id (bot profile for service accounts). We always
+// write profile_id into access/id token claims and return top-level "subject"
+// so Hydra can set sub when supported.
 //
-// The subject argument is the profile_id (bot profile for service accounts).
+// Hydra v26 client_credentials still forces wire sub=client_id and ignores the
+// hook subject field. Frame NormalizeIdentity() then rewrites in-process
+// Subject to profile_id after JWT validation — never treat client_id as actor.
 func writeTokenHookResponseWithSubject(rw http.ResponseWriter, claims map[string]any, subject string) error {
 	if claims != nil && subject != "" {
-		// profile_id must always be present — it is the authorization actor.
+		// profile_id must always be present — it is the authorization actor
+		// and the source Frame uses to normalize JWT sub.
 		claims["profile_id"] = subject
 	}
 	hookResponse := map[string]any{
@@ -370,8 +371,8 @@ func writeTokenHookResponseWithSubject(rw http.ResponseWriter, claims map[string
 			"access_token": claims,
 			"id_token":     claims,
 		},
-		// Best-effort: some Hydra versions may accept this; profile_id claim is
-		// the authoritative actor identity either way.
+		// Requested JWT sub. Hydra v26 may ignore this for client_credentials;
+		// profile_id claim + Frame NormalizeIdentity still enforce the invariant.
 		"subject": subject,
 	}
 	rw.Header().Set("Content-Type", "application/json")

--- a/apps/default/service/handlers/webhook.go
+++ b/apps/default/service/handlers/webhook.go
@@ -363,7 +363,7 @@ func writeTokenHookResponse(rw http.ResponseWriter, claims map[string]any) error
 func writeTokenHookResponseWithSubject(rw http.ResponseWriter, claims map[string]any, subject string) error {
 	if claims != nil && subject != "" {
 		// profile_id must always be present — it is the authorization actor
-		// and the source Frame uses to normalize JWT sub.
+		// and the source Frame uses to normalise JWT sub.
 		claims["profile_id"] = subject
 	}
 	hookResponse := map[string]any{

--- a/docs/IDENTITY_AND_AUTHORIZATION.md
+++ b/docs/IDENTITY_AND_AUTHORIZATION.md
@@ -3,74 +3,92 @@
 **Canonical reference.** Prefer this document over ad-hoc comments when reasoning
 about who is acting, what `client_id` means, and how Keto grants are keyed.
 
+## Invariant
+
+```text
+JWT sub  ===  profile_id  ===  ReBAC subject
+```
+
+Always. For users and for service accounts. There is no case where `client_id`
+is the acting subject for authorization.
+
 ## Do not conflate these identifiers
 
 | Identifier | What it is | Used for | **Not** used for |
 |------------|------------|----------|------------------|
-| **`profile_id`** | The **acting principal** (person or bot profile) | Keto subjects on all authorization planes; audit of “who did this” | Naming OAuth clients |
-| **`client_id`** | OAuth2 client (often the partition’s public client, or a service account’s machine client) | Login / token issuance; resolving which **partition** the flow belongs to; Hydra client admin | Keto relation subjects; “who is requesting a resource” |
-| **JWT `sub`** | OAuth2 subject claim | Wire-level JWT field | Sole authority for ReBAC when `profile_id` is present |
+| **`profile_id` / JWT `sub`** | The **acting principal** (person or bot profile) | Keto subjects on all planes; audit of “who did this” | Naming OAuth clients |
+| **`client_id`** | OAuth2 client (RP app or service-account machine client) | Login / token issuance; resolving which **partition** the flow belongs to | Keto relation subjects; actor identity |
 
 ### Rules
 
-1. **Permissions are granted against `profile_id`.**  
-   Users and service accounts both act as profiles. Service accounts have a bot
-   `profile_id`; that profile is the Keto subject for Plane 1 (`tenancy_access`)
-   and Plane 2 (`granted_*` in service namespaces).
+1. **`sub` is always `profile_id`.**  
+   Consent sets this for users. For service accounts, the token enrichment hook
+   sets `profile_id` and requests subject override. After authentication, Frame
+   `NormalizeIdentity()` ensures in-process claims have `Subject = profile_id`
+   even if the wire JWT still has Hydra’s default `sub` for
+   `client_credentials`.
 
-2. **`client_id` is for login and partition binding.**  
-   During authorization-code or client-credentials flows, `client_id` tells us
-   which OAuth client (and thus which partition / tenancy path) the token is
-   for. It is **not** the actor requesting profile, tenancy, or other resources.
+2. **Permissions are granted against `profile_id`.**  
+   Service accounts have a bot `profile_id`; that profile is the Keto subject.
 
-3. **JWT `sub` may differ from `profile_id` for machine tokens.**  
-   Ory Hydra sets `sub` to the OAuth2 `client_id` for `client_credentials` and
-   does not reliably allow the token hook to override `sub`. The token hook
-   **must** still put `profile_id` in access-token claims. Frame resolves the
-   actor via `GetProfileID()` (prefers `profile_id` claim over JWT `sub`).
+3. **`client_id` is for login and partition binding only.**  
+   It selects the OAuth client (and thus tenant/partition) for the token family.
+   It is never the actor requesting resources.
 
-4. **Never write Keto grants with `client_id` as the subject** “because JWT sub
-   is the client_id.” That confuses OAuth client identity with the acting
-   profile and will drift every time Hydra’s `sub` behaviour changes.
+4. **Never write Keto grants with `client_id` as the subject.**
+
+## Hydra note (implementation detail, not a model exception)
+
+Ory Hydra v26 sets wire JWT `sub` to the OAuth `client_id` for
+`client_credentials` and the token hook cannot change that field. That is a
+Hydra limitation, not a platform design choice.
+
+Our compensation:
+
+1. Token hook always writes `profile_id` into access-token claims (and best-effort
+   top-level `subject`).
+2. Frame `NormalizeIdentity()` rewrites `RegisteredClaims.Subject` to
+   `profile_id` after JWT validation so **every service** sees
+   `sub === profile_id`.
+
+Do not “fix” this by keying Keto on `client_id`.
 
 ## End-to-end paths
 
 ### User (authorization code)
 
 1. User authenticates; consent sets JWT `sub` = user `profile_id`.
-2. Claims include `tenant_id`, `partition_id` from the **RP client** (`client_id`).
-3. ReBAC checks: subject = `profile_id`, object path = `tenant_id/partition_id`.
+2. Claims include `tenant_id`, `partition_id` from the RP `client_id`.
+3. ReBAC: subject = `profile_id`, path = `tenant_id/partition_id`.
 
 ### Service account (client_credentials)
 
-1. Service authenticates as OAuth client (`client_id` = e.g. `service-authentication`).
-2. Token webhook loads Hydra client metadata → bot `profile_id`, tenancy, roles.
-3. Access token claims include `profile_id` (actor), `tenant_id`, `partition_id`, `roles`.
-4. JWT `sub` may still be `client_id` (Hydra). Frame `GetProfileID()` uses claim.
-5. Keto grants for that bot were written as subject = **`profile_id`**.
+1. Service authenticates as OAuth client (`client_id` e.g. `service-authentication`).
+2. Token webhook loads metadata → bot `profile_id`, tenancy, roles.
+3. Claims include `profile_id` (actor). Wire `sub` may still be `client_id`.
+4. Frame normalizes → `Subject` / `GetProfileID()` / `GetSubject()` = bot `profile_id`.
+5. Keto grants for that bot use subject = **`profile_id`**.
 
 ## Where grants are written
 
 | Mechanism | Subject |
 |-----------|---------|
 | `AuthzServiceAccountSyncEvent` | `sa.ProfileID` |
-| `EnsureServiceBotTenancyAccess` (bootstrap) | `sa.ProfileID` |
+| `EnsureServiceBotTenancyAccess` | `sa.ProfileID` |
 | User access / roles | user `profile_id` |
 
 ## Debugging checklist
 
-1. Is the error subject a **client_id** (e.g. `service-authentication`)?  
-   → Frame version may still be using JWT `sub` instead of `profile_id`.  
-   → Upgrade frame; do **not** re-key Keto to client_id.
-2. Does the access token carry `profile_id` (top-level or under `ext`)?  
-   → Fix token enrichment if missing.
-3. Does Keto have `#service` / `granted_*` for that **profile_id** on the path?  
-   → Run SA policy sync / service-bot bootstrap; check audiences.
+1. Error subject looks like a **client_id** (`service-authentication`)?  
+   → Frame is not normalizing (upgrade frame). Do **not** re-key Keto to client_id.
+2. Token missing `profile_id` claim?  
+   → Fix token enrichment webhook.
+3. Keto missing `#service` / `granted_*` for the **profile_id**?  
+   → SA policy sync / service-bot bootstrap.
 
 ## Related code
 
-- Frame: `security.AuthenticationClaims.GetProfileID`, tenancy/function checkers
-- Token hook: `writeTokenHookResponseWithSubject` (always sets `profile_id`)
-- SA sync: `apps/tenancy/service/events/authz_service_account_sync.go`
-- Bot bootstrap: `apps/tenancy/service/business/bootstrap_service_bots.go`
-- Overview: `CLAUDE.md`, `docs/TOKEN_ENRICHMENT.md`
+- Frame: `NormalizeIdentity`, `GetProfileID`, tenancy/function checkers
+- Token hook: `writeTokenHookResponseWithSubject` (sets `profile_id` + subject)
+- SA sync / bot bootstrap under `apps/tenancy/`
+- `CLAUDE.md`, `docs/TOKEN_ENRICHMENT.md`

--- a/docs/TOKEN_ENRICHMENT.md
+++ b/docs/TOKEN_ENRICHMENT.md
@@ -73,18 +73,18 @@ These claims represent the session that created the token family and **should no
 
 ### 2. Identity Claims (Stable)
 
-These identify the **acting principal**. Authorization (Keto) is always keyed by
-`profile_id`, never by OAuth `client_id`. See
+**Invariant: JWT `sub` === `profile_id`.** Authorization (Keto) is always keyed
+by that profile, never by OAuth `client_id`. See
 [`IDENTITY_AND_AUTHORIZATION.md`](IDENTITY_AND_AUTHORIZATION.md).
 
 | Claim | Description |
 |-------|-------------|
-| `profile_id` | **Actor** — user or service-account bot profile. Required on every access token. |
+| `profile_id` | **Actor** — user or service-account bot profile. Required on every access token; also the JWT `sub`. |
 | `profile_contact` | User's contact (currently same as profile_id) |
 
-For service accounts, Hydra may leave JWT `sub` as the OAuth `client_id`. The
-token hook still sets `profile_id` in session extras; Frame `GetProfileID()`
-prefers that claim for ReBAC.
+Token hook always sets `profile_id` (and requests subject override). Hydra v26
+may still leave wire `sub=client_id` for `client_credentials`; Frame
+`NormalizeIdentity()` rewrites in-process subject to `profile_id`.
 
 ### 3. Tenancy Claims (Client-Bound)
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame/v2 v2.0.4
+	github.com/pitabwire/frame/v2 v2.0.5
 	github.com/pitabwire/util v0.9.1
 	github.com/posthog/posthog-go v1.17.5
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.0.4 h1:TO/CHFbtjig7ZLW7jwghsOwUKV6rc6GpJ7SXvVLzcgo=
-github.com/pitabwire/frame/v2 v2.0.4/go.mod h1:Ncs1D/SsQW2LEMWwpJYHkBSjIA3czWEbasTD6ffVzQM=
+github.com/pitabwire/frame/v2 v2.0.5 h1:neE2mKydXxhMckXp4fv7a4I2Bt8CbC5xERoc98O2Cec=
+github.com/pitabwire/frame/v2 v2.0.5/go.mod h1:Ncs1D/SsQW2LEMWwpJYHkBSjIA3czWEbasTD6ffVzQM=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary
Records the platform invariant **JWT `sub` === `profile_id` always**.

`client_id` is only for login/partition binding. Hydra may leave wire sub as client_id for machine tokens; Frame normalizes so services never treat client_id as the actor.

Depends on frame PR enforcing `NormalizeIdentity`: https://github.com/pitabwire/frame/pull/681