### PR TITLE
release: frame v2.0.17 setup plan (no runtime permission PreStart)

### DIFF
--- a/apps/audit/cmd/main.go
+++ b/apps/audit/cmd/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pitabwire/frame/v2/security"
 	"github.com/pitabwire/frame/v2/security/authorizer"
 	connectInterceptors "github.com/pitabwire/frame/v2/security/interceptors/connect"
+	"github.com/pitabwire/frame/v2/setup"
 	"github.com/pitabwire/util"
 )
 
@@ -56,8 +57,19 @@ func main() {
 
 	ctx, svc := frame.NewServiceWithContext(ctx, frame.WithConfig(&cfg), frame.WithDatastore())
 
-	// Handle database migration if requested
-	if handleDatabaseMigration(ctx, &cfg, svc.DatastoreManager()) {
+	sd := auditv1.File_audit_v1_audit_proto.Services().ByName("AuditService")
+
+	// Setup plan: migrate (+ permissions when URL is set). No runtime PreStart.
+	svc.Setup().RegisterFunc(setup.NameMigrate, func(ctx context.Context) error {
+		return repository.Migrate(ctx, svc.DatastoreManager(), cfg.GetDatabaseMigrationPath())
+	})
+
+	if frame.ShouldRunSetup(&cfg) {
+		svc.Init(ctx, frame.WithPermissionRegistration(sd))
+		if setupErr := svc.RunSetupForProcess(ctx, &cfg); setupErr != nil {
+			util.Log(ctx).WithError(setupErr).Fatal("setup plan failed")
+		}
+		util.Log(ctx).Info("setup plan complete — exiting")
 		return
 	}
 
@@ -79,9 +91,6 @@ func main() {
 	// Setup Connect RPC server with full interceptor chain
 	connectHandler := setupConnectServer(ctx, svc.SecurityManager(), auditSrv)
 
-	// Register permission manifest for the audit service
-	sd := auditv1.File_audit_v1_audit_proto.Services().ByName("AuditService")
-
 	serviceOptions := []frame.Option{
 		frame.WithHTTPHandler(connectHandler),
 		frame.WithPermissionRegistration(sd),
@@ -99,22 +108,6 @@ func main() {
 			log.Fatal("server stopping with error")
 		}
 	}
-}
-
-// handleDatabaseMigration performs database migration if configured to do so.
-func handleDatabaseMigration(
-	ctx context.Context,
-	cfg config.ConfigurationDatabase,
-	dbManager datastore.Manager,
-) bool {
-	if cfg.DoDatabaseMigrate() {
-		err := repository.Migrate(ctx, dbManager, cfg.GetDatabaseMigrationPath())
-		if err != nil {
-			util.Log(ctx).WithError(err).Fatal("database migration failed")
-		}
-		return true
-	}
-	return false
 }
 
 // loadOrGenerateSigner loads an Ed25519 signing key from config or generates one.

--- a/apps/default/cmd/main.go
+++ b/apps/default/cmd/main.go
@@ -71,9 +71,10 @@ func main() {
 		cfg.ServiceName = "service_authentication"
 	}
 
-	// Migration-only path: database only — no cache, no OIDC network.
+	// Legacy migrate-only job: database only — no cache, no OIDC network.
 	// Must finish and exit so Helm pre-upgrade Jobs complete (activeDeadline).
-	if cfg.DoDatabaseMigrate() {
+	// Full setup (including permissions) uses argv `setup …` with OIDC below.
+	if cfg.DoDatabaseMigrate() && !frame.IsSetupMode(&cfg) {
 		runDatabaseMigrationAndExit(ctx, cfg)
 		return
 	}
@@ -162,7 +163,7 @@ func main() {
 	defaultServer := frame.WithHTTPHandler(authMux)
 	serviceOptions = append(serviceOptions, defaultServer)
 
-	// Register permission manifest for the authentication service
+	// Permissions step for setup jobs (no runtime PreStart — fast cold start).
 	sd := authv1.File_authentication_v1_authentication_proto.Services().ByName("AuthenticationService")
 	serviceOptions = append(serviceOptions, frame.WithPermissionRegistration(sd))
 
@@ -173,6 +174,15 @@ func main() {
 	))
 
 	svc.Init(ctx, serviceOptions...)
+
+	// setup argv (e.g. setup permissions): publish manifests with full OIDC.
+	if frame.IsSetupMode(&cfg) {
+		if setupErr := svc.RunSetupForProcess(ctx, &cfg); setupErr != nil {
+			log.WithError(setupErr).Fatal("setup plan failed")
+		}
+		log.Info("setup plan complete — exiting")
+		return
+	}
 
 	err = svc.Run(ctx, "")
 	if err != nil {

--- a/apps/tenancy/cmd/main.go
+++ b/apps/tenancy/cmd/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/pitabwire/frame/v2/security/authorizer"
 	connectInterceptors "github.com/pitabwire/frame/v2/security/interceptors/connect"
 	securityhttp "github.com/pitabwire/frame/v2/security/interceptors/httptor"
+	"github.com/pitabwire/frame/v2/setup"
 	"github.com/pitabwire/util"
 )
 
@@ -61,21 +62,6 @@ func main() {
 
 	ctx, svc := frame.NewServiceWithContext(ctx, frame.WithConfig(&cfg), frame.WithDatastore())
 
-	isMigration := cfg.DoDatabaseMigrate()
-
-	// Handle database migration if requested
-	if isMigration {
-		if migErr := repository.Migrate(
-			ctx,
-			svc.DatastoreManager(),
-			cfg.GetDatabaseMigrationPath(),
-		); migErr != nil {
-			util.Log(ctx).WithError(migErr).Fatal("database migration failed")
-		}
-	}
-
-	sm := svc.SecurityManager()
-
 	// Hydra admin: no service OAuth2 (bootstrap circularity). On Cloud Run the
 	// admin surface is IAM-authenticated HTTPS — hydraadmin attaches a Google
 	// ID token for roles/run.invoker. Cluster http:// URIs stay plain.
@@ -90,6 +76,7 @@ func main() {
 		util.Log(ctx).WithError(err).Fatal("could not setup profile service client")
 	}
 
+	sm := svc.SecurityManager()
 	auth := sm.GetAuthorizer(ctx)
 	partSrv := handlers.NewTenancyServer(ctx, svc, profileCli)
 	authContractSrv, err := handlers.NewAuthContractServer(partSrv, cfg.GetOauth2AudienceBaseURL())
@@ -106,11 +93,12 @@ func main() {
 		auth,
 	)
 
-	// Migration path only: seed root super-user tuples + plane-1 bot access.
-	// Runtime pods must not run bulk reconcile/bootstrap in ad-hoc goroutines —
-	// permission registration + /_internal/sync/clients (cron) are the plug-
-	// and-play recovery paths and scale with the number of services.
-	if isMigration {
+	// Setup plan steps (migrate + root/bot bootstrap). Permissions step is
+	// registered via WithPermissionRegistration — never on runtime PreStart.
+	svc.Setup().RegisterFunc(setup.NameMigrate, func(ctx context.Context) error {
+		return repository.Migrate(ctx, svc.DatastoreManager(), cfg.GetDatabaseMigrationPath())
+	})
+	svc.Setup().RegisterFunc(setup.NameBootstrap, func(ctx context.Context) error {
 		if bootstrapErr := business.EnsureRootAuthorization(ctx, business.RootAuthorizationDeps{
 			AccessRepo:           partSrv.AccessRepo,
 			AccessRoleRepo:       partSrv.AccessRoleRepo,
@@ -118,29 +106,33 @@ func main() {
 			ServiceNamespaceRepo: partSrv.ServiceNamespaceRepo,
 			Authorizer:           auth,
 		}); bootstrapErr != nil {
-			util.Log(ctx).WithError(bootstrapErr).Fatal("root authorization bootstrap failed")
+			return bootstrapErr
 		}
-		if botErr := business.EnsureServiceBotTenancyAccess(ctx, business.ServiceBotTenancyDeps{
+		return business.EnsureServiceBotTenancyAccess(ctx, business.ServiceBotTenancyDeps{
 			ServiceAccountRepo: partSrv.ServiceAccountRepo,
 			PartitionRepo:      partSrv.PartitionRepo,
 			Authorizer:         auth,
-		}); botErr != nil {
-			util.Log(ctx).WithError(botErr).Fatal("service bot tenancy access bootstrap failed")
+		})
+	})
+
+	sd := tenancyv1.File_tenancy_v1_tenancy_proto.Services().ByName("TenancyService")
+
+	if frame.ShouldRunSetup(&cfg) {
+		// Tenancy is the permission registration *target* — skip self-registration
+		// unless PERMISSIONS_REGISTRATION_URL is explicitly set to another host.
+		svc.Init(ctx)
+		if setupErr := svc.RunSetupForProcess(ctx, &cfg); setupErr != nil {
+			util.Log(ctx).WithError(setupErr).Fatal("setup plan failed")
 		}
-		util.Log(ctx).Info("migration and root authorization bootstrap complete — exiting")
+		util.Log(ctx).Info("setup plan complete — exiting")
 		return
 	}
 
-	// Setup Connect server
+	// Runtime: fast start — no permission POST on PreStart.
 	connectHandler := setupConnectServer(ctx, sm, partSrv, authContractSrv)
-
-	// Register permission manifest for the tenancy service so the UI can
-	// discover available permissions for assignment.
-	sd := tenancyv1.File_tenancy_v1_tenancy_proto.Services().ByName("TenancyService")
-
-	// Setup HTTP handlers
 	serviceOptions := []frame.Option{
 		frame.WithHTTPHandler(connectHandler),
+		// Register permissions step for setup jobs sharing this image; unused at runtime.
 		frame.WithPermissionRegistration(sd),
 		frame.WithRegisterEvents(
 			events.NewClientSynchronizationEventHandler(
@@ -168,8 +160,6 @@ func main() {
 
 	svc.Init(ctx, serviceOptions...)
 
-	// Event workers + Frame permission registration handle the steady state.
-	// Bulk repair is intentionally left to /_internal/sync/clients (cron).
 	err = svc.Run(ctx, "")
 	if err != nil {
 		log := util.Log(ctx).WithError(err)
@@ -194,10 +184,8 @@ func setupConnectServer(
 	auth := sm.GetAuthorizer(ctx)
 	tenancyAccessChecker := authorizer.NewTenancyAccessChecker(auth, authz.NamespaceTenancyAccess)
 
-	// Connect: tenancy access interceptor runs after authentication to verify data access.
 	tenancyAccessInterceptor := connectInterceptors.NewTenancyAccessInterceptor(tenancyAccessChecker)
 
-	// Layer 2: FunctionAccessInterceptor enforces per-RPC permissions from proto annotations.
 	sd := tenancyv1.File_tenancy_v1_tenancy_proto.Services().ByName("TenancyService")
 	procMap := permissions.BuildProcedureMap(sd)
 	svcPerms := permissions.ForService(sd)
@@ -232,7 +220,6 @@ func setupConnectServer(
 		connect.WithInterceptors(v2Interceptors...),
 	)
 
-	// HTTP: auth middleware (outer) populates claims → tenancy access (inner) verifies data access → handler.
 	publicRestHandler := securityhttp.AuthenticationMiddleware(
 		securityhttp.TenancyAccessMiddleware(implementation.NewSecureRouterV1(), tenancyAccessChecker),
 		authenticator)
@@ -242,8 +229,6 @@ func setupConnectServer(
 	mux.Handle("/", serverHandler)
 	mux.Handle("/public/", http.StripPrefix("/public", publicRestHandler))
 
-	// Client bootstrap remains cluster-internal. Permission registration also
-	// requires a verified service-account token and binds namespaces to it.
 	mux.Handle("/_internal/sync/clients", implementation.NewInternalSyncHandler())
 	mux.Handle(
 		"/_internal/register/permissions",

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame/v2 v2.0.15
+	github.com/pitabwire/frame/v2 v2.0.17
 	github.com/pitabwire/util v0.9.1
 	github.com/posthog/posthog-go v1.22.0
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.0.15 h1:XtpKRL7Qf/KXAsFG7caVweHF8iTCdDT/nv/u04E5uvQ=
-github.com/pitabwire/frame/v2 v2.0.15/go.mod h1:32j4Jr6Soom38QkLy67oGxf1F+jEj0wE0hdUkzMJDOk=
+github.com/pitabwire/frame/v2 v2.0.17 h1:I+7nhS2TibL2EWTUwydq/dwI+cPqS51/RIaHmtUhD+I=
+github.com/pitabwire/frame/v2 v2.0.17/go.mod h1:32j4Jr6Soom38QkLy67oGxf1F+jEj0wE0hdUkzMJDOk=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary
- Bump `github.com/pitabwire/frame/v2` **v2.0.15 → v2.0.17**
- Setup plan: tenancy (migrate+bootstrap), audit (migrate+permissions), auth setup argv for permissions
- **No runtime PreStart** permission POSTs (fast Cloud Run cold starts)

## Test plan
- [x] `go build` tenancy, default, audit
- [x] `go test` hydraadmin + tenancy events
- [x] golangci-lint clean on changed packages