### PR TITLE
docs(authz): config-only permission registration model

### DIFF
--- a/docs/PERMISSION_REGISTRATION.md
+++ b/docs/PERMISSION_REGISTRATION.md
@@ -1,34 +1,60 @@
 # Permission Manifest Registration
 
 How services register namespaces, permissions, and role bindings with tenancy
-(and how that drives Keto), securely and reliably.
+(and how that drives Keto) — **configuration only**, no per-service custom
+bootstrap code.
 
-## Invariant
+## Design goals
 
-- **Actor** for ReBAC is always `profile_id` (`JWT sub` after Frame normalize).
-- **Permission namespaces** (e.g. `service_profile`) are owned by the matching
-  **internal root service account** (`Name` / `ClientID` map to that namespace).
-- Registration is **authenticated machine-to-machine** — not an open admin API.
+1. **Declare once** in proto (`service_permissions` + `method_permissions`).
+2. **Register automatically** at process start (Frame + colony).
+3. **Grant via SA policy** (auth-contract / SA config), not imperative scripts.
+4. **Materialise to Keto** via the existing SA reconcile event pipeline.
+5. **No per-app goroutines**, no one-off bootstrap hooks, no copy-paste.
 
-## Startup flow (every service)
+## Plug-and-play checklist (every service)
+
+| Step | Where | What |
+|------|-------|------|
+| 1 | Proto | `option (common.v1.service_permissions) = { namespace, permissions, role_bindings }` |
+| 2 | Proto | `method_permissions` on each RPC |
+| 3 | `cmd/main.go` | `frame.WithPermissionRegistration(serviceDescriptor)` once |
+| 4 | Deploy (colony) | Default `PERMISSIONS_REGISTRATION_URL` → tenancy |
+| 5 | Deploy (colony) | `oauth2.requestedAudiencePaths` = **business** deps only; colony auto-adds `/tenancy` when registration is enabled |
+| 6 | Platform SA | Auth-contract policy lists which namespaces/permissions this SA needs |
+| 7 | Owning SA | Root internal SA name/client matches namespace (`service-devices` ↔ `service_device`) |
+
+That is the entire service-side contract. Everything else is platform plumbing.
+
+## End-to-end flow
 
 ```
-1. cmd/main.go: frame.WithPermissionRegistration(serviceDescriptor)
-2. PERMISSIONS_REGISTRATION_URL points at tenancy:
-     http://service-tenancy.../_internal/register/permissions
-3. PreStart publishes proto service_permissions annotation as JSON manifest
-4. Frame HTTP client uses the service's OAuth2 client_credentials token
-5. Tenancy AuthenticationMiddleware validates JWT
-6. Handler requires:
-     - roles include "internal"
-     - claims carry service_account_id (flat claim, not nested ext.ext)
-     - SA is internal, on root partition, and owns the namespace
-7. Upsert service_namespaces; re-queue SA policy sync + partition authz sync
-8. AuthzServiceAccountSyncEvent materialises Keto granted_* for SAs that
-   declare the namespace in their audiences
+┌──────────────────┐   proto annotations    ┌────────────────────────────┐
+│ Service binary   │ ─────────────────────► │ Frame PermissionRegistration│
+│ (devices, files…)│   startup             │ POST manifest to tenancy   │
+└──────────────────┘                        └─────────────┬──────────────┘
+                                                          │ JWT (internal SA)
+                                                          ▼
+┌──────────────────┐   ownership check      ┌────────────────────────────┐
+│ Service SA policy│ ◄── re-queue ───────── │ Tenancy register endpoint  │
+│ (grants in DB)   │                        │ Upsert service_namespaces  │
+└────────┬─────────┘                        └────────────────────────────┘
+         │ EventKeyAuthzServiceAccountSync
+         ▼
+┌──────────────────┐
+│ Keto granted_*   │  e.g. service_device:t/p#granted_device_manage ← profile_id
+└──────────────────┘
 ```
 
-Colony chart injects `PERMISSIONS_REGISTRATION_URL` by default for all services.
+### Critical distinction
+
+| Concern | Config | Not |
+|---------|--------|-----|
+| OAuth token **audience** (who can call me / who I call) | Hydra client + `oauth_client_recipients` + `requestedAudiencePaths` | Keto grants |
+| **Functional ReBAC** (what I may do) | SA authorization policy grants/permissions | OAuth audiences alone |
+| **Namespace schema** (what permissions exist) | Proto → registration | Hand-edited Keto OPL alone |
+
+Auth already **declares** `service_device:device_manage` and `service_file:content_upload` in its SA policy. Those grants stay **pending** until the owning service registers the namespace.
 
 ## Token claims required for registration
 
@@ -36,62 +62,75 @@ Service-account access-token extras (token webhook) **must** include:
 
 | Claim | Purpose |
 |-------|---------|
-| `profile_id` | Actor identity (sub after normalize) |
+| `profile_id` | Actor identity (sub after Frame normalize) |
 | `service_account_id` | Ownership binding for registration |
 | `roles` | Must include `internal` |
 | `tenant_id` / `partition_id` | Tenancy path (usually root) |
+| `aud` | Must include tenancy resource URL when calling registration |
 
-**Do not nest** `service_account_id` under a nested `ext` object inside the
-access-token map — Hydra already places the whole map under JWT `ext`.
+Colony injects `/tenancy` into `OAUTH2_REQUESTED_AUDIENCES` when
+`permissionsRegistrationUrl` is set so services do not list it by hand.
+
+Hydra must allow top-level claim mirroring for `service_account_id` (see
+`oauth2.allowed_top_level_claims` / `mirror_top_level_claims` on the Hydra
+release).
 
 ## Ownership rules (secure)
 
 An SA may register namespace `N` only if all hold:
 
-1. Authenticated with internal role
-2. `service_account_id` present and exists
-3. SA `type = internal`, not deleted
-4. SA `partition_id` = platform root partition
+1. Authenticated with internal role  
+2. `service_account_id` present and exists  
+3. SA `type = internal`, not deleted  
+4. SA `partition_id` = platform root partition  
 5. SA `Name == N` **or** `ClientID` with `-`→`_` equals `N`  
-   (e.g. `service-profile` owns `service_profile`)
+   (e.g. `service-devices` owns `service_device`)
 
 ## Reliability
 
 - Registration is an **idempotent upsert** keyed by namespace.
-- Frame retries with backoff when tenancy/token signing is briefly unavailable
-  (auth cold start).
-- After registration, pending SA authorization policies for that namespace are
-  re-queued so Keto tuples catch up without manual intervention.
-- Service bot Plane-1 bootstrap (`EnsureServiceBotTenancyAccess`) runs on
-  tenancy start so `#service` exists even before individual SA policy sync.
+- Frame retries with backoff when tenancy/token signing is briefly unavailable.
+- After registration, pending SA policies for that namespace are **re-queued**
+  so Keto tuples catch up without manual intervention.
+- Plane-1 `#service` for bot profiles is maintained by platform bootstrap on
+  tenancy (not by each app).
 
-## Service checklist
+## Debugging permission_denied (e.g. ShowConsent / device_manage)
 
-Every production binary that owns a `service_permissions` proto must:
+Error shape:
 
-1. Call `frame.WithPermissionRegistration(sd)` for each service descriptor
-2. Run with `PERMISSIONS_REGISTRATION_URL` set (colony default)
-3. Use frame ≥ **v2.0.5** so `sub === profile_id` after auth
-4. Have a root internal SA whose name/client matches the namespace
-5. Declare needed audiences on that SA so Plane-2 `granted_*` are written
+```text
+d75qclkpf2t1uum8ij40 cannot device_manage on service_device:tenant/partition
+```
 
-## Debugging 403 on registration
+Actor is **profile_id** of the calling SA (auth bot). Check in order:
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| `service-account identity is required` | Missing `service_account_id` in token | Token webhook flat claim (not nested) |
-| `internal service-account token is required` | No/invalid internal role | Webhook sets `roles: ["internal"]` |
-| `cannot register this namespace` | SA name/client ≠ namespace, or not root/internal | Fix SA seed/name or client_id |
-| Endless retry, status 503 | Token endpoint cold | Wait; retries continue |
-| Registered but Keto still denies | SA policy not reconciled / missing audience | Trigger SA sync; check audiences |
+1. **Namespace registered?**  
+   `SELECT namespace FROM service_namespaces WHERE namespace = 'service_device';`  
+   If missing → owning service (`service-devices`) failed registration (usually
+   missing tenancy audience → 403 on register).
+
+2. **SA policy includes the grant?**  
+   `service_account_authorization_grants` + `_permissions` for the caller SA.
+
+3. **Policy applied?**  
+   `status = applied` and `applied_generation = generation`.  
+   If `failed` with `namespace "…" is not registered` → fix (1) then re-sync.
+
+4. **Keto tuple exists?**  
+   `service_device:t/p#granted_device_manage` subject = **profile_id**.
+
+Do **not** add ad-hoc grants in app code or random startup goroutines. Fix
+registration and SA policy config; the event pipeline is the framework.
 
 ## Related code
 
 | Area | Location |
 |------|----------|
 | Frame publisher | `frame.WithPermissionRegistration` |
+| Colony auto `/tenancy` audience | `charts/colony` ≥ 2.0.1 |
 | Endpoint | `apps/tenancy/.../handlers/permissions.go` |
 | Business rules | `apps/tenancy/.../business/permission_registry.go` |
-| SA claims | `apps/default/.../handlers/webhook.go` `buildServiceAccountClaims` |
+| SA claims | `apps/default/.../handlers/webhook.go` |
 | SA Keto sync | `apps/tenancy/.../events/authz_service_account_sync.go` |
-| Bot Plane-1 bootstrap | `apps/tenancy/.../business/bootstrap_service_bots.go` |
+| Proto annotations | `common/v1/permissions.proto` + per-service protos |


### PR DESCRIPTION
Document plug-and-play permission registration and debugging device_manage/content_upload denials.