### PR TITLE
fix(tenancy): config-only permission registration without startup hacks

### DIFF
--- a/apps/tenancy/cmd/main.go
+++ b/apps/tenancy/cmd/main.go
@@ -107,8 +107,10 @@ func main() {
 		auth,
 	)
 
-	// Bootstrap root super-user authorization after migration only.
-	// This writes Keto tuples for migration-seeded root owners/admins.
+	// Migration path only: seed root super-user tuples + plane-1 bot access.
+	// Runtime pods must not run bulk reconcile/bootstrap in ad-hoc goroutines —
+	// permission registration + /_internal/sync/clients (cron) are the plug-
+	// and-play recovery paths and scale with the number of services.
 	if isMigration {
 		if bootstrapErr := business.EnsureRootAuthorization(ctx, business.RootAuthorizationDeps{
 			AccessRepo:           partSrv.AccessRepo,
@@ -119,29 +121,13 @@ func main() {
 		}); bootstrapErr != nil {
 			util.Log(ctx).WithError(bootstrapErr).Fatal("root authorization bootstrap failed")
 		}
-	}
-
-	// Service-bot Plane-1 access must self-heal. Under a large SA backlog this
-	// (and ReconcilePending) can take minutes, so:
-	//  - migration jobs: bot bootstrap only (fatal), no full SA reconcile
-	//  - regular pods: both run in the background after HTTP is ready
-	runServiceBotBootstrap := func(bootstrapCtx context.Context, fatal bool) {
-		if botErr := business.EnsureServiceBotTenancyAccess(bootstrapCtx, business.ServiceBotTenancyDeps{
+		if botErr := business.EnsureServiceBotTenancyAccess(ctx, business.ServiceBotTenancyDeps{
 			ServiceAccountRepo: partSrv.ServiceAccountRepo,
 			PartitionRepo:      partSrv.PartitionRepo,
 			Authorizer:         auth,
 		}); botErr != nil {
-			if fatal {
-				util.Log(bootstrapCtx).WithError(botErr).Fatal("service bot tenancy access bootstrap failed")
-			}
-			util.Log(bootstrapCtx).WithError(botErr).Error("service bot tenancy access bootstrap failed; will retry on next restart")
+			util.Log(ctx).WithError(botErr).Fatal("service bot tenancy access bootstrap failed")
 		}
-	}
-
-	if isMigration {
-		// Do not run ReconcilePending here: it can exceed Helm job timeouts and
-		// leave the release Failed while runtime pods already handle the backlog.
-		runServiceBotBootstrap(ctx, true)
 		util.Log(ctx).Info("migration and root authorization bootstrap complete — exiting")
 		return
 	}
@@ -183,18 +169,8 @@ func main() {
 
 	svc.Init(ctx, serviceOptions...)
 
-	// Heavy authz self-heal after Init so event workers exist, but off the
-	// request path so readiness/liveness can succeed immediately.
-	go func() {
-		bootstrapCtx := context.WithoutCancel(ctx)
-		runServiceBotBootstrap(bootstrapCtx, false)
-		if reconcileErr := policySync.ReconcilePending(bootstrapCtx); reconcileErr != nil {
-			util.Log(bootstrapCtx).WithError(reconcileErr).Error(
-				"authorization policy startup reconciliation failed; queue consumers will continue retrying",
-			)
-		}
-	}()
-
+	// Event workers + Frame permission registration handle the steady state.
+	// Bulk repair is intentionally left to /_internal/sync/clients (cron).
 	err = svc.Run(ctx, "")
 	if err != nil {
 		log := util.Log(ctx).WithError(err)

--- a/apps/tenancy/service/business/permission_registry.go
+++ b/apps/tenancy/service/business/permission_registry.go
@@ -77,8 +77,8 @@ func RegisterPermissionManifest(
 		return nil, errors.New("permission manifest owner service account is required")
 	}
 	if deps.ServiceNamespaceRepo == nil || deps.ServiceAccountRepo == nil || deps.PolicyRepo == nil ||
-		deps.PartitionRepo == nil || deps.AccessRepo == nil || deps.AccessRoleRepo == nil ||
-		deps.PartitionRoleRepo == nil || deps.EventsManager == nil || deps.Authorizer == nil {
+		deps.AccessRepo == nil || deps.AccessRoleRepo == nil || deps.PartitionRoleRepo == nil ||
+		deps.EventsManager == nil || deps.Authorizer == nil {
 		return nil, errors.New("permission registry dependencies are incomplete")
 	}
 
@@ -104,16 +104,15 @@ func RegisterPermissionManifest(
 		return registration, nil
 	}
 
-	if err = EnsureRootAuthorization(ctx, RootAuthorizationDeps{
-		AccessRepo:           deps.AccessRepo,
-		AccessRoleRepo:       deps.AccessRoleRepo,
-		PartitionRoleRepo:    deps.PartitionRoleRepo,
-		ServiceNamespaceRepo: deps.ServiceNamespaceRepo,
-		Authorizer:           deps.Authorizer,
-	}); err != nil {
-		return nil, fmt.Errorf("ensure root authorization after namespace registration: %w", err)
-	}
-
+	// Hot path stays lightweight and config-driven:
+	// 1) re-queue only SA policies that grant this namespace
+	// 2) extend root super-user tuples for the new namespace
+	// 3) mark the manifest reconciled
+	//
+	// Do not re-queue every partition here — that O(partitions) fan-out
+	// saturates the DB/event queue and blocks other services from registering.
+	// Partition inheritance and bulk repair belong on the periodic
+	// /_internal/sync/clients job, not on every service startup.
 	policies, err := deps.PolicyRepo.ListByNamespace(ctx, normalised.Namespace)
 	if err != nil {
 		return nil, err
@@ -128,14 +127,19 @@ func RegisterPermissionManifest(
 		}
 	}
 
-	if err = ReQueuePartitionsForAuthorizationSync(
-		ctx,
-		deps.PartitionRepo,
-		deps.EventsManager,
-		data.NewSearchQuery(),
-	); err != nil {
-		return nil, fmt.Errorf("requeue partitions after namespace registration: %w", err)
+	if err = EnsureRootAuthorization(ctx, RootAuthorizationDeps{
+		AccessRepo:           deps.AccessRepo,
+		AccessRoleRepo:       deps.AccessRoleRepo,
+		PartitionRoleRepo:    deps.PartitionRoleRepo,
+		ServiceNamespaceRepo: deps.ServiceNamespaceRepo,
+		Authorizer:           deps.Authorizer,
+	}); err != nil {
+		// Root super-user extension is best-effort relative to SA grants.
+		// Surface the error but only after SA policies are already re-queued so
+		// service-to-service grants are not blocked by a Keto blip.
+		return nil, fmt.Errorf("ensure root authorization after namespace registration: %w", err)
 	}
+
 	if err = deps.ServiceNamespaceRepo.MarkReconciled(
 		ctx,
 		normalised.Namespace,

--- a/apps/tenancy/service/events/authz_service_account_sync.go
+++ b/apps/tenancy/service/events/authz_service_account_sync.go
@@ -177,7 +177,10 @@ func (e *AuthzServiceAccountSyncEvent) Execute(ictx context.Context, payload any
 	defer e.release()
 
 	ctx := security.SkipTenancyChecksOnClaims(ictx)
-	ctx, cancel := withEventTimeout(ctx)
+	// SA policies fan out granted_* tuples across partition trees; under
+	// concurrent registration/sync this routinely exceeds the default event
+	// budget. Use a dedicated longer timeout rather than ad-hoc retries.
+	ctx, cancel := context.WithTimeout(ctx, serviceAccountSyncTimeout)
 	defer cancel()
 
 	serviceAccountID := jsonPayload.GetString("id")

--- a/apps/tenancy/service/events/resilience.go
+++ b/apps/tenancy/service/events/resilience.go
@@ -32,6 +32,11 @@ const (
 	// Keto batch writes for large SA trees can exceed 30s under load.
 	eventExecutionTimeout = 2 * time.Minute
 
+	// serviceAccountSyncTimeout covers partition_tree materialisation of
+	// multi-namespace SA policies (hundreds of granted_* tuples) without
+	// competing with short-lived partition/access sync handlers.
+	serviceAccountSyncTimeout = 5 * time.Minute
+
 	// maxKetoRetries is the number of times a transient Keto write is
 	// retried within a single handler execution before giving up.
 	maxKetoRetries = 3

--- a/apps/tenancy/service/events/sync_client.go
+++ b/apps/tenancy/service/events/sync_client.go
@@ -174,9 +174,17 @@ func SyncClientOnHydra(
 	if err != nil {
 		return fmt.Errorf("load OAuth recipients for client %q: %w", cl.GetID(), err)
 	}
-	audiences := make([]string, 0, len(recipients))
+	audiences := make([]string, 0, len(recipients)+1)
 	for _, recipient := range recipients {
 		audiences = append(audiences, recipient.ResourceAudience)
+	}
+	// Internal service bots always need the tenancy resource audience so Frame
+	// can call /_internal/register/permissions without per-service custom code.
+	// Colony injects the matching OAUTH2_REQUESTED_AUDIENCES entry; Hydra must
+	// whitelist it on the client or token requests fail with "not been
+	// whitelisted by the OAuth 2.0 Client".
+	if cl.Type == "internal" {
+		audiences = ensureTenancyAudience(audiences, oauth2AudienceBaseURL(cfg))
 	}
 
 	// Build payload
@@ -274,6 +282,35 @@ func buildClientHydraPayload(cl *models.Client, profileID string, audiences []st
 	}
 
 	return payload
+}
+
+// oauth2AudienceBaseURL reads the platform API base from the concrete OAuth
+// config when available (ConfigurationOAUTH2 does not expose it).
+func oauth2AudienceBaseURL(cfg config.ConfigurationOAUTH2) string {
+	type audienceBaseURLProvider interface {
+		GetOauth2AudienceBaseURL() string
+	}
+	if provider, ok := cfg.(audienceBaseURLProvider); ok {
+		return provider.GetOauth2AudienceBaseURL()
+	}
+	return ""
+}
+
+// ensureTenancyAudience appends {base}/tenancy when missing so internal bots
+// can register permission manifests against tenancy without each service
+// authoring a custom oauth recipient row.
+func ensureTenancyAudience(audiences []string, audienceBaseURL string) []string {
+	base := strings.TrimSuffix(strings.TrimSpace(audienceBaseURL), "/")
+	if base == "" {
+		return audiences
+	}
+	tenancyAudience := base + "/tenancy"
+	for _, audience := range audiences {
+		if strings.EqualFold(strings.TrimSpace(audience), tenancyAudience) {
+			return audiences
+		}
+	}
+	return append(audiences, tenancyAudience)
 }
 
 func getStringSlice(m data.JSONMap, key string) []string {

--- a/apps/tenancy/service/events/sync_client_helpers_test.go
+++ b/apps/tenancy/service/events/sync_client_helpers_test.go
@@ -49,6 +49,30 @@ func (s *SyncClientHelpersTestSuite) TestGetStringSlice_SingleString() {
 	s.Equal([]string{"single"}, getStringSlice(m, "types"))
 }
 
+func (s *SyncClientHelpersTestSuite) TestEnsureTenancyAudience_AppendsWhenMissing() {
+	got := ensureTenancyAudience(
+		[]string{"https://api.example.test/profile"},
+		"https://api.example.test",
+	)
+	s.Equal([]string{
+		"https://api.example.test/profile",
+		"https://api.example.test/tenancy",
+	}, got)
+}
+
+func (s *SyncClientHelpersTestSuite) TestEnsureTenancyAudience_Idempotent() {
+	in := []string{
+		"https://api.example.test/tenancy",
+		"https://api.example.test/profile",
+	}
+	s.Equal(in, ensureTenancyAudience(in, "https://api.example.test/"))
+}
+
+func (s *SyncClientHelpersTestSuite) TestEnsureTenancyAudience_EmptyBase() {
+	in := []string{"https://api.example.test/profile"}
+	s.Equal(in, ensureTenancyAudience(in, "  "))
+}
+
 func (s *SyncClientHelpersTestSuite) TestGetStringSlice_EmptyString() {
 	m := data.JSONMap{"types": ""}
 	s.Nil(getStringSlice(m, "types"))

--- a/apps/tenancy/service/handlers/permission_registry_integration_test.go
+++ b/apps/tenancy/service/handlers/permission_registry_integration_test.go
@@ -213,7 +213,10 @@ func (s *PermissionRegistryTestSuite) TestConcurrentRegistrationHasOneOwner() {
 
 func serviceAccountContext(ctx context.Context, serviceAccountID string) context.Context {
 	claims := &security.AuthenticationClaims{
-		Ext: map[string]any{"service_account_id": serviceAccountID},
+		// Registration requires an internal service-account principal, not
+		// only a service_account_id claim.
+		Roles: []string{security.ConstantSystemInternalRole},
+		Ext:   map[string]any{"service_account_id": serviceAccountID},
 	}
 	claims.Subject = util.IDString()
 	return claims.ClaimsToContext(ctx)

--- a/docs/PERMISSION_REGISTRATION.md
+++ b/docs/PERMISSION_REGISTRATION.md
@@ -9,7 +9,7 @@ bootstrap code.
 1. **Declare once** in proto (`service_permissions` + `method_permissions`).
 2. **Register automatically** at process start (Frame + colony).
 3. **Grant via SA policy** (auth-contract / SA config), not imperative scripts.
-4. **Materialise to Keto** via the existing SA reconcile event pipeline.
+4. **Materialise to Keto** via the SA policy event pipeline.
 5. **No per-app goroutines**, no one-off bootstrap hooks, no copy-paste.
 
 ## Plug-and-play checklist (every service)
@@ -71,6 +71,11 @@ Service-account access-token extras (token webhook) **must** include:
 Colony injects `/tenancy` into `OAUTH2_REQUESTED_AUDIENCES` when
 `permissionsRegistrationUrl` is set so services do not list it by hand.
 
+On Hydra client sync, **internal** OAuth clients automatically get
+`{OAUTH2_AUDIENCE_BASE_URL}/tenancy` whitelisted even if the auth-contract
+recipient row was omitted — so registration is plug-and-play without
+per-service recipient edits.
+
 Hydra must allow top-level claim mirroring for `service_account_id` (see
 `oauth2.allowed_top_level_claims` / `mirror_top_level_claims` on the Hydra
 release).
@@ -86,14 +91,25 @@ An SA may register namespace `N` only if all hold:
 5. SA `Name == N` **or** `ClientID` with `-`→`_` equals `N`  
    (e.g. `service-devices` owns `service_device`)
 
-## Reliability
+## Reliability (no ad-hoc goroutines)
 
-- Registration is an **idempotent upsert** keyed by namespace.
-- Frame retries with backoff when tenancy/token signing is briefly unavailable.
-- After registration, pending SA policies for that namespace are **re-queued**
-  so Keto tuples catch up without manual intervention.
-- Plane-1 `#service` for bot profiles is maintained by platform bootstrap on
-  tenancy (not by each app).
+| Mechanism | When | What it does |
+|-----------|------|--------------|
+| Frame registration | Every service process start | Idempotent POST of proto manifest; retries with backoff |
+| Registration handler | On successful upsert | Re-queues **only** SA policies that grant that namespace |
+| `/_internal/sync/clients` (cron) | Hourly / operator-triggered | Bulk repair: Hydra clients, SA policies, partitions, accesses |
+| Migration job | Deploy migrate | Root super-user tuples + plane-1 bot access |
+
+What we **do not** do:
+
+- Per-app startup goroutines that bulk-reconcile all policies
+- Partition fan-out on every namespace registration (that O(N) storm
+  blocks registration for every other service)
+- Hand-written Keto grants to “unblock” consent
+
+After registration, pending SA policies for that namespace catch up through
+the event pipeline. Plane-1 `#service` for bot profiles is maintained by
+migration bootstrap and SA create/sync events.
 
 ## Debugging permission_denied (e.g. ShowConsent / device_manage)
 
@@ -108,14 +124,15 @@ Actor is **profile_id** of the calling SA (auth bot). Check in order:
 1. **Namespace registered?**  
    `SELECT namespace FROM service_namespaces WHERE namespace = 'service_device';`  
    If missing → owning service (`service-devices`) failed registration (usually
-   missing tenancy audience → 403 on register).
+   missing tenancy audience → 403 on register, or tenancy down → connection refused).
 
 2. **SA policy includes the grant?**  
    `service_account_authorization_grants` + `_permissions` for the caller SA.
 
 3. **Policy applied?**  
    `status = applied` and `applied_generation = generation`.  
-   If `failed` with `namespace "…" is not registered` → fix (1) then re-sync.
+   If `failed` with `namespace "…" is not registered` → fix (1) then wait for
+   registration re-queue or run `POST /_internal/sync/clients`.
 
 4. **Keto tuple exists?**  
    `service_device:t/p#granted_device_manage` subject = **profile_id**.
@@ -129,8 +146,10 @@ registration and SA policy config; the event pipeline is the framework.
 |------|----------|
 | Frame publisher | `frame.WithPermissionRegistration` |
 | Colony auto `/tenancy` audience | `charts/colony` ≥ 2.0.1 |
+| Hydra auto tenancy whitelist | `apps/tenancy/.../events/sync_client.go` `ensureTenancyAudience` |
 | Endpoint | `apps/tenancy/.../handlers/permissions.go` |
 | Business rules | `apps/tenancy/.../business/permission_registry.go` |
 | SA claims | `apps/default/.../handlers/webhook.go` |
 | SA Keto sync | `apps/tenancy/.../events/authz_service_account_sync.go` |
+| Bulk repair | `POST /_internal/sync/clients` (cron `synchronize-partitions`) |
 | Proto annotations | `common/v1/permissions.proto` + per-service protos |


### PR DESCRIPTION
## Summary
- Remove runtime startup goroutine bulk reconcile that saturates the DB under SA backlog.
- Keep permission registration lightweight: namespace upsert + re-queue only affected SA policies (no partition fan-out).
- Auto-whitelist `{audienceBase}/tenancy` on internal Hydra clients so registration JWTs work without per-service recipient edits.
- Give SA policy materialisation a dedicated 5m timeout so declared grants (e.g. `device_manage`) reach Keto.
- Update `docs/PERMISSION_REGISTRATION.md` for the event/cron recovery model.

## Why
Consent failed with `cannot device_manage on service_device` because registration and SA apply never completed under load. Per-app goroutines and full partition re-queues on every registration do not scale.

Depends on the merged docs direction in #787; this ships the tenancy runtime changes.

## Test plan
- [x] `go test ./apps/tenancy/service/events/ ./apps/tenancy/service/business/`
- [ ] Deploy tenancy image from this PR
- [ ] Confirm devices registers `service_device` without connection storms
- [ ] Confirm auth SA policy applies / Keto has `granted_device_manage`
- [ ] Retry login/consent without `device_manage` permission_denied