### PR TITLE
fix(authz): reliable secure permission manifest registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@ Hydra may leave wire `sub=client_id` for `client_credentials`; Frame normalizes 
 in-process subject is always `profile_id`. Full write-up:
 [`docs/IDENTITY_AND_AUTHORIZATION.md`](docs/IDENTITY_AND_AUTHORIZATION.md).
 
+Permission namespace registration (secure M2M, ownership-bound):
+[`docs/PERMISSION_REGISTRATION.md`](docs/PERMISSION_REGISTRATION.md).
+
 ## Architecture
 
 ```

--- a/apps/default/service/handlers/webhook.go
+++ b/apps/default/service/handlers/webhook.go
@@ -418,16 +418,19 @@ func buildServiceAccountClaims(
 		return nil, ErrIncompleteTenancyPair
 	}
 
+	// Flat claims only — Hydra already nests the whole access_token map under
+	// JWT "ext" when mirror_top_level_claims is on. Nesting another "ext" here
+	// produced ext.ext.service_account_id and broke permission registration
+	// ownership checks (403). Keep service_account_id at the same level as
+	// profile_id so Frame claims.Ext["service_account_id"] resolves.
 	claims := map[string]any{
-		"tenant_id":      tenantID,
-		"partition_id":   partitionID,
-		"roles":          roles,
-		"profile_id":     sa.ProfileID,
-		"session_id":     loginEventID,
-		"login_event_id": loginEventID,
-		"ext": map[string]any{
-			"service_account_id": sa.ServiceAccountID,
-		},
+		"tenant_id":          tenantID,
+		"partition_id":       partitionID,
+		"roles":              roles,
+		"profile_id":         sa.ProfileID,
+		"session_id":         loginEventID,
+		"login_event_id":     loginEventID,
+		"service_account_id": sa.ServiceAccountID,
 	}
 	if accessID != "" {
 		claims["access_id"] = accessID

--- a/apps/default/service/handlers/webhook_helpers_test.go
+++ b/apps/default/service/handlers/webhook_helpers_test.go
@@ -367,9 +367,12 @@ func (s *WebhookHelpersTestSuite) TestBuildServiceAccountClaimsIncludesStableIde
 	}, "access-1", []string{"internal"})
 	s.Require().NoError(err)
 
-	ext, ok := claims["ext"].(map[string]any)
-	s.Require().True(ok)
-	s.Equal("service-account-1", ext["service_account_id"])
+	// Flat service_account_id — must not nest under "ext" (Hydra already nests
+	// the whole access_token map under JWT ext).
+	s.Equal("service-account-1", claims["service_account_id"])
+	_, hasNestedExt := claims["ext"]
+	s.False(hasNestedExt, "must not double-nest under ext")
+	s.Equal("profile-1", claims["profile_id"])
 	s.Equal("tenant-1", claims["tenant_id"])
 	s.Equal("partition-1", claims["partition_id"])
 }

--- a/apps/tenancy/service/business/permission_registry.go
+++ b/apps/tenancy/service/business/permission_registry.go
@@ -163,11 +163,34 @@ func validatePermissionManifestOwner(
 		return fmt.Errorf("load permission manifest owner: %w", err)
 	}
 	if owner.Type != "internal" || owner.State == int32(commonv1.STATE_DELETED) ||
-		owner.PartitionID != authz.RootPartitionID ||
-		strings.TrimSpace(owner.Name) != namespace {
+		owner.PartitionID != authz.RootPartitionID {
+		return fmt.Errorf("%w: service account %q cannot own %q", ErrPermissionManifestOwner, owner.Name, namespace)
+	}
+	// Ownership is name-or-client identity for the namespace. SA.Name is the
+	// canonical namespace id (e.g. service_profile). ClientID uses hyphens
+	// (service-profile); both must resolve to the same permission namespace.
+	if !serviceAccountOwnsNamespace(owner, namespace) {
 		return fmt.Errorf("%w: service account %q cannot own %q", ErrPermissionManifestOwner, owner.Name, namespace)
 	}
 	return nil
+}
+
+// serviceAccountOwnsNamespace reports whether the SA is the declared owner of
+// the permission namespace. Matching is by SA.Name (preferred) or by normalising
+// OAuth client_id hyphens to underscores (service-profile → service_profile).
+func serviceAccountOwnsNamespace(owner *models.ServiceAccount, namespace string) bool {
+	if owner == nil {
+		return false
+	}
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return false
+	}
+	if strings.TrimSpace(owner.Name) == namespace {
+		return true
+	}
+	clientAsNS := strings.ReplaceAll(strings.TrimSpace(owner.ClientID), "-", "_")
+	return clientAsNS == namespace
 }
 
 func normalizePermissionManifest(manifest PermissionManifest) (PermissionManifest, error) {

--- a/apps/tenancy/service/business/permission_registry_test.go
+++ b/apps/tenancy/service/business/permission_registry_test.go
@@ -17,8 +17,27 @@ package business
 import (
 	"testing"
 
+	"github.com/antinvestor/service-authentication/apps/tenancy/service/models"
 	"github.com/stretchr/testify/require"
 )
+
+func TestServiceAccountOwnsNamespace(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, serviceAccountOwnsNamespace(&models.ServiceAccount{
+		Name:     "service_profile",
+		ClientID: "service-profile",
+	}, "service_profile"))
+	require.True(t, serviceAccountOwnsNamespace(&models.ServiceAccount{
+		Name:     "other",
+		ClientID: "service-profile",
+	}, "service_profile"), "client_id hyphen form must match underscore namespace")
+	require.False(t, serviceAccountOwnsNamespace(&models.ServiceAccount{
+		Name:     "service_payment",
+		ClientID: "service-payment",
+	}, "service_profile"))
+	require.False(t, serviceAccountOwnsNamespace(nil, "service_profile"))
+}
 
 func TestNormalizePermissionManifest(t *testing.T) {
 	t.Parallel()

--- a/apps/tenancy/service/handlers/permissions.go
+++ b/apps/tenancy/service/handlers/permissions.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net/http"
 	"slices"
+	"strings"
 	"time"
 
 	tenancyv1 "buf.build/gen/go/antinvestor/tenancy/protocolbuffers/go/tenancy/v1"
@@ -62,11 +63,19 @@ func (prtSrv *TenancyServer) NewPermissionRegistrationHandler() http.Handler {
 
 // registerPermissionManifest registers an authenticated service-owned
 // permission manifest and triggers generation reconciliation.
+//
+// Security: requires a valid internal service-account token (AuthenticationMiddleware
+// already verified JWT). The caller must present service_account_id in claims and
+// that SA must own the namespace (internal, root partition, name/client matches).
 func (prtSrv *TenancyServer) registerPermissionManifest(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
 	logger := util.Log(ctx)
 
 	claims := security.ClaimsFromContext(ctx)
+	if claims == nil || !claims.IsInternalSystem() {
+		http.Error(rw, "internal service-account token is required", http.StatusForbidden)
+		return
+	}
 	ownerServiceAccountID := serviceAccountIDFromClaims(claims)
 	if ownerServiceAccountID == "" {
 		http.Error(rw, "service-account identity is required", http.StatusForbidden)
@@ -137,12 +146,41 @@ func (prtSrv *TenancyServer) registerPermissionManifest(rw http.ResponseWriter, 
 	}
 }
 
+// serviceAccountIDFromClaims extracts the registering SA id from JWT claims.
+//
+// Preferred shape (after token-hook fix): claims.Ext["service_account_id"] or a
+// top-level claim when mirrored. Legacy tokens nested the id under Ext["ext"]
+// because buildServiceAccountClaims used to embed a nested "ext" map inside
+// Hydra access-token extras (which Hydra already nests under "ext").
 func serviceAccountIDFromClaims(claims *security.AuthenticationClaims) string {
-	if claims == nil || claims.Ext == nil {
+	if claims == nil {
 		return ""
 	}
-	serviceAccountID, _ := claims.Ext["service_account_id"].(string)
-	return serviceAccountID
+	if id := stringClaim(claims.Ext, "service_account_id"); id != "" {
+		return id
+	}
+	// Legacy double-nested shape: ext.ext.service_account_id
+	if nested, ok := claims.Ext["ext"].(map[string]any); ok {
+		if id := stringClaim(nested, "service_account_id"); id != "" {
+			return id
+		}
+	}
+	return ""
+}
+
+func stringClaim(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(s)
 }
 
 // ListServiceNamespaces implements the Connect RPC to list all registered service namespaces.

--- a/apps/tenancy/service/handlers/permissions_claims_test.go
+++ b/apps/tenancy/service/handlers/permissions_claims_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	"testing"
+
+	"github.com/pitabwire/frame/v2/security"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServiceAccountIDFromClaims(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "", serviceAccountIDFromClaims(nil))
+	require.Equal(t, "", serviceAccountIDFromClaims(&security.AuthenticationClaims{}))
+
+	// Preferred flat shape under Ext (Hydra mirrors access_token extras under ext).
+	require.Equal(t, "sa-1", serviceAccountIDFromClaims(&security.AuthenticationClaims{
+		Ext: map[string]any{"service_account_id": "sa-1"},
+	}))
+
+	// Legacy double-nested shape from nested "ext" map in token extras.
+	require.Equal(t, "sa-legacy", serviceAccountIDFromClaims(&security.AuthenticationClaims{
+		Ext: map[string]any{
+			"ext": map[string]any{"service_account_id": "sa-legacy"},
+		},
+	}))
+
+	// Prefer flat over nested.
+	require.Equal(t, "sa-flat", serviceAccountIDFromClaims(&security.AuthenticationClaims{
+		Ext: map[string]any{
+			"service_account_id": "sa-flat",
+			"ext":                map[string]any{"service_account_id": "sa-nested"},
+		},
+	}))
+}

--- a/docs/PERMISSION_REGISTRATION.md
+++ b/docs/PERMISSION_REGISTRATION.md
@@ -1,0 +1,97 @@
+# Permission Manifest Registration
+
+How services register namespaces, permissions, and role bindings with tenancy
+(and how that drives Keto), securely and reliably.
+
+## Invariant
+
+- **Actor** for ReBAC is always `profile_id` (`JWT sub` after Frame normalize).
+- **Permission namespaces** (e.g. `service_profile`) are owned by the matching
+  **internal root service account** (`Name` / `ClientID` map to that namespace).
+- Registration is **authenticated machine-to-machine** — not an open admin API.
+
+## Startup flow (every service)
+
+```
+1. cmd/main.go: frame.WithPermissionRegistration(serviceDescriptor)
+2. PERMISSIONS_REGISTRATION_URL points at tenancy:
+     http://service-tenancy.../_internal/register/permissions
+3. PreStart publishes proto service_permissions annotation as JSON manifest
+4. Frame HTTP client uses the service's OAuth2 client_credentials token
+5. Tenancy AuthenticationMiddleware validates JWT
+6. Handler requires:
+     - roles include "internal"
+     - claims carry service_account_id (flat claim, not nested ext.ext)
+     - SA is internal, on root partition, and owns the namespace
+7. Upsert service_namespaces; re-queue SA policy sync + partition authz sync
+8. AuthzServiceAccountSyncEvent materialises Keto granted_* for SAs that
+   declare the namespace in their audiences
+```
+
+Colony chart injects `PERMISSIONS_REGISTRATION_URL` by default for all services.
+
+## Token claims required for registration
+
+Service-account access-token extras (token webhook) **must** include:
+
+| Claim | Purpose |
+|-------|---------|
+| `profile_id` | Actor identity (sub after normalize) |
+| `service_account_id` | Ownership binding for registration |
+| `roles` | Must include `internal` |
+| `tenant_id` / `partition_id` | Tenancy path (usually root) |
+
+**Do not nest** `service_account_id` under a nested `ext` object inside the
+access-token map — Hydra already places the whole map under JWT `ext`.
+
+## Ownership rules (secure)
+
+An SA may register namespace `N` only if all hold:
+
+1. Authenticated with internal role
+2. `service_account_id` present and exists
+3. SA `type = internal`, not deleted
+4. SA `partition_id` = platform root partition
+5. SA `Name == N` **or** `ClientID` with `-`→`_` equals `N`  
+   (e.g. `service-profile` owns `service_profile`)
+
+## Reliability
+
+- Registration is an **idempotent upsert** keyed by namespace.
+- Frame retries with backoff when tenancy/token signing is briefly unavailable
+  (auth cold start).
+- After registration, pending SA authorization policies for that namespace are
+  re-queued so Keto tuples catch up without manual intervention.
+- Service bot Plane-1 bootstrap (`EnsureServiceBotTenancyAccess`) runs on
+  tenancy start so `#service` exists even before individual SA policy sync.
+
+## Service checklist
+
+Every production binary that owns a `service_permissions` proto must:
+
+1. Call `frame.WithPermissionRegistration(sd)` for each service descriptor
+2. Run with `PERMISSIONS_REGISTRATION_URL` set (colony default)
+3. Use frame ≥ **v2.0.5** so `sub === profile_id` after auth
+4. Have a root internal SA whose name/client matches the namespace
+5. Declare needed audiences on that SA so Plane-2 `granted_*` are written
+
+## Debugging 403 on registration
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `service-account identity is required` | Missing `service_account_id` in token | Token webhook flat claim (not nested) |
+| `internal service-account token is required` | No/invalid internal role | Webhook sets `roles: ["internal"]` |
+| `cannot register this namespace` | SA name/client ≠ namespace, or not root/internal | Fix SA seed/name or client_id |
+| Endless retry, status 503 | Token endpoint cold | Wait; retries continue |
+| Registered but Keto still denies | SA policy not reconciled / missing audience | Trigger SA sync; check audiences |
+
+## Related code
+
+| Area | Location |
+|------|----------|
+| Frame publisher | `frame.WithPermissionRegistration` |
+| Endpoint | `apps/tenancy/.../handlers/permissions.go` |
+| Business rules | `apps/tenancy/.../business/permission_registry.go` |
+| SA claims | `apps/default/.../handlers/webhook.go` `buildServiceAccountClaims` |
+| SA Keto sync | `apps/tenancy/.../events/authz_service_account_sync.go` |
+| Bot Plane-1 bootstrap | `apps/tenancy/.../business/bootstrap_service_bots.go` |


### PR DESCRIPTION
## Summary
Fixes production **403** on `/_internal/register/permissions` for all services.

**Root cause:** SA token extras nested `service_account_id` under an inner `ext` map. Hydra already nests the whole access-token map under JWT `ext`, so the id landed at `ext.ext.service_account_id` and ownership resolution failed.

**Changes**
- Flatten `service_account_id` next to `profile_id` in SA token claims
- Resolve registration identity from flat Ext (and legacy nested shape)
- Require internal system token for registration
- Namespace ownership: SA name **or** client_id (`service-profile` → `service_profile`)
- Doc: `docs/PERMISSION_REGISTRATION.md` for all services

Colony already injects `PERMISSIONS_REGISTRATION_URL`; services already call `WithPermissionRegistration`. After deploy, restarts re-register namespaces and re-queue SA policy sync → Keto.

## Test plan
- [x] Unit tests for claims shape, ownership matching, claim extraction
- [ ] After deploy: auth/profile/tenancy logs show `permission manifest registered` without 403