### PR TITLE
fix(authz): setup-only bootstrap and permission registration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,15 @@ jobs:
     secrets:
       buf_token: ${{ secrets.BUF_TOKEN }}
 
+  # Merge opl/**/*.opl.ts into identity-authorization-keto namespaces.ts.
+  opl-push:
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+    uses: antinvestor/common/.github/workflows/opl-push.yml@main
+    secrets:
+      deploy_token: ${{ secrets.DEPLOY_REPO_TOKEN }}
+
   # Two Cloud Run apps from this monorepo (default + tenancy images).
   ship-authentication:
     needs: [docker]

--- a/apps/audit/cmd/main.go
+++ b/apps/audit/cmd/main.go
@@ -96,9 +96,9 @@ func main() {
 	// Setup Connect RPC server with full interceptor chain
 	connectHandler := setupConnectServer(ctx, svc.SecurityManager(), auditSrv)
 
+	// Runtime only — permission manifests publish on the setup Job path above.
 	serviceOptions := []frame.Option{
 		frame.WithHTTPHandler(connectHandler),
-		frame.WithPermissionRegistration(sd),
 	}
 
 	svc.Init(ctx, serviceOptions...)

--- a/apps/default/cmd/main.go
+++ b/apps/default/cmd/main.go
@@ -95,6 +95,19 @@ func main() {
 
 	log := util.Log(ctx)
 
+	// Setup Job (argv setup / DO_SETUP): publish permission manifest only.
+	// Full OIDC is already loaded above so the Job can authenticate to tenancy.
+	// Do not wire HTTP routes, peer clients, or hypertables on this path.
+	sd := authv1.File_authentication_v1_authentication_proto.Services().ByName("AuthenticationService")
+	if frame.IsSetupMode(&cfg) || frame.ShouldRunSetup(&cfg) {
+		svc.Init(ctx, frame.WithPermissionRegistration(sd))
+		if setupErr := svc.RunSetupForProcess(ctx, &cfg); setupErr != nil {
+			log.WithError(setupErr).Fatal("setup plan failed")
+		}
+		log.Info("setup plan complete — exiting")
+		return
+	}
+
 	sm := svc.SecurityManager()
 	dbManager := svc.DatastoreManager()
 	cacheManager := svc.CacheManager()
@@ -163,26 +176,13 @@ func main() {
 	defaultServer := frame.WithHTTPHandler(authMux)
 	serviceOptions = append(serviceOptions, defaultServer)
 
-	// Permissions step for setup jobs (no runtime PreStart — fast cold start).
-	sd := authv1.File_authentication_v1_authentication_proto.Services().ByName("AuthenticationService")
-	serviceOptions = append(serviceOptions, frame.WithPermissionRegistration(sd))
-
-	// Register async event consumers (queue-backed — scales with replicas).
+	// Runtime only — permission manifests publish on the setup Job path above.
 	serviceOptions = append(serviceOptions, frame.WithRegisterEvents(
 		events.NewProfileAvatarSyncEventHandler(profileCli, filesCli),
 		events.NewServiceAccountLoginAuditEventHandler(loginRepo, loginEventRepo),
 	))
 
 	svc.Init(ctx, serviceOptions...)
-
-	// setup argv (e.g. setup permissions): publish manifests with full OIDC.
-	if frame.IsSetupMode(&cfg) {
-		if setupErr := svc.RunSetupForProcess(ctx, &cfg); setupErr != nil {
-			log.WithError(setupErr).Fatal("setup plan failed")
-		}
-		log.Info("setup plan complete — exiting")
-		return
-	}
 
 	err = svc.Run(ctx, "")
 	if err != nil {

--- a/apps/tenancy/cmd/main.go
+++ b/apps/tenancy/cmd/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/antinvestor/common/v2/servicecatalog"
@@ -73,6 +74,9 @@ func main() {
 	svc.Setup().RegisterFunc(setup.NameMigrate, func(ctx context.Context) error {
 		return repository.Migrate(ctx, svc.DatastoreManager(), cfg.GetDatabaseMigrationPath())
 	})
+	// Setup Job only (migrate → bootstrap → …). Never on runtime cold start.
+	// Bootstrap: root tuples, service-bot Plane-1 access, then materialise any
+	// SA authorization policies whose namespaces are already registered.
 	svc.Setup().RegisterFunc(setup.NameBootstrap, func(ctx context.Context) error {
 		if bootstrapErr := business.EnsureRootAuthorization(ctx, business.RootAuthorizationDeps{
 			AccessRepo:           setupPartSrv.AccessRepo,
@@ -83,11 +87,29 @@ func main() {
 		}); bootstrapErr != nil {
 			return bootstrapErr
 		}
-		return business.EnsureServiceBotTenancyAccess(ctx, business.ServiceBotTenancyDeps{
+		if botErr := business.EnsureServiceBotTenancyAccess(ctx, business.ServiceBotTenancyDeps{
 			ServiceAccountRepo: setupPartSrv.ServiceAccountRepo,
 			PartitionRepo:      setupPartSrv.PartitionRepo,
 			Authorizer:         auth,
-		})
+		}); botErr != nil {
+			return botErr
+		}
+		// Materialise pending SA policies (Plane-2 granted_*) for namespaces that
+		// are already registered. Policies whose namespaces are still missing stay
+		// pending until files/profile/etc. setup Jobs re-register and requeue them.
+		reconciler := events.NewAuthzServiceAccountSyncEventHandler(
+			setupPartSrv.ServiceAccountRepo,
+			setupPartSrv.PartitionRepo,
+			setupPartSrv.AuthorizationPolicyRepo,
+			setupPartSrv.ServiceNamespaceRepo,
+			setupPartSrv.AuthContractRepo,
+			svc.EventsManager(),
+			auth,
+		)
+		if recErr := reconciler.ReconcilePending(ctx); recErr != nil {
+			return fmt.Errorf("setup bootstrap: reconcile pending SA policies: %w", recErr)
+		}
+		return nil
 	})
 
 	if frame.ShouldRunSetup(&cfg) {
@@ -135,14 +157,10 @@ func main() {
 		auth,
 	)
 
-	sd := tenancyv1.File_tenancy_v1_tenancy_proto.Services().ByName("TenancyService")
-
-	// Runtime: fast start — no permission POST on PreStart.
+	// Runtime: fast start — no setup steps, no permission registration.
 	connectHandler := setupConnectServer(ctx, sm, partSrv, authContractSrv)
 	serviceOptions := []frame.Option{
 		frame.WithHTTPHandler(connectHandler),
-		// Register permissions step for setup jobs sharing this image; unused at runtime.
-		frame.WithPermissionRegistration(sd),
 		frame.WithRegisterEvents(
 			events.NewClientSynchronizationEventHandler(
 				ctx,
@@ -167,6 +185,8 @@ func main() {
 		),
 	}
 
+	// Runtime: serve traffic only. Bot bootstrap + SA policy reconcile run in the
+	// setup Job (NameBootstrap), not on every cold start.
 	svc.Init(ctx, serviceOptions...)
 
 	err = svc.Run(ctx, "")

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/moby/moby/api v1.55.0
 	github.com/ory/hydra-client-go/v25 v25.4.0
-	github.com/pitabwire/frame/v2 v2.1.3
+	github.com/pitabwire/frame/v2 v2.1.4
 	github.com/pitabwire/util v0.9.1
 	github.com/posthog/posthog-go v1.22.0
 	github.com/rs/xid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -270,8 +270,8 @@ github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0 h1:huZxe
 github.com/ory/keto/proto v0.13.0-alpha.0.0.20260420082854-eb334a7a5cf0/go.mod h1:c2UboItfGpqIzXoXlxBRMCp3rQqO+Wx2ecsH25jcWxU=
 github.com/panjf2000/ants/v2 v2.12.1 h1:BWvU2wHpyXWxhhNXsGB6JXLCNbshyLd1QxvoAmZnu10=
 github.com/panjf2000/ants/v2 v2.12.1/go.mod h1:tSQuaNQ6r6NRhPt+IZVUevvDyFMTs+eS4ztZc52uJTY=
-github.com/pitabwire/frame/v2 v2.1.3 h1:G+bSbQfIqCOyxOtU9+7Qke24SgtF5I+arksa8aE1DMY=
-github.com/pitabwire/frame/v2 v2.1.3/go.mod h1:5WqtBx14wGi5RQ0FmHSSOUqQW26/ych/CbU0vZEkfT4=
+github.com/pitabwire/frame/v2 v2.1.4 h1:d/5KqXhRoFp3TbIaiYDW7LUzy9yqAVnzpRnLjo3UB24=
+github.com/pitabwire/frame/v2 v2.1.4/go.mod h1:NcmL8QJh/XeRY6SkcAm07kZtsiyM/Lg+/JsXZ5HJl4A=
 github.com/pitabwire/natspubsub v0.8.4 h1:iXncMM/Fuvmyu3+VFDazOxKf5M3AWNQZdvLpM+NtKZ0=
 github.com/pitabwire/natspubsub v0.8.4/go.mod h1:h2S81+ro+eB1NeWWDbhK4EkEN/A72o7hnrDXTUq67Js=
 github.com/pitabwire/util v0.9.1 h1:V8Ag8TNGXoLztuTCbItj67MmQSS+ObEPzQipUCo2NKY=


### PR DESCRIPTION
## Summary
- Setup Job runs bot tenancy bootstrap + pending SA policy reconciliation
- Runtime no longer runs auth bootstrap goroutines
- Permission registration only on setup paths for authentication + audit
- opl-push on release; frame v2.1.4

## Test plan
- [x] go build apps/{tenancy,default,audit}/cmd
- [ ] Setup Job: identity-tenancy-migrate with args setup
- [ ] Confirm SA policies leave pending after files namespace registers