### PR TITLE
fix(tenancy): stop partition-sync timeout death spiral

### DIFF
--- a/apps/tenancy/service/business/partition.go
+++ b/apps/tenancy/service/business/partition.go
@@ -261,7 +261,10 @@ func (pb *partitionBusiness) CreatePartition(
 	}
 
 	// Emit authz partition sync to write inheritance tuples for partitions with parents.
-	if emitErr := pb.eventsMan.Emit(ctx, events.EventKeyAuthzPartitionSync, data.JSONMap{"id": partition.GetID()}); emitErr != nil {
+	if emitErr := pb.eventsMan.Emit(ctx, events.EventKeyAuthzPartitionSync, data.JSONMap{
+		"id":     partition.GetID(),
+		"reason": "partition_created",
+	}); emitErr != nil {
 		util.Log(ctx).WithError(emitErr).Warn("failed to emit authz partition sync event")
 	}
 
@@ -471,7 +474,10 @@ func ReQueuePartitionsForAuthorizationSync(ctx context.Context, partitionRepo re
 		}
 
 		for _, partition := range result.Item() {
-			if err = eventsMan.Emit(ctx, events.EventKeyAuthzPartitionSync, data.JSONMap{"id": partition.GetID()}); err != nil {
+			if err = eventsMan.Emit(ctx, events.EventKeyAuthzPartitionSync, data.JSONMap{
+				"id":     partition.GetID(),
+				"reason": "periodic_repair",
+			}); err != nil {
 				return err
 			}
 		}

--- a/apps/tenancy/service/events/authz_partition_sync.go
+++ b/apps/tenancy/service/events/authz_partition_sync.go
@@ -169,8 +169,15 @@ func (e *AuthzPartitionSyncEvent) Execute(ictx context.Context, payload any) err
 		}
 	}
 
-	if err = e.requeueAncestorServiceAccountPolicies(ctx, partition); err != nil {
-		return err
+	// Only re-queue partition_tree SA policies when topology actually changed.
+	// Periodic /_internal/sync/clients repair must NOT do this: every partition
+	// re-queue fan-out multiplies into full SA materialisations, overloads Keto,
+	// and starves interactive GetPartition/login with context deadlines.
+	reason := jsonPayload.GetString("reason")
+	if reason == "partition_created" || reason == "topology_changed" {
+		if err = e.requeueAncestorServiceAccountPolicies(ctx, partition); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/apps/tenancy/service/events/authz_service_account_sync.go
+++ b/apps/tenancy/service/events/authz_service_account_sync.go
@@ -37,12 +37,11 @@ import (
 const EventKeyAuthzServiceAccountSync = "authorization.service_account.sync"
 
 // maxConcurrentAuthorizationReconciliations bounds parallel Keto policy
-// materialisations. Keep high enough that a full SA fleet (dozens of
-// accounts) drains without every waiter hitting eventExecutionTimeout while
-// blocked on acquire — that previously produced mass
-// "wait for authorization reconciliation capacity: context deadline exceeded"
-// and starved Hydra/partition sync work on the same process.
-const maxConcurrentAuthorizationReconciliations = 24
+// materialisations. Keep this modest: each SA with partition_tree grants
+// writes hundreds of tuples, and high concurrency saturates Keto + locks
+// service_account_authorization_policies, which then times out interactive
+// tenancy RPCs (GetPartition) used by login/consent.
+const maxConcurrentAuthorizationReconciliations = 4
 
 // AuthzServiceAccountSyncEvent reconciles exact Keto state from the normalised
 // authorization policy. Events carry a generation and are only a latency


### PR DESCRIPTION
## Summary
Login/consent was timing out because tenancy was busy dying under an event feedback loop:

1. `authorization.partition.sync` (periodic repair) re-queued every `partition_tree` SA policy
2. Each SA write hundreds of Keto tuples
3. Keto + DB locks saturated
4. Failed partition.sync redelivered → more SA re-queues
5. Interactive `GetPartition` for login hit `context canceled`

### Fix
- Only re-queue ancestor SA policies when reason is `partition_created` or `topology_changed`
- Periodic repair emits `reason=periodic_repair` (inheritance/schema only)
- Cap concurrent SA reconciliations at 4 (was 24)

## Test plan
- [x] `go test ./apps/tenancy/service/events/ ./apps/tenancy/service/business/`
- [ ] Deploy; tenancy logs stop flooding with partition.sync deadlines
- [ ] Login/consent completes without tenancy GetPartition timeouts