### PR TITLE
feat(tenancy): seed service-chat-agent SA and Hydra client contract

### DIFF
--- a/apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql
+++ b/apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql
@@ -1,0 +1,87 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+-- Service account: service_chat_agent (platform-chat-agent Cloud Run app)
+-- Owns permission namespace service_chat_agent; Hydra client_id service-chat-agent.
+
+INSERT INTO clients (
+    id, tenant_id, partition_id, name, client_id, client_secret,
+    type, grant_types, scopes,
+    token_endpoint_auth_method, service_account_id, properties
+) VALUES (
+    'd9lemh4pf2t9nfnavkag',
+    'c2f4j7au6s7f91uqnojg',
+    'c2f4j7au6s7f91uqnokg',
+    'sa-service_chat_agent',
+    'service-chat-agent',
+    '',
+    'internal',
+    '{"types": ["client_credentials"]}',
+    'system_int openid',
+    'private_key_jwt',
+    'd9lemh4pf2t9nfnavkbg',
+    '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO service_accounts (
+    id, tenant_id, partition_id, name, profile_id,
+    client_id, client_ref, type, properties
+) VALUES (
+    'd9lemh4pf2t9nfnavkbg',
+    'c2f4j7au6s7f91uqnojg',
+    'c2f4j7au6s7f91uqnokg',
+    'service_chat_agent',
+    'd9lemh4pf2t9nfnavkcg',
+    'service-chat-agent',
+    'd9lemh4pf2t9nfnavkag',
+    'internal',
+    '{}'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Resource audiences this SA may request (tenancy auto-adds /tenancy when registering permissions).
+INSERT INTO public.oauth_client_recipients (
+  id, created_at, modified_at, version, tenant_id, partition_id, client_ref, resource_audience
+) VALUES
+  ('d9lemn4pf2t9a621dr00', NOW(), NOW(), 1, 'c2f4j7au6s7f91uqnojg', 'c2f4j7au6s7f91uqnokg', 'd9lemh4pf2t9nfnavkag', 'https://api.stawi.org/chat-agent'),
+  ('d9lemn4pf2t9a621dr0g', NOW(), NOW(), 1, 'c2f4j7au6s7f91uqnojg', 'c2f4j7au6s7f91uqnokg', 'd9lemh4pf2t9nfnavkag', 'https://api.stawi.org/profile'),
+  ('d9lemn4pf2t9a621dr10', NOW(), NOW(), 1, 'c2f4j7au6s7f91uqnojg', 'c2f4j7au6s7f91uqnokg', 'd9lemh4pf2t9nfnavkag', 'https://api.stawi.org/tenancy'),
+  ('d9lemn4pf2t9a621dr1g', NOW(), NOW(), 1, 'c2f4j7au6s7f91uqnojg', 'c2f4j7au6s7f91uqnokg', 'd9lemh4pf2t9nfnavkag', 'https://api.stawi.org/notification')
+ON CONFLICT (client_ref, resource_audience) DO NOTHING;
+
+-- Authorization policy: owns service_chat_agent namespace.
+INSERT INTO public.service_account_authorization_policies (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  service_account_id, schema_version, generation, applied_generation,
+  status, retry_count, last_error_code, last_error, next_attempt_at, synced_at
+) VALUES (
+  'd9lemh4pf2t9nfnavkc0', NOW(), NOW(), '', '', 1,
+  'c2f4j7au6s7f91uqnojg', 'c2f4j7au6s7f91uqnokg', '', NULL,
+  'd9lemh4pf2t9nfnavkbg', 1, 1, 0,
+  'pending', 0, '', '', NULL, NULL
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.service_account_authorization_grants (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  policy_id, namespace, scope
+) VALUES (
+  'd9lemn4pf2t9a621dr20', NOW(), NOW(), '', '', 1,
+  'c2f4j7au6s7f91uqnojg', 'c2f4j7au6s7f91uqnokg', '', NULL,
+  'd9lemh4pf2t9nfnavkc0', 'service_chat_agent', 'partition_tree'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Own-namespace permissions (must match chatagent.proto service_permissions).
+INSERT INTO public.service_account_authorization_permissions (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  grant_id, permission
+) VALUES
+  ('d9lemn4pf2t9a621dr2g', NOW(), NOW(), '', '', 1, 'c2f4j7au6s7f91uqnojg', 'c2f4j7au6s7f91uqnokg', '', NULL, 'd9lemn4pf2t9a621dr20', 'chat_agent_view'),
+  ('d9lemn4pf2t9a621dr30', NOW(), NOW(), '', '', 1, 'c2f4j7au6s7f91uqnojg', 'c2f4j7au6s7f91uqnokg', '', NULL, 'd9lemn4pf2t9a621dr20', 'chat_agent_manage'),
+  ('d9lemn4pf2t9a621dr3g', NOW(), NOW(), '', '', 1, 'c2f4j7au6s7f91uqnojg', 'c2f4j7au6s7f91uqnokg', '', NULL, 'd9lemn4pf2t9a621dr20', 'chat_agent_turn')
+ON CONFLICT (id) DO NOTHING;
+
+-- Force Hydra re-sync of this client.
+UPDATE public.clients
+SET modified_at = NOW(),
+    synced_at = NULL
+WHERE client_id = 'service-chat-agent';

--- a/apps/tenancy/migrations/IDS.md
+++ b/apps/tenancy/migrations/IDS.md
@@ -94,6 +94,7 @@ configuration.
 | d8as62bvfo145u8bon3g | service-fort | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260704_01_greenfield_seed.sql |
 | d8le7qspf2t8u08dff3g | service-payment-pawapay | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260704_01_greenfield_seed.sql |
 | d8lt2gkpf2t1ql3csd1g | service-payment-checkout | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260704_01_greenfield_seed.sql |
+| d9lemh4pf2t9nfnavkag | service-chat-agent | c2f4j7au6s7f91uqnokg | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
 
 ## Service accounts
 | xid | profile_id (placeholder) | client | file |
@@ -143,6 +144,7 @@ configuration.
 | d86tt34pf2tddudk9q60 | d86tt34pf2tddudk9q6g | d86tt34pf2tddudk9q5g | apps/tenancy/migrations/0001/20260704_01_greenfield_seed.sql |
 | d86tt34pf2tddudk9q7g | d86tt34pf2tddudk9q80 | d86tt34pf2tddudk9q70 | apps/tenancy/migrations/0001/20260704_01_greenfield_seed.sql |
 | d8as62fieol45uar4okg | d8as6297jdi45ufqlh70 | d8as62bvfo145u8bon3g | apps/tenancy/migrations/0001/20260704_01_greenfield_seed.sql |
+| d9lemh4pf2t9nfnavkbg | d9lemh4pf2t9nfnavkcg | d9lemh4pf2t9nfnavkag | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
 
 ## Referenced profile IDs
 | xid | what | file |
@@ -184,3 +186,19 @@ configuration.
 | d7j42dspf2tfev9jfh50 | member | d7j42dspf2tfev9jfh40 | apps/tenancy/migrations/0001/20260704_01_greenfield_seed.sql |
 | d7j42dspf2tfev9jfh5g | admin  | 9bsv0s0hijjb83qksr20 | apps/tenancy/migrations/0001/20260704_01_greenfield_seed.sql |
 | d7j42dspf2tfev9jfh60 | member | 9bsv0s0hijjb83qksr20 | apps/tenancy/migrations/0001/20260704_01_greenfield_seed.sql |
+
+## Service chat-agent seed extras
+| xid | what | file |
+|-----|------|------|
+| d9lemh4pf2t9nfnavkag | client row id | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemh4pf2t9nfnavkbg | service account | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemh4pf2t9nfnavkcg | profile placeholder | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemh4pf2t9nfnavkc0 | authorization policy | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemn4pf2t9a621dr00 | oauth recipient chat-agent | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemn4pf2t9a621dr0g | oauth recipient profile | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemn4pf2t9a621dr10 | oauth recipient tenancy | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemn4pf2t9a621dr1g | oauth recipient notification | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemn4pf2t9a621dr20 | auth grant service_chat_agent | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemn4pf2t9a621dr2g | perm chat_agent_view | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemn4pf2t9a621dr30 | perm chat_agent_manage | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+| d9lemn4pf2t9a621dr3g | perm chat_agent_turn | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |

--- a/apps/tenancy/service/repository/clients_test.go
+++ b/apps/tenancy/service/repository/clients_test.go
@@ -36,12 +36,12 @@ func (s *ClientRepositoryTestSuite) TestGreenfieldSeedUsesOnlyNormalizedAuthCont
 		db := svc.DatastoreManager().GetPool(ctx, datastore.DefaultPoolName).DB(ctx, true)
 
 		for table, expected := range map[string]int64{
-			"clients":                                   56,
-			"oauth_client_recipients":                   256,
-			"service_accounts":                          45,
-			"service_account_authorization_policies":    45,
-			"service_account_authorization_grants":      177,
-			"service_account_authorization_permissions": 1845,
+			"clients":                                   57,  // +service-chat-agent
+			"oauth_client_recipients":                   260, // +chat-agent,profile,tenancy,notification
+			"service_accounts":                          46,  // +service_chat_agent
+			"service_account_authorization_policies":    46,
+			"service_account_authorization_grants":      178,  // +service_chat_agent namespace
+			"service_account_authorization_permissions": 1848, // +chat_agent_view/manage/turn
 		} {
 			var count int64
 			s.Require().NoError(db.Table(table).Count(&count).Error)


### PR DESCRIPTION
## Summary

Seeds `service-chat-agent` internal SA + OAuth client for platform-chat-agent Cloud Run.

**Root cause of CI ship failure:** migrate job used `OAUTH2_SERVICE_CLIENT_ID=platform-chat-agent` (unknown Hydra client) → `invalid_client` on permission registration.

This migration + Hydra client (already created in admin) enables:
- private_key_jwt token mint as `service-chat-agent`
- ownership of namespace `service_chat_agent` for permission registration
- audiences: chat-agent, profile, tenancy, notification

## Test plan
- [x] `make check-ids`
- [ ] Ship identity-tenancy migrate
- [ ] Re-run platform-chat-agent-migrate → exit 0