### PR TITLE
fix(deps): bump frame/v2 to v2.0.15 for Cloud Run Keto gRPC

### DIFF
--- a/apps/default/tests/base_testsuite.go
+++ b/apps/default/tests/base_testsuite.go
@@ -256,6 +256,8 @@ func (bs *BaseTestSuite) CreateService(
 	cfg.TraceRequests = true
 	cfg.DatabaseMigrate = true
 	cfg.DatabaseTraceQueries = true
+	// Tests do not run Keto; Frame ≥2.0.13 fail-closes when mode is enforced without a read URI.
+	cfg.AuthorizationMode = "disabled"
 	// cfg.RunServiceSecurely = false
 	if bs.handler == nil {
 		cfg.HTTPServerPort = bs.FreeAuthPort

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame/v2 v2.0.12
+	github.com/pitabwire/frame/v2 v2.0.15
 	github.com/pitabwire/util v0.9.1
 	github.com/posthog/posthog-go v1.22.0
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.0.12 h1:wmnCv6fzLwyX1D9CvQ/AsvQl6vtUrZbaQDkuCkEyYkk=
-github.com/pitabwire/frame/v2 v2.0.12/go.mod h1:RqLpEfKx7nQdSdzUo6yZ64xw36MZscp12VreLBX2p8E=
+github.com/pitabwire/frame/v2 v2.0.15 h1:XtpKRL7Qf/KXAsFG7caVweHF8iTCdDT/nv/u04E5uvQ=
+github.com/pitabwire/frame/v2 v2.0.15/go.mod h1:32j4Jr6Soom38QkLy67oGxf1F+jEj0wE0hdUkzMJDOk=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=

--- a/pkg/tests/authentication_dep.go
+++ b/pkg/tests/authentication_dep.go
@@ -56,9 +56,10 @@ func (d *authenticationDependency) migrateContainer(
 	containerRequest := testcontainers.ContainerRequest{
 		Image: d.Name(),
 		Env: map[string]string{
-			"LOG_LEVEL":    "debug",
-			"DO_MIGRATION": "true",
-			"DATABASE_URL": databaseURL,
+			"LOG_LEVEL":          "debug",
+			"AUTHORIZATION_MODE": "disabled",
+			"DO_MIGRATION":       "true",
+			"DATABASE_URL":       databaseURL,
 		},
 
 		WaitingFor: wait.ForExit(),
@@ -118,6 +119,7 @@ func (d *authenticationDependency) Setup(ctx context.Context, ntwk *testcontaine
 		Image: d.Name(),
 		Env: map[string]string{
 			"LOG_LEVEL":            "debug",
+			"AUTHORIZATION_MODE":   "disabled",
 			"TRACE_REQUESTS":       "true",
 			"DATABASE_LOG_QUERIES": "true",
 			"HTTP_PORT":            strings.Replace(d.Opts().Ports[0], "/tcp", "", 1),

--- a/pkg/tests/device_dep.go
+++ b/pkg/tests/device_dep.go
@@ -56,9 +56,10 @@ func (d *deviceDependency) migrateContainer(
 	containerRequest := testcontainers.ContainerRequest{
 		Image: d.Name(),
 		Env: map[string]string{
-			"LOG_LEVEL":    "debug",
-			"DO_MIGRATION": "true",
-			"DATABASE_URL": databaseURL,
+			"LOG_LEVEL":          "debug",
+			"AUTHORIZATION_MODE": "disabled",
+			"DO_MIGRATION":       "true",
+			"DATABASE_URL":       databaseURL,
 		},
 
 		WaitingFor: wait.ForExit(),
@@ -133,6 +134,7 @@ func (d *deviceDependency) Setup(ctx context.Context, ntwk *testcontainers.Docke
 		Env: map[string]string{
 			"LOG_LEVEL":                         "debug",
 			"RUN_SERVICE_SECURELY":              "false",
+			"AUTHORIZATION_MODE":                "disabled",
 			"TRACE_REQUESTS":                    "true",
 			"DATABASE_LOG_QUERIES":              "true",
 			"OPENTELEMETRY_DISABLE":             "true",

--- a/pkg/tests/notification_dep.go
+++ b/pkg/tests/notification_dep.go
@@ -132,6 +132,7 @@ func (d *notificationDependancy) Setup(ctx context.Context, ntwk *testcontainers
 		Env: map[string]string{
 			"LOG_LEVEL":             "debug",
 			"RUN_SERVICE_SECURELY":  "false",
+			"AUTHORIZATION_MODE":    "disabled",
 			"TRACE_REQUESTS":        "true",
 			"DATABASE_LOG_QUERIES":  "true",
 			"OPENTELEMETRY_DISABLE": "true",

--- a/pkg/tests/profile_dep.go
+++ b/pkg/tests/profile_dep.go
@@ -57,9 +57,10 @@ func (d *dependency) migrateContainer(
 	containerRequest := testcontainers.ContainerRequest{
 		Image: d.Name(),
 		Env: map[string]string{
-			"LOG_LEVEL":    "debug",
-			"DO_MIGRATION": "true",
-			"DATABASE_URL": databaseURL,
+			"LOG_LEVEL":          "debug",
+			"AUTHORIZATION_MODE": "disabled",
+			"DO_MIGRATION":       "true",
+			"DATABASE_URL":       databaseURL,
 		},
 
 		WaitingFor: wait.ForExit(),
@@ -145,8 +146,10 @@ func (d *dependency) Setup(ctx context.Context, ntwk *testcontainers.DockerNetwo
 	containerRequest := testcontainers.ContainerRequest{
 		Image: d.Name(),
 		Env: map[string]string{
-			"LOG_LEVEL":             "debug",
-			"RUN_SERVICE_SECURELY":  "false",
+			"LOG_LEVEL":            "debug",
+			"RUN_SERVICE_SECURELY": "false",
+			// No Keto in this test stack — Frame ≥2.0.13 fail-closes when mode is enforced without a read URI.
+			"AUTHORIZATION_MODE":    "disabled",
 			"TRACE_REQUESTS":        "true",
 			"DATABASE_LOG_QUERIES":  "true",
 			"OPENTELEMETRY_DISABLE": "true",


### PR DESCRIPTION
## Summary
- Bumps `github.com/pitabwire/frame/v2` from v2.0.12 → **v2.0.15**.
- Frame authorizer now dials `https://…` Keto endpoints with **TLS** and attaches a **Google ID token** (Cloud Run `roles/run.invoker`).
- Fixes tenancy `migrate` failing at service-bot bootstrap with:
  `authz service error during read_exact_tuple: rpc error: code = Unavailable … unexpected EOF`

## Context
Tenancy migrate schema succeeds; post-migrate `EnsureServiceBotTenancyAccess` writes ~506 Keto tuples via gRPC. The old client used `insecure` credentials against Cloud Run HTTPS → connection EOF.

Companion infra (cloud.deployment): keto `use_http2`, migrate OAuth/Keto env wiring.

## Test plan
- [ ] CI green
- [ ] Release tag ships new tenancy image
- [ ] Re-run `identity-tenancy-migrate` after keto h2c + new image; expect exit 0