### PR TITLE
fix(tenancy): raise SA authz reconcile capacity

### DIFF
--- a/apps/tenancy/service/events/authz_service_account_sync.go
+++ b/apps/tenancy/service/events/authz_service_account_sync.go
@@ -36,7 +36,13 @@ import (
 
 const EventKeyAuthzServiceAccountSync = "authorization.service_account.sync"
 
-const maxConcurrentAuthorizationReconciliations = 4
+// maxConcurrentAuthorizationReconciliations bounds parallel Keto policy
+// materialisations. Keep high enough that a full SA fleet (dozens of
+// accounts) drains without every waiter hitting eventExecutionTimeout while
+// blocked on acquire — that previously produced mass
+// "wait for authorization reconciliation capacity: context deadline exceeded"
+// and starved Hydra/partition sync work on the same process.
+const maxConcurrentAuthorizationReconciliations = 24
 
 // AuthzServiceAccountSyncEvent reconciles exact Keto state from the normalised
 // authorization policy. Events carry a generation and are only a latency
@@ -163,13 +169,16 @@ func (e *AuthzServiceAccountSyncEvent) Execute(ictx context.Context, payload any
 	}
 
 	jsonPayload := data.JSONMap(*d)
-	ctx := security.SkipTenancyChecksOnClaims(ictx)
-	ctx, cancel := withEventTimeout(ctx)
-	defer cancel()
-	if err := e.acquire(ctx); err != nil {
+	// Acquire capacity on the parent context so a temporary backlog only waits
+	// — it must not burn the short eventExecutionTimeout and fail permanently.
+	if err := e.acquire(ictx); err != nil {
 		return err
 	}
 	defer e.release()
+
+	ctx := security.SkipTenancyChecksOnClaims(ictx)
+	ctx, cancel := withEventTimeout(ctx)
+	defer cancel()
 
 	serviceAccountID := jsonPayload.GetString("id")
 	eventGeneration := authorizationPolicyGeneration(jsonPayload)

--- a/apps/tenancy/service/events/resilience.go
+++ b/apps/tenancy/service/events/resilience.go
@@ -28,9 +28,9 @@ import (
 
 const (
 	// eventExecutionTimeout is the maximum time an event handler may run
-	// before the context is cancelled. This prevents handlers from hanging
-	// indefinitely on slow downstream calls.
-	eventExecutionTimeout = 30 * time.Second
+	// once it has started real work (after any concurrency-slot wait).
+	// Keto batch writes for large SA trees can exceed 30s under load.
+	eventExecutionTimeout = 2 * time.Minute
 
 	// maxKetoRetries is the number of times a transient Keto write is
 	// retried within a single handler execution before giving up.


### PR DESCRIPTION
## Summary
Fixes mass failures of \`authorization.service_account.sync\` and the empty-reply failures of the \`synchronize-partitions\` CronJob.

**Cause:** Up to dozens of SA policy events competed for **4** slots; waiters used the **30s** event timeout and all died with \`context deadline exceeded\`, starving the HTTP handler.

**Fix:** Acquire capacity on the parent context; 2m timeout only for real work; 24 concurrent reconciliations.