### PR TITLE
fix(tenancy,auth): Google ID token for Cloud Run Hydra admin

### DIFF
--- a/apps/default/service/handlers/init_server.go
+++ b/apps/default/service/handlers/init_server.go
@@ -42,6 +42,7 @@ import (
 	"github.com/antinvestor/service-authentication/apps/default/service/repository"
 	"github.com/antinvestor/service-authentication/apps/default/service/telemetry"
 	"github.com/antinvestor/service-authentication/apps/default/utils"
+	"github.com/antinvestor/service-authentication/pkg/hydraadmin"
 	"github.com/pitabwire/frame/v2/cache"
 	"github.com/pitabwire/frame/v2/client"
 	fevents "github.com/pitabwire/frame/v2/events"
@@ -152,15 +153,14 @@ func NewAuthServer(ctx context.Context,
 		httpOpts = append(httpOpts, client.WithHTTPTraceRequests(), client.WithHTTPTraceRequestHeaders())
 	}
 
-	// Use context.Background() to avoid inheriting the service's OAuth2 token
-	// source. The Hydra admin API is internal and does not require OAuth2 auth.
-	// Using the service context would cause a circular dependency: the signing
-	// webhook needs Hydra admin to fetch JWK sets, but the HTTP client would
-	// try to authenticate via the signer (itself) before making the request.
+	// Hydra admin must not inherit service OAuth2 (private_key_jwt circularity
+	// via the signing webhook). hydraadmin still attaches a Google ID token
+	// when admin is HTTPS Cloud Run (roles/run.invoker); cluster http:// stays plain.
 	// Hydra admin timeout is the single bound for all admin API hops.
 	httpOpts = append(httpOpts, client.WithHTTPTimeout(hydraAdminHTTPTimeout))
-	hydraHTTPCli := client.NewHTTPClient(context.Background(), httpOpts...)
-	hydraCli := hydra.NewDefaultHydra(hydraHTTPCli, authConfig.GetOauth2ServiceAdminURI())
+	adminURI := authConfig.GetOauth2ServiceAdminURI()
+	hydraHTTPCli := hydraadmin.NewHTTPClient(ctx, adminURI, httpOpts...)
+	hydraCli := hydra.NewDefaultHydra(hydraHTTPCli, adminURI)
 
 	h := &AuthServer{
 

--- a/apps/tenancy/cmd/main.go
+++ b/apps/tenancy/cmd/main.go
@@ -36,8 +36,8 @@ import (
 	"github.com/antinvestor/service-authentication/apps/tenancy/service/events"
 	"github.com/antinvestor/service-authentication/apps/tenancy/service/handlers"
 	"github.com/antinvestor/service-authentication/apps/tenancy/service/repository"
+	"github.com/antinvestor/service-authentication/pkg/hydraadmin"
 	"github.com/pitabwire/frame/v2"
-	"github.com/pitabwire/frame/v2/client"
 	"github.com/pitabwire/frame/v2/config"
 	"github.com/pitabwire/frame/v2/security"
 	"github.com/pitabwire/frame/v2/security/authorizer"
@@ -76,11 +76,10 @@ func main() {
 
 	sm := svc.SecurityManager()
 
-	// Unauthenticated HTTP client for Hydra admin API calls.
-	// Hydra admin is cluster-internal and doesn't require OAuth2 tokens.
-	// Using the authenticated client causes bootstrap failures when the
-	// service's own OAuth2 client isn't yet registered in Hydra.
-	hydraClient := client.NewManager(context.Background())
+	// Hydra admin: no service OAuth2 (bootstrap circularity). On Cloud Run the
+	// admin surface is IAM-authenticated HTTPS — hydraadmin attaches a Google
+	// ID token for roles/run.invoker. Cluster http:// URIs stay plain.
+	hydraClient := hydraadmin.NewManager(ctx, cfg.GetOauth2ServiceAdminURI())
 
 	profileCli, err := connection.NewServiceClient(ctx, &cfg, common.ServiceTarget{
 		Endpoint:              cfg.ProfileServiceURI,

--- a/apps/tenancy/service/events/sync_client.go
+++ b/apps/tenancy/service/events/sync_client.go
@@ -191,6 +191,16 @@ func SyncClientOnHydra(
 	if err != nil {
 		return err
 	}
+
+	// Concurrent syncs can race GET→POST: Hydra returns 409 once the client
+	// exists. Fall through to PUT so the payload still lands.
+	if resp.StatusCode == http.StatusConflict && httpMethod == http.MethodPost {
+		util.CloseAndLogOnError(ctx, resp)
+		resp, err = cli.Invoke(ctx, http.MethodPut, hydraIDURL, payload, nil)
+		if err != nil {
+			return err
+		}
+	}
 	defer util.CloseAndLogOnError(ctx, resp)
 
 	result, err := resp.ToContent(ctx)

--- a/apps/tenancy/tests/base_testsuite.go
+++ b/apps/tenancy/tests/base_testsuite.go
@@ -323,9 +323,8 @@ func (bs *BaseTestSuite) createServiceInternal(
 	auth := svc.SecurityManager().GetAuthorizer(ctx)
 	implementation := handlers.NewTenancyServer(ctx, svc, nil)
 
-	// Use a plain HTTP client for Hydra admin API calls (no OAuth2 transport).
-	// This matches production (cmd/main.go) where hydraClient is unauthenticated
-	// because Hydra admin is cluster-internal and doesn't require OAuth2 tokens.
+	// Test Hydra is http:// (cluster-style). hydraadmin only attaches a Google
+	// ID token for https admin URIs, so NewManager here stays unauthenticated.
 	hydraClient := client.NewManager(context.Background())
 
 	serviceOptions := []frame.Option{frame.WithRegisterEvents(

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.36.0
+	google.golang.org/api v0.290.0
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gorm.io/gorm v1.31.2
@@ -172,7 +173,6 @@ require (
 	golang.org/x/text v0.40.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
-	google.golang.org/api v0.290.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260720211330-0afa2a65878a // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260720211330-0afa2a65878a // indirect

--- a/pkg/hydraadmin/client.go
+++ b/pkg/hydraadmin/client.go
@@ -1,0 +1,96 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hydraadmin builds HTTP clients for the Ory Hydra admin API.
+//
+// Cluster-era deployments reach Hydra admin over plain http:// inside the
+// mesh (no auth). Cloud Run exposes admin as IAM-authenticated HTTPS
+// (e.g. https://oauth2-w.stawi.org); callers must attach a Google ID token
+// minted for that origin so roles/run.invoker accepts the request.
+//
+// Service OAuth2 client-credentials / private_key_jwt are intentionally
+// never attached: bootstrap would otherwise circular-depend on Hydra
+// itself (tenancy registering its own client; authentication fetching JWKS).
+package hydraadmin
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/pitabwire/frame/v2/client"
+	"github.com/pitabwire/util"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/idtoken"
+)
+
+// NewManager returns a client.Manager for Hydra admin.
+// https admin URIs get a Google ID token transport; http:// stays plain.
+func NewManager(ctx context.Context, adminURI string, opts ...client.HTTPOption) client.Manager {
+	// Background context so Frame does not auto-attach service OAuth2 tokens
+	// from the runtime config (bootstrap circularity).
+	mgr := client.NewManager(context.Background(), opts...)
+	if cl := withGoogleIDToken(ctx, mgr.Client(ctx), adminURI); cl != nil {
+		mgr.SetClient(ctx, cl)
+	}
+	return mgr
+}
+
+// NewHTTPClient returns an *http.Client for Hydra admin (same auth rules as NewManager).
+func NewHTTPClient(ctx context.Context, adminURI string, opts ...client.HTTPOption) *http.Client {
+	base := client.NewHTTPClient(context.Background(), opts...)
+	if cl := withGoogleIDToken(ctx, base, adminURI); cl != nil {
+		return cl
+	}
+	return base
+}
+
+// withGoogleIDToken wraps base with oauth2.Transport when adminURI is https.
+// Returns nil when no wrap is needed or the token source cannot be created
+// (caller keeps the unauthenticated client; Cloud Run will 403 until fixed).
+func withGoogleIDToken(ctx context.Context, base *http.Client, adminURI string) *http.Client {
+	if base == nil {
+		return nil
+	}
+	audience := AudienceFromHTTPSURI(adminURI)
+	if audience == "" {
+		return nil
+	}
+	ts, err := idtoken.NewTokenSource(ctx, audience)
+	if err != nil {
+		util.Log(ctx).WithError(err).WithField("audience", audience).
+			Warn("hydra admin: Google ID token source unavailable; Cloud Run invoker calls may 403")
+		return nil
+	}
+	return &http.Client{
+		Transport: &oauth2.Transport{
+			Base:   base.Transport,
+			Source: oauth2.ReuseTokenSource(nil, ts),
+		},
+		Timeout:       base.Timeout,
+		Jar:           base.Jar,
+		CheckRedirect: base.CheckRedirect,
+	}
+}
+
+// AudienceFromHTTPSURI returns https://host for Cloud Run ID-token audience,
+// or empty for non-https / unparseable URIs (cluster-internal http).
+func AudienceFromHTTPSURI(rawURI string) string {
+	u, err := url.Parse(strings.TrimSpace(rawURI))
+	if err != nil || u.Host == "" || !strings.EqualFold(u.Scheme, "https") {
+		return ""
+	}
+	return "https://" + u.Host
+}

--- a/pkg/hydraadmin/client_test.go
+++ b/pkg/hydraadmin/client_test.go
@@ -1,0 +1,44 @@
+// Copyright 2023-2026 Ant Investor Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hydraadmin
+
+import (
+	"testing"
+)
+
+func TestAudienceFromHTTPSURI(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"https://oauth2-w.stawi.org", "https://oauth2-w.stawi.org"},
+		{"https://oauth2-w.stawi.org/admin", "https://oauth2-w.stawi.org"},
+		{"https://identity-oauth2-hydra-admin-akpnezytka-od.a.run.app", "https://identity-oauth2-hydra-admin-akpnezytka-od.a.run.app"},
+		{"http://service-authentication-oauth2-hydra-admin.identity.svc:4445", ""},
+		{"http://127.0.0.1:4445", ""},
+		{"", ""},
+		{"not-a-url", ""},
+		{"  https://oauth2-w.stawi.org/  ", "https://oauth2-w.stawi.org"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			if got := AudienceFromHTTPSURI(tc.in); got != tc.want {
+				t.Fatalf("AudienceFromHTTPSURI(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Tenancy and authentication were calling Hydra admin over HTTPS without a Google ID token, so Cloud Run returned **403** on `/admin/clients` and partition sync could not populate OAuth clients.
- Add `pkg/hydraadmin`: no service OAuth2 (bootstrap circularity), but attach a Google ID token when `OAUTH2_SERVICE_ADMIN_URI` is `https://…`.
- On concurrent sync races, treat Hydra **409** after POST as “already exists” and fall through to **PUT**.

## Deployed (hot-ship)
- `identity-tenancy` → `…/service-authentication-tenancy:v1.54.60`
- `identity-authentication` → `…/service-authentication:v1.54.59`
- Full sync job returned **HTTP 200**; Hydra admin lists **56** clients (`x-total-count: 56`).

## Test plan
- [x] `go test ./pkg/hydraadmin/`
- [x] Manual Cloud Run job `identity-tenancy-sync-partitions` → 200
- [x] Probe Hydra `/admin/clients` as tenancy SA → 200, 56 clients
- [ ] CI / release tag once PR merges (images already live from AR push)