### PR TITLE
fix(auth): CORS + OPTIONS on OAuth token facade

### DIFF
--- a/apps/default/service/handlers/oauth_token_facade.go
+++ b/apps/default/service/handlers/oauth_token_facade.go
@@ -148,6 +148,25 @@ func (h *AuthServer) OpenIDConfigurationFacadeEndpoint(w http.ResponseWriter, r 
 	return json.NewEncoder(w).Encode(doc)
 }
 
+// setOAuthPublicCORSHeaders enables browser PKCE/token exchange against the
+// accounts-hosted token facade. Credentials are not used (public clients /
+// Authorization header or form body), so a wildcard origin is safe and matches
+// the Gateway CORS policy on oauth2.stawi.org.
+func setOAuthPublicCORSHeaders(w http.ResponseWriter, r *http.Request) {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		return
+	}
+	// Echo request origin when present so credentialed-or-not SPA fetches work
+	// consistently; do not set Allow-Credentials (token exchange is public).
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Vary", "Origin")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, DPoP, DPoP-Nonce")
+	w.Header().Set("Access-Control-Expose-Headers", "Content-Type, DPoP-Nonce")
+	w.Header().Set("Access-Control-Max-Age", "86400")
+}
+
 // OAuthTokenFacadeEndpoint serves the public /oauth2/token facade. It handles
 // native provider ID-token exchange and proxies all ordinary grants to Hydra.
 func (h *AuthServer) OAuthTokenFacadeEndpoint(w http.ResponseWriter, r *http.Request) error {

--- a/apps/default/service/handlers/oauth_token_facade_endpoints_internal_test.go
+++ b/apps/default/service/handlers/oauth_token_facade_endpoints_internal_test.go
@@ -113,6 +113,24 @@ func TestSameHTTPHost(t *testing.T) {
 	require.False(t, sameHTTPHost("https://a.example.com", "::::not-a-url"))
 }
 
+func TestSetOAuthPublicCORSHeadersEchoesOrigin(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/oauth2/token", nil)
+	req.Header.Set("Origin", "https://opportunities.stawi.org")
+	setOAuthPublicCORSHeaders(rec, req)
+	require.Equal(t, "https://opportunities.stawi.org", rec.Header().Get("Access-Control-Allow-Origin"))
+	require.Contains(t, rec.Header().Get("Access-Control-Allow-Methods"), "POST")
+	require.Contains(t, rec.Header().Get("Access-Control-Allow-Headers"), "Content-Type")
+	require.Equal(t, "Origin", rec.Header().Get("Vary"))
+}
+
+func TestSetOAuthPublicCORSHeadersSkipsWithoutOrigin(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/oauth2/token", nil)
+	setOAuthPublicCORSHeaders(rec, req)
+	require.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+}
+
 func TestHydraUpstreamBaseRejectsSelfReference(t *testing.T) {
 	h := &AuthServer{config: &authconfig.AuthenticationConfig{
 		FedCMPublicOrigin:            "https://accounts.example.com",

--- a/apps/default/service/handlers/routing.go
+++ b/apps/default/service/handlers/routing.go
@@ -100,11 +100,20 @@ func (h *AuthServer) SetupRouterV1(ctx context.Context) *http.ServeMux {
 	h.addHandler(router, h.ErrorEndpoint, "/error", "ErrorEndpoint")
 	h.addHandler(router, h.SwaggerEndpoint, "/swagger.json", "SwaggerEndpoint")
 	router.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		setOAuthPublicCORSHeaders(w, r)
 		if err := h.OpenIDConfigurationFacadeEndpoint(w, r); err != nil {
 			h.writeAPIError(r.Context(), w, err, "OpenIDConfigurationFacade")
 		}
 	})
+	// Browser SPAs discover token_endpoint on the accounts host and preflight
+	// with OPTIONS before exchanging authorization codes (PKCE).
+	router.HandleFunc("OPTIONS /oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		setOAuthPublicCORSHeaders(w, r)
+		w.Header().Set("Allow", "POST, OPTIONS")
+		w.WriteHeader(http.StatusNoContent)
+	})
 	router.HandleFunc("POST /oauth2/token", func(w http.ResponseWriter, r *http.Request) {
+		setOAuthPublicCORSHeaders(w, r)
 		if err := h.OAuthTokenFacadeEndpoint(w, r); err != nil {
 			h.writeAPIError(r.Context(), w, err, "OAuthTokenFacade")
 		}


### PR DESCRIPTION
## Summary
Fixes browser console CORS errors when exchanging auth codes against
`https://accounts.stawi.org/oauth2/token` from app origins (e.g. opportunities).

- OPTIONS /oauth2/token → 204 with CORS headers
- POST /oauth2/token and discovery set Access-Control-Allow-Origin

Pair with deployment.manifests gateway CORS on accounts.stawi.org.

## Test plan
- [x] unit tests for CORS header helper
- [ ] OPTIONS accounts.stawi.org/oauth2/token returns ACAO after deploy