### PR TITLE
fix(tenancy): matching→chat-agent peer contract + ADR 0002

### DIFF
--- a/apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql
+++ b/apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql
@@ -1,12 +1,21 @@
 -- Copyright 2023-2026 Ant Investor Ltd
--- Allow opportunities-matching to call platform chat-agent (S2S).
+--
+-- LIVE-CLUSTER REPAIR ONLY — not a per-customer / per-tenant template.
+-- Canonical model: docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md
+--
+-- Fixes incomplete PLATFORM product SA peer contract for client_id
+-- opportunities-matching (root bot). Deploy already requested /chat-agent and
+-- /checkout; Hydra whitelist + SA ReBAC grants were missing.
+--
 -- Without oauth_client_recipients for https://api.stawi.org/chat-agent, Hydra
 -- rejects client_credentials with:
 --   Requested audience 'https://api.stawi.org/chat-agent' has not been whitelisted
--- Also grant service_chat_agent functional permissions so Turn/CreateSession
--- pass ReBAC after the token is issued. Add checkout audience already
--- requested by matching env.
-
+-- Gate 3: service_chat_agent permissions so CreateSession/Turn/UpsertContext pass.
+--
+-- DO NOT copy this pattern "for each customer". Once this platform SA is fixed,
+-- every logged-in user with matching access gets chat via BFF (user JWT → matching
+-- → SA JWT → chat-agent). New tenants need partition access only — not this SQL.
+--
 -- Resolve opportunities-matching client + policy via stable client_id (not hardcoded seed xids).
 -- New row xids for this migration (registered in IDS.md):
 --   d9mchat1matchaud0001, d9mchat1matchaud0002 (recipients)

--- a/apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql
+++ b/apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql
@@ -1,0 +1,78 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+-- Allow opportunities-matching to call platform chat-agent (S2S).
+-- Without oauth_client_recipients for https://api.stawi.org/chat-agent, Hydra
+-- rejects client_credentials with:
+--   Requested audience 'https://api.stawi.org/chat-agent' has not been whitelisted
+-- Also grant service_chat_agent functional permissions so Turn/CreateSession
+-- pass ReBAC after the token is issued. Add checkout audience already
+-- requested by matching env.
+
+-- Resolve opportunities-matching client + policy via stable client_id (not hardcoded seed xids).
+-- New row xids for this migration (registered in IDS.md):
+--   d9mchat1matchaud0001, d9mchat1matchaud0002 (recipients)
+--   d9mchat1matchgrant001 (grant)
+--   d9mchat1matchperm0001..0003 (permissions)
+
+INSERT INTO public.oauth_client_recipients (
+  id, created_at, modified_at, version, tenant_id, partition_id, client_ref, resource_audience
+)
+SELECT
+  v.id, NOW(), NOW(), 1, c.tenant_id, c.partition_id, c.id, v.aud
+FROM public.clients c
+CROSS JOIN (
+  VALUES
+    ('d9mchat1matchaud0001', 'https://api.stawi.org/chat-agent'),
+    ('d9mchat1matchaud0002', 'https://api.stawi.org/checkout')
+) AS v(id, aud)
+WHERE c.client_id = 'opportunities-matching'
+ON CONFLICT (client_ref, resource_audience) DO NOTHING;
+
+INSERT INTO public.service_account_authorization_grants (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  policy_id, namespace, scope
+)
+SELECT
+  'd9mchat1matchgrant001', NOW(), NOW(), '', '', 1,
+  p.tenant_id, p.partition_id, '', NULL,
+  p.id, 'service_chat_agent', 'partition_tree'
+FROM public.service_account_authorization_policies p
+JOIN public.service_accounts sa ON sa.id = p.service_account_id
+WHERE sa.client_id = 'opportunities-matching'
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.service_account_authorization_permissions (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  grant_id, permission
+)
+SELECT
+  v.id, NOW(), NOW(), '', '', 1,
+  g.tenant_id, g.partition_id, '', NULL,
+  g.id, v.perm
+FROM public.service_account_authorization_grants g
+CROSS JOIN (
+  VALUES
+    ('d9mchat1matchperm0001', 'chat_agent_view'),
+    ('d9mchat1matchperm0002', 'chat_agent_manage'),
+    ('d9mchat1matchperm0003', 'chat_agent_turn')
+) AS v(id, perm)
+WHERE g.id = 'd9mchat1matchgrant001'
+ON CONFLICT (id) DO NOTHING;
+
+-- Bump policy generation so setup/reconcile re-materialises Keto grants.
+UPDATE public.service_account_authorization_policies p
+SET generation = generation + 1,
+    status = 'pending',
+    modified_at = NOW(),
+    last_error = '',
+    last_error_code = ''
+FROM public.service_accounts sa
+WHERE p.service_account_id = sa.id
+  AND sa.client_id = 'opportunities-matching';
+
+-- Force Hydra re-sync of opportunities-matching client audiences.
+UPDATE public.clients
+SET modified_at = NOW(),
+    synced_at = NULL
+WHERE client_id = 'opportunities-matching';

--- a/apps/tenancy/migrations/0001/20260806_02_resync_public_clients_platform_baseline.sql
+++ b/apps/tenancy/migrations/0001/20260806_02_resync_public_clients_platform_baseline.sql
@@ -2,7 +2,10 @@
 --
 -- Re-sync all public (user) OAuth clients so Hydra picks up the baseline
 -- platform self-service audiences injected by ensurePublicPlatformAudiences
--- (profile, devices, geolocation, chat-agent, settings, files, notification).
+-- (profile, devices, geolocation, chat-agent, files).
+--
+-- /settings and /notification are NOT auto-injected — products add those
+-- recipients only when they intentionally integrate those surfaces.
 --
 -- No per-customer grant rows. Logged-in partition members already get
 -- ROLE_MEMBER functional permits via access role sync + OPL.

--- a/apps/tenancy/migrations/0001/20260806_02_resync_public_clients_platform_baseline.sql
+++ b/apps/tenancy/migrations/0001/20260806_02_resync_public_clients_platform_baseline.sql
@@ -1,0 +1,15 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+--
+-- Re-sync all public (user) OAuth clients so Hydra picks up the baseline
+-- platform self-service audiences injected by ensurePublicPlatformAudiences
+-- (profile, devices, geolocation, chat-agent, settings, files, notification).
+--
+-- No per-customer grant rows. Logged-in partition members already get
+-- ROLE_MEMBER functional permits via access role sync + OPL.
+-- See docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md.
+
+UPDATE public.clients
+SET modified_at = NOW(),
+    synced_at = NULL
+WHERE type = 'public'
+  AND deleted_at IS NULL;

--- a/apps/tenancy/migrations/DIFF_NOTES.md
+++ b/apps/tenancy/migrations/DIFF_NOTES.md
@@ -12,3 +12,22 @@ The tenancy database starts directly on the v2 authentication contract. The base
 The snapshot is bootstrap data, not a service catalog. After bootstrap, new service audiences are accepted as canonical HTTPS children of the configured platform audience base, and permission namespaces are registered by authenticated services at startup. Adding a service does not require an authentication-service source or migration change.
 
 If the baseline itself is intentionally regenerated, use `new-partition.sh` or `new-service.sh`. Both accept canonical recipient URL arrays; service seeds also require explicit authorization grants.
+
+## Product peer edges (read before writing another migration)
+
+**ADR:** `docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md`
+
+| Do | Do not |
+|----|--------|
+| Declare S2S peers on the **consumer product SA** (recipients + SA grants) at platform root | Write “grant customer X chat-agent” / per-tenant S2S rows |
+| Use dated SQL only as **live-cluster repair** of a named `client_id` / SA | Treat repair migrations as the product model or copy them per tenant |
+| Keep deploy `requested_audience_paths` ⊆ consumer recipients | Ship deploy peers without Hydra whitelist + ReBAC grants |
+| Scaffold **new** SAs with `new-service.sh` (`RECIPIENTS` + `GRANTS`) | Expect `new-service` to reverse-wire existing consumers |
+
+When a product bot starts calling a peer (e.g. matching → chat-agent), update
+**that product SA’s** auth contract in the same program of work. Logged-in users
+inherit the feature via product edge access (SPA audience + partition membership);
+they never need SA grant rows for the peer.
+
+Historical repair example (not a customer template):
+`0001/20260806_01_matching_chat_agent_audience.sql`.

--- a/apps/tenancy/migrations/IDS.md
+++ b/apps/tenancy/migrations/IDS.md
@@ -202,3 +202,13 @@ configuration.
 | d9lemn4pf2t9a621dr2g | perm chat_agent_view | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
 | d9lemn4pf2t9a621dr30 | perm chat_agent_manage | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
 | d9lemn4pf2t9a621dr3g | perm chat_agent_turn | apps/tenancy/migrations/0001/20260730_01_service_chat_agent.sql |
+
+## Matching chat-agent audience (2026-08-06)
+| xid | what | file |
+|-----|------|------|
+| d9mchat1matchaud0001 | oauth recipient matching→chat-agent | apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql |
+| d9mchat1matchaud0002 | oauth recipient matching→checkout | apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql |
+| d9mchat1matchgrant001 | auth grant matching service_chat_agent | apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql |
+| d9mchat1matchperm0001 | perm chat_agent_view (matching) | apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql |
+| d9mchat1matchperm0002 | perm chat_agent_manage (matching) | apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql |
+| d9mchat1matchperm0003 | perm chat_agent_turn (matching) | apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql |

--- a/apps/tenancy/service/business/business_integration_test.go
+++ b/apps/tenancy/service/business/business_integration_test.go
@@ -295,10 +295,14 @@ func (s *BusinessTestSuite) TestAuthorizationSchemaFailureRemainsPendingAndFails
 	s.Equal("schema_not_ready", failed.Policy.LastErrorCode)
 	s.NotNil(failed.Policy.NextAttemptAt)
 
+	// Schema-not-ready (missing Keto OPL) must not fail the whole setup reconcile;
+	// policies stay non-applied and can be retried after OPL lands.
 	err = reconciler.ReconcilePending(ctx)
-	s.Require().Error(err)
+	s.Require().NoError(err)
 	failed, err = deps.AuthorizationPolicyRepo.GetByServiceAccountID(ctx, serviceAccount.GetID())
 	s.Require().NoError(err)
+	s.Equal(models.AuthorizationPolicyFailed, failed.Policy.Status)
+	s.Equal("schema_not_ready", failed.Policy.LastErrorCode)
 	s.Equal(int32(2), failed.Policy.RetryCount)
 }
 

--- a/apps/tenancy/service/events/sync_client.go
+++ b/apps/tenancy/service/events/sync_client.go
@@ -180,8 +180,17 @@ func SyncClientOnHydra(
 	// Colony injects the matching OAUTH2_REQUESTED_AUDIENCES entry; Hydra must
 	// whitelist it on the client or token requests fail with "not been
 	// whitelisted by the OAuth 2.0 Client".
+	baseURL := oauth2AudienceBaseURL(cfg)
 	if cl.Type == "internal" {
-		audiences = ensureTenancyAudience(audiences, oauth2AudienceBaseURL(cfg))
+		audiences = ensureTenancyAudience(audiences, baseURL)
+	}
+	// Public (user) clients get baseline platform self-service audiences so a
+	// logged-in member can call profile/devices/geo/chat-agent/etc. with their
+	// JWT without per-product oauth_client_recipients rows for every SPA.
+	// Product-specific APIs (matching, jobs, payment, …) stay explicit.
+	// See docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md § user baseline.
+	if cl.Type == "public" {
+		audiences = ensurePublicPlatformAudiences(audiences, baseURL)
 	}
 
 	// Build payload
@@ -307,17 +316,60 @@ func oauth2AudienceBaseURL(cfg config.ConfigurationOAUTH2) string {
 // can register permission manifests against tenancy without each service
 // authoring a custom oauth recipient row.
 func ensureTenancyAudience(audiences []string, audienceBaseURL string) []string {
+	return ensureAudiencePaths(audiences, audienceBaseURL, "/tenancy")
+}
+
+// publicPlatformAudiencePaths are user-scoped platform services that any
+// logged-in partition member may call with their own JWT (ROLE_MEMBER +
+// partition access). Kept small and personal — not product-domain APIs.
+//
+// Paths must stay in sync with docs/adr/0002 and ROLE_MEMBER bindings on
+// each service's proto service_permissions.
+var publicPlatformAudiencePaths = []string{ //nolint:gochecknoglobals // stable platform baseline
+	"/profile",
+	"/devices",
+	"/geolocation",
+	"/chat-agent",
+	"/settings",
+	"/files",
+	"/notification",
+}
+
+// ensurePublicPlatformAudiences appends baseline user-platform audiences so
+// public OAuth clients can obtain tokens for self-service RPCs without
+// hand-maintaining oauth_client_recipients for every SPA.
+func ensurePublicPlatformAudiences(audiences []string, audienceBaseURL string) []string {
+	return ensureAudiencePaths(audiences, audienceBaseURL, publicPlatformAudiencePaths...)
+}
+
+// ensureAudiencePaths appends each {base}{path} that is not already present.
+func ensureAudiencePaths(audiences []string, audienceBaseURL string, paths ...string) []string {
 	base := strings.TrimSuffix(strings.TrimSpace(audienceBaseURL), "/")
-	if base == "" {
+	if base == "" || len(paths) == 0 {
 		return audiences
 	}
-	tenancyAudience := base + "/tenancy"
-	for _, audience := range audiences {
-		if strings.EqualFold(strings.TrimSpace(audience), tenancyAudience) {
-			return audiences
+	out := audiences
+	for _, path := range paths {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		if !strings.HasPrefix(path, "/") {
+			path = "/" + path
+		}
+		want := base + path
+		found := false
+		for _, audience := range out {
+			if strings.EqualFold(strings.TrimSpace(audience), want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			out = append(out, want)
 		}
 	}
-	return append(audiences, tenancyAudience)
+	return out
 }
 
 func getStringSlice(m data.JSONMap, key string) []string {

--- a/apps/tenancy/service/events/sync_client.go
+++ b/apps/tenancy/service/events/sync_client.go
@@ -323,6 +323,10 @@ func ensureTenancyAudience(audiences []string, audienceBaseURL string) []string 
 // logged-in partition member may call with their own JWT (ROLE_MEMBER +
 // partition access). Kept small and personal — not product-domain APIs.
 //
+// Not in this list (product must add oauth_client_recipients explicitly):
+//
+//	/settings, /notification — opt-in at SPA/product setup only.
+//
 // Paths must stay in sync with docs/adr/0002 and ROLE_MEMBER bindings on
 // each service's proto service_permissions.
 var publicPlatformAudiencePaths = []string{ //nolint:gochecknoglobals // stable platform baseline
@@ -330,9 +334,7 @@ var publicPlatformAudiencePaths = []string{ //nolint:gochecknoglobals // stable 
 	"/devices",
 	"/geolocation",
 	"/chat-agent",
-	"/settings",
 	"/files",
-	"/notification",
 }
 
 // ensurePublicPlatformAudiences appends baseline user-platform audiences so

--- a/apps/tenancy/service/events/sync_client_helpers_test.go
+++ b/apps/tenancy/service/events/sync_client_helpers_test.go
@@ -73,6 +73,29 @@ func (s *SyncClientHelpersTestSuite) TestEnsureTenancyAudience_EmptyBase() {
 	s.Equal(in, ensureTenancyAudience(in, "  "))
 }
 
+func (s *SyncClientHelpersTestSuite) TestEnsurePublicPlatformAudiences_AddsBaseline() {
+	got := ensurePublicPlatformAudiences(
+		[]string{"https://api.example.test/matching"},
+		"https://api.example.test",
+	)
+	s.Contains(got, "https://api.example.test/matching")
+	for _, path := range publicPlatformAudiencePaths {
+		s.Contains(got, "https://api.example.test"+path)
+	}
+}
+
+func (s *SyncClientHelpersTestSuite) TestEnsurePublicPlatformAudiences_Idempotent() {
+	base := "https://api.example.test"
+	first := ensurePublicPlatformAudiences(nil, base)
+	second := ensurePublicPlatformAudiences(first, base)
+	s.Equal(first, second)
+}
+
+func (s *SyncClientHelpersTestSuite) TestEnsurePublicPlatformAudiences_EmptyBase() {
+	in := []string{"https://api.example.test/profile"}
+	s.Equal(in, ensurePublicPlatformAudiences(in, ""))
+}
+
 func (s *SyncClientHelpersTestSuite) TestGetStringSlice_EmptyString() {
 	m := data.JSONMap{"types": ""}
 	s.Nil(getStringSlice(m, "types"))

--- a/apps/tenancy/service/repository/clients_test.go
+++ b/apps/tenancy/service/repository/clients_test.go
@@ -37,11 +37,11 @@ func (s *ClientRepositoryTestSuite) TestGreenfieldSeedUsesOnlyNormalizedAuthCont
 
 		for table, expected := range map[string]int64{
 			"clients":                                   57,  // +service-chat-agent
-			"oauth_client_recipients":                   260, // +chat-agent,profile,tenancy,notification
+			"oauth_client_recipients":                   262, // +matching→chat-agent,checkout
 			"service_accounts":                          46,  // +service_chat_agent
 			"service_account_authorization_policies":    46,
-			"service_account_authorization_grants":      178,  // +service_chat_agent namespace
-			"service_account_authorization_permissions": 1848, // +chat_agent_view/manage/turn
+			"service_account_authorization_grants":      179,  // +matching service_chat_agent grant
+			"service_account_authorization_permissions": 1851, // +matching chat_agent_view/manage/turn
 		} {
 			var count int64
 			s.Require().NoError(db.Table(table).Count(&count).Error)

--- a/docs/IDENTITY_AND_AUTHORIZATION.md
+++ b/docs/IDENTITY_AND_AUTHORIZATION.md
@@ -77,6 +77,18 @@ Do not “fix” this by keying Keto on `client_id`.
 | `EnsureServiceBotTenancyAccess` | `sa.ProfileID` |
 | User access / roles | user `profile_id` |
 
+## Product S2S peers vs user access
+
+Do not confuse **human** access to a product with **service-account** rights to
+call platform peers (chat-agent, checkout, …).
+
+- **Users:** SPA audiences + partition membership + roles. No SA grant rows per customer.
+- **Product bots:** `oauth_client_recipients` + SA policy grants on the **platform**
+  product SA (root). One peer contract covers all tenants (`partition_tree`).
+
+Full rules, checklists, and forbidden patterns:
+[adr/0002-product-peer-mesh-not-per-tenant-grants.md](adr/0002-product-peer-mesh-not-per-tenant-grants.md).
+
 ## Debugging checklist
 
 1. Error subject looks like a **client_id** (`service-authentication`)?  

--- a/docs/PERMISSION_REGISTRATION.md
+++ b/docs/PERMISSION_REGISTRATION.md
@@ -73,13 +73,14 @@ not grants on each tenant or logged-in user:
 
 ### End users vs product bots
 
-| Actor | Needs peer audience on **their** OAuth client? | Needs peer `granted_*`? |
-|-------|-----------------------------------------------|-------------------------|
-| Logged-in user (SPA) | Only for product edge APIs (e.g. `/matching`) | Human roles on product namespaces; **not** SA grant tables for platform peers |
+| Actor | Needs audience on **their** OAuth client? | Needs peer `granted_*`? |
+|-------|-------------------------------------------|-------------------------|
+| Logged-in user (SPA) — **platform self-service** | **Automatic baseline** on public clients: profile, devices, geolocation, chat-agent, settings, files, notification (`ensurePublicPlatformAudiences`) | `ROLE_MEMBER` via access grant + OPL — **not** SA grant tables |
+| Logged-in user (SPA) — **product APIs** | Explicit product paths (`/matching`, `/jobs`, …) | Product service `ROLE_MEMBER` / roles |
 | Product SA (BFF → peer) | **Yes** for each peer it calls | **Yes** — explicit perms for RPCs it invokes |
 
-Default product pattern for shared services (chat-agent, etc.): **BFF**.
-Browser → product with user JWT; product → peer with SA JWT; `subject_id` in body.
+**Default for user-tied platform APIs:** user JWT direct (mode U in ADR 0002).  
+**Optional BFF** when the product owns multi-step domain logic: browser → product JWT; product → peer SA JWT; `subject_id` in body.
 
 ### Forbidden
 

--- a/docs/PERMISSION_REGISTRATION.md
+++ b/docs/PERMISSION_REGISTRATION.md
@@ -75,7 +75,7 @@ not grants on each tenant or logged-in user:
 
 | Actor | Needs audience on **their** OAuth client? | Needs peer `granted_*`? |
 |-------|-------------------------------------------|-------------------------|
-| Logged-in user (SPA) — **platform self-service** | **Automatic baseline** on public clients: profile, devices, geolocation, chat-agent, settings, files, notification (`ensurePublicPlatformAudiences`) | `ROLE_MEMBER` via access grant + OPL — **not** SA grant tables |
+| Logged-in user (SPA) — **platform self-service** | **Automatic baseline** on public clients: profile, devices, geolocation, chat-agent, files (`ensurePublicPlatformAudiences`). **Settings and notification are setup-only** (explicit SPA recipients). | `ROLE_MEMBER` via access grant + OPL — **not** SA grant tables |
 | Logged-in user (SPA) — **product APIs** | Explicit product paths (`/matching`, `/jobs`, …) | Product service `ROLE_MEMBER` / roles |
 | Product SA (BFF → peer) | **Yes** for each peer it calls | **Yes** — explicit perms for RPCs it invokes |
 

--- a/docs/PERMISSION_REGISTRATION.md
+++ b/docs/PERMISSION_REGISTRATION.md
@@ -56,6 +56,45 @@ That is the entire service-side contract. Everything else is platform plumbing.
 
 Auth already **declares** `service_device:device_manage` and `service_file:content_upload` in its SA policy. Those grants stay **pending** until the owning service registers the namespace.
 
+## Product peer mesh (S2S consumers) — required reading
+
+**Canonical ADR:** [adr/0002-product-peer-mesh-not-per-tenant-grants.md](adr/0002-product-peer-mesh-not-per-tenant-grants.md).
+
+Permission registration (this document) covers **owner** namespace schema.
+It does **not** auto-wire **consumers** of a new service. A product bot that
+calls peer `S` needs **three gates** on the **consumer** SA (platform root),
+not grants on each tenant or logged-in user:
+
+| Gate | Where |
+|------|--------|
+| 1. Request `aud` | Deploy `requested_audience_paths` → `OAUTH2_REQUESTED_AUDIENCES` |
+| 2. Hydra whitelist | Consumer `oauth_client_recipients` for that audience URL |
+| 3. ReBAC | Consumer SA policy grant on peer namespace + explicit permissions |
+
+### End users vs product bots
+
+| Actor | Needs peer audience on **their** OAuth client? | Needs peer `granted_*`? |
+|-------|-----------------------------------------------|-------------------------|
+| Logged-in user (SPA) | Only for product edge APIs (e.g. `/matching`) | Human roles on product namespaces; **not** SA grant tables for platform peers |
+| Product SA (BFF → peer) | **Yes** for each peer it calls | **Yes** — explicit perms for RPCs it invokes |
+
+Default product pattern for shared services (chat-agent, etc.): **BFF**.
+Browser → product with user JWT; product → peer with SA JWT; `subject_id` in body.
+
+### Forbidden
+
+- Migrations or admin grants “for customer / tenant X” to unlock S2S peers  
+- Adding only deploy `requested_audience_paths` without consumer recipients + SA grants  
+- Auto-granting every internal SA a new peer  
+- Hand-written Keto tuples in app startup to “unblock” chat / consent  
+
+### Allowed repair
+
+A **dated** tenancy migration that updates a **named platform product SA**
+(`client_id = opportunities-matching`, etc.) is live-cluster repair of an
+incomplete peer contract — never a per-customer template. Fold the same rows
+into greenfield / SA contract for wipe-reseed.
+
 ## Token claims required for registration
 
 Service-account access-token extras (token webhook) **must** include:

--- a/docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md
+++ b/docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md
@@ -1,0 +1,184 @@
+# ADR 0002: Product peer mesh is platform SA config — never per-tenant grants
+
+- Status: **Accepted**
+- Date: 2026-08-06
+- Supersedes practice: ad-hoc tenancy migrations that grant OAuth audiences or
+  ReBAC permissions “for a customer” or “to unblock chat”
+- Related: [ADR 0001](0001-runtime-service-contract-registry.md),
+  [PERMISSION_REGISTRATION.md](../PERMISSION_REGISTRATION.md),
+  [IDENTITY_AND_AUTHORIZATION.md](../IDENTITY_AND_AUTHORIZATION.md)
+
+## Context
+
+Product features (e.g. Opportunities matching → platform chat-agent) failed in
+production with:
+
+```text
+Requested audience 'https://api.stawi.org/chat-agent' has not been whitelisted
+by the OAuth 2.0 Client
+```
+
+Deploy already listed `/chat-agent` in `requested_audience_paths`. The gap was
+**platform service-account contract data** (Hydra recipients + SA ReBAC grants)
+for the **product bot** `opportunities-matching`, not missing authorization for
+individual tenants or logged-in candidates.
+
+A recurring wrong response is to write dated SQL that “grants chat to matching”
+or, worse, per-tenant / per-customer permission rows. That does not scale, confuses
+planes, and will be reinvented incorrectly every time a product adds a peer.
+
+## Decision
+
+### Two planes — never mix them
+
+| Plane | Principal | What “access” means | How it is provisioned |
+|-------|-----------|---------------------|------------------------|
+| **A. End-user product access** | Human `profile_id` (JWT `sub`) | May call product APIs (e.g. matching) for their partition | SPA OAuth client audiences + partition `tenancy_access#member` + human roles / OPL |
+| **B. Product peer mesh (S2S)** | Platform **service account** bot `profile_id` (root partition) | Product bot may mint token for peer audience and hold `granted_*` on peer namespace | **Consumer SA auth contract**: `oauth_client_recipients` + SA policy grants/permissions; scope typically `partition_tree` |
+
+**Logged-in users must never require a tenancy migration or SA grant row to use
+a product feature that is implemented as BFF → platform peer.**
+
+If the product is wired correctly at plane B, **every** user who already has
+plane A access to the product edge gets the feature automatically.
+
+### BFF pattern for platform shared services (chat-agent, etc.)
+
+For product-agnostic platform services such as chat-agent:
+
+1. Browser / SPA authenticates to the **product edge** only (matching, etc.).
+2. Product service calls the peer with **its own** `client_credentials` token.
+3. End-user identity is passed as **request data** (`subject_id`), not as the
+   peer’s Bearer principal.
+4. SPA OAuth clients **do not** need the peer audience (`/chat-agent`) unless the
+   product deliberately exposes a direct browser→peer API (default: no).
+
+```text
+User JWT ──► product (matching) ── SA JWT ──► peer (chat-agent)
+                 │                      │
+                 │                      └── ReBAC: matching bot profile_id
+                 └── subject_id = user profile_id (body)
+```
+
+### Three gates for every S2S peer edge (all required)
+
+| # | Gate | Config surface | Failure mode if missing |
+|---|------|----------------|-------------------------|
+| 1 | Request audience | Deploy / Frame `OAUTH2_REQUESTED_AUDIENCES` / `requested_audience_paths` | Token mint omits `aud` |
+| 2 | Hydra whitelist | `oauth_client_recipients` → Hydra client `audience` | “has not been whitelisted” |
+| 3 | Functional ReBAC | SA policy grant on peer namespace + explicit permissions | `permission_denied` after token works |
+
+**Listing a path only in Cloud Run tfvars is necessary but never sufficient.**
+
+`/tenancy` is the only peer with automatic Hydra whitelist assist
+(`ensureTenancyAudience` for internal clients). **All other product peers must be
+declared on the consumer SA contract** (seed, API update of that SA, or future
+automated materialization from the same contract). Do not invent per-tenant SQL.
+
+### Where peer edges live
+
+| Location | Allowed? | Notes |
+|----------|----------|--------|
+| **Product / platform SA seed or SA API update** (root partition) | **Yes — canonical** | Consumer owns its dependency list |
+| **Greenfield auth-contract snapshot** | Yes | Must stay consistent with live product topology for wipe/reseed |
+| **Dated migration** | **Live-cluster repair only** | Fold intent into product contract / greenfield; never model “per customer” |
+| **Per-tenant / per-customer grant rows for S2S peers** | **Forbidden** | Wrong plane |
+| **Auto-grant every internal SA the peer** | **Forbidden** | Breaks least privilege |
+| **Hand Keto tuples in app startup** | **Forbidden** | Use SA policy pipeline |
+
+### Consumer checklist (mandatory when a product starts calling a peer)
+
+When product service **P** starts calling platform service **S**:
+
+1. **Deploy:** add `/{S}` to P’s `requested_audience_paths` (colony / frame-cloudrun).
+2. **Auth contract for P’s SA** (same change set or blocking follow-up — never “later in prod”):
+   - `oauth_client_recipients`: `https://api.stawi.org/{S}` (canonical base URL).
+   - SA authorization grant: namespace of S (e.g. `service_chat_agent`) with scope
+     `partition_tree` (or documented narrower scope).
+   - Explicit permissions required by the RPCs P calls (least privilege; read
+     callee proto `method_permissions`).
+3. **Owner of S** still registers its namespace via Frame permission registration
+   (ADR 0001). Grants stay pending until registration succeeds — fail-closed is OK.
+4. **Client code:** use authenticated Connect/OAuth client (token actually attached).
+5. **CI / review:** reject PRs that add (1) without (2), or that add tenant-scoped
+   rows “so customers can chat.”
+6. **After DB change:** clear consumer client `synced_at` (Hydra re-sync) and bump
+   SA policy `generation` / `status=pending` (Keto re-materialize). Existing
+   pipelines do this; do not skip.
+
+### Provider checklist (when introducing a new platform service)
+
+Shipping **S** alone is not enough:
+
+1. Seed owner SA for S (own namespace grant + own outbound recipients).
+2. Document **known consumers** and either:
+   - update each consumer’s SA contract in the **same program of work**, or
+   - leave consumers unenabled until their contract is updated (fail-closed).
+3. Do **not** reverse-wire every SA. Only declared consumers.
+4. `make new-service` only scaffolds **S**. It does **not** update consumers —
+   that is intentional least privilege, not “consumers auto-work.”
+
+### What “new customer works from get-go” means
+
+| Event | Required work | Not required |
+|-------|---------------|--------------|
+| New tenant / partition | Partition seed, SPA client audiences for **product** APIs, access grants for humans | Chat-agent audience or `chat_agent_*` for each user |
+| New candidate logs in | Login + partition membership | Any SA grant row |
+| Product enables chat-agent | **One** update to product SA peer contract (platform root) | Migration per tenant |
+
+Platform SAs use plane-1 service access and `partition_tree` grants so **one**
+bot policy covers all partitions the product operates in.
+
+### Forbidden patterns (do not reintroduce)
+
+1. **“Grant this customer chat”** SQL or admin one-offs for S2S peers.
+2. **Only** fixing deploy env after Hydra whitelist errors without SA grants
+   (or only grants without recipients).
+3. Putting peer edges only in comments / runbooks without seed or SA API.
+4. Granting `chat_agent_manage` (or full RoleService) when the consumer only
+   needs `chat_agent_turn` / `chat_agent_view` — still use least privilege.
+5. Direct SPA → chat-agent as the default product path without an explicit product
+   decision and SPA recipient + human role_bindings workstream.
+6. Treating dated repair migrations as the product model instead of folding into
+   the consumer SA contract / greenfield.
+
+### Incident class: matching → chat-agent (2026-08)
+
+| What went wrong | Correct fix class |
+|-----------------|-------------------|
+| Matching tfvars requested `/chat-agent` | Gate 1 only |
+| Auth contract for `opportunities-matching` lacked recipient + `service_chat_agent` grant | Gate 2 + 3 — **platform SA**, not tenants |
+| Chat-agent seed only created owner SA | Expected; consumers must be declared separately |
+| Temptation: “migrate each customer” | **Reject** — plane A already sufficient once plane B is fixed |
+
+Live repair migration (if present):
+`apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql`
+is **cluster repair**, not a template for future customer work.
+
+## Consequences
+
+- Product teams own their peer list; identity does not hardcode a service mesh graph.
+- New tenants and users inherit product features without identity migrations.
+- Incomplete consumer contracts fail closed (Hydra or ReBAC) instead of silent
+  heuristic fallbacks.
+- Reviewers have a checklist and a hard “forbidden” list.
+- Future automation (materialize recipients/grants from a single peer declaration)
+  must preserve consumer-owned least privilege — not “all internal SAs get all peers.”
+
+## Enforcement (process)
+
+- Code review: any new `requested_audience_paths` entry requires matching
+  `oauth_client_recipients` + SA grant for that product SA (or a tracked API
+  update of that SA in the same release).
+- Migrations: titles/comments must not say “for customer X”; peer edges name the
+  **client_id** / SA of the product bot.
+- Ops docs for each consumer (e.g. opportunities `docs/ops/chat-agent-integration.md`)
+  must restate the BFF + three-gate model and link here.
+
+## References
+
+- `docs/PERMISSION_REGISTRATION.md` — audiences vs ReBAC; registration pipeline
+- `docs/IDENTITY_AND_AUTHORIZATION.md` — `sub === profile_id`
+- `apps/tenancy/migrations/DIFF_NOTES.md` — greenfield vs live repair
+- `tools/migrations/new-service.sh` — scaffolds **new** SA only
+- Opportunities: `docs/ops/chat-agent-integration.md`

--- a/docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md
+++ b/docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md
@@ -45,23 +45,23 @@ planes, and will be reinvented incorrectly every time a product adds a peer.
 
 After login, a partition **member** can call user-tied platform services with **their own JWT**:
 
-| Audience path | Namespace | Member may (examples) |
-|---------------|-----------|------------------------|
-| `/profile` | `service_profile` | view/update own profile, contacts, addresses |
-| `/devices` | `service_device` | register/link device, keys, presence, logs |
-| `/geolocation` | `service_geolocation` | **ingest location**, view tracks/nearby |
-| `/chat-agent` | `service_chat_agent` | create session / turn (own `subject_id`) |
-| `/settings` | `service_setting` | view/manage own settings |
-| `/files` | `service_file` | upload/view content |
-| `/notification` | `service_notification` | search/status view |
+| Audience path | Namespace | Member may (examples) | On public clients |
+|---------------|-----------|------------------------|-------------------|
+| `/profile` | `service_profile` | view/update own profile, contacts, addresses | **Auto** baseline |
+| `/devices` | `service_device` | register/link device, keys, presence, logs | **Auto** baseline |
+| `/geolocation` | `service_geolocation` | **ingest location**, view tracks/nearby | **Auto** baseline |
+| `/chat-agent` | `service_chat_agent` | create session / turn (own `subject_id`) | **Auto** baseline |
+| `/files` | `service_file` | upload/view content | **Auto** baseline |
+| `/settings` | `service_setting` | view/manage settings | **Setup only** — explicit SPA recipient |
+| `/notification` | `service_notification` | search/status (or send via product) | **Setup only** — explicit SPA recipient |
 
 **How this stays low-config:**
 
-1. **OAuth:** Hydra client sync injects baseline audiences for every `type=public` client (`ensurePublicPlatformAudiences`) — same idea as `ensureTenancyAudience` for internal bots. Product APIs (`/matching`, `/jobs`, …) remain explicit.
+1. **OAuth:** Hydra client sync injects **baseline** audiences for every `type=public` client (`ensurePublicPlatformAudiences`) — same idea as `ensureTenancyAudience` for internal bots. Product APIs (`/matching`, `/jobs`, …) and **settings / notification** remain explicit recipients at product setup.
 2. **ReBAC:** Access grant → default partition role `member` → `BuildRoleTuples` writes `#member` on every registered namespace that declares `ROLE_MEMBER` → OPL permits resolve permissions. **No per-user permission rows.**
-3. **Proto:** Each platform service’s `ROLE_MEMBER` binding must include self-service write perms (e.g. `location_ingest`, `device_manage`, `chat_agent_turn`). Keep admin-only actions on owner/admin.
+3. **Proto:** Baseline platform services’ `ROLE_MEMBER` bindings include self-service write perms (e.g. `location_ingest`, `device_manage`, `chat_agent_turn`). Keep admin-only actions on owner/admin.
 
-Users call these services **directly** when the SPA has the audience (auto for baseline) and the API is personal. Optional BFF is fine, but not required for mode U.
+Users call baseline services **directly** when the SPA has the audience (auto) and the API is personal. Settings and notifications require the product to opt in via `oauth_client_recipients` (or equivalent SPA setup).
 
 ### Mode B — BFF when the product owns the flow
 

--- a/docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md
+++ b/docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md
@@ -29,29 +29,43 @@ planes, and will be reinvented incorrectly every time a product adds a peer.
 
 ## Decision
 
-### Two planes — never mix them
+### Three access modes — pick the lightest that fits
 
-| Plane | Principal | What “access” means | How it is provisioned |
-|-------|-----------|---------------------|------------------------|
-| **A. End-user product access** | Human `profile_id` (JWT `sub`) | May call product APIs (e.g. matching) for their partition | SPA OAuth client audiences + partition `tenancy_access#member` + human roles / OPL |
-| **B. Product peer mesh (S2S)** | Platform **service account** bot `profile_id` (root partition) | Product bot may mint token for peer audience and hold `granted_*` on peer namespace | **Consumer SA auth contract**: `oauth_client_recipients` + SA policy grants/permissions; scope typically `partition_tree` |
+| Mode | Principal | When to use | Config required |
+|------|-----------|-------------|-----------------|
+| **U. User-scoped platform self-service** | Human JWT (`sub` = profile) | Location, devices, own profile, personal LLM chat, settings, files — **tied to the user** | Login + partition membership + `ROLE_MEMBER` (default on access) + public client baseline audiences (**automatic**) |
+| **A. Product edge (SPA → product API)** | Human JWT | Product domain (matching, jobs, checkout) | Explicit product audiences on SPA (`/matching`, …) + partition access |
+| **B. Product peer mesh (S2S BFF)** | Product SA bot | Product server must call a peer on behalf of many subjects or own domain secrets | Consumer **platform SA** recipients + SA grants (once for the product bot — never per tenant) |
 
-**Logged-in users must never require a tenancy migration or SA grant row to use
-a product feature that is implemented as BFF → platform peer.**
+**Logged-in users must not need tenancy migrations or SA grant rows for mode U.**
 
-If the product is wired correctly at plane B, **every** user who already has
-plane A access to the product edge gets the feature automatically.
+**Logged-in users must not need per-tenant grants for mode B either** — only the product SA is wired once; all members of the product inherit via the BFF.
 
-### BFF pattern for platform shared services (chat-agent, etc.)
+### Mode U — user-scoped platform baseline (default for personal APIs)
 
-For product-agnostic platform services such as chat-agent:
+After login, a partition **member** can call user-tied platform services with **their own JWT**:
 
-1. Browser / SPA authenticates to the **product edge** only (matching, etc.).
-2. Product service calls the peer with **its own** `client_credentials` token.
-3. End-user identity is passed as **request data** (`subject_id`), not as the
-   peer’s Bearer principal.
-4. SPA OAuth clients **do not** need the peer audience (`/chat-agent`) unless the
-   product deliberately exposes a direct browser→peer API (default: no).
+| Audience path | Namespace | Member may (examples) |
+|---------------|-----------|------------------------|
+| `/profile` | `service_profile` | view/update own profile, contacts, addresses |
+| `/devices` | `service_device` | register/link device, keys, presence, logs |
+| `/geolocation` | `service_geolocation` | **ingest location**, view tracks/nearby |
+| `/chat-agent` | `service_chat_agent` | create session / turn (own `subject_id`) |
+| `/settings` | `service_setting` | view/manage own settings |
+| `/files` | `service_file` | upload/view content |
+| `/notification` | `service_notification` | search/status view |
+
+**How this stays low-config:**
+
+1. **OAuth:** Hydra client sync injects baseline audiences for every `type=public` client (`ensurePublicPlatformAudiences`) — same idea as `ensureTenancyAudience` for internal bots. Product APIs (`/matching`, `/jobs`, …) remain explicit.
+2. **ReBAC:** Access grant → default partition role `member` → `BuildRoleTuples` writes `#member` on every registered namespace that declares `ROLE_MEMBER` → OPL permits resolve permissions. **No per-user permission rows.**
+3. **Proto:** Each platform service’s `ROLE_MEMBER` binding must include self-service write perms (e.g. `location_ingest`, `device_manage`, `chat_agent_turn`). Keep admin-only actions on owner/admin.
+
+Users call these services **directly** when the SPA has the audience (auto for baseline) and the API is personal. Optional BFF is fine, but not required for mode U.
+
+### Mode B — BFF when the product owns the flow
+
+Use S2S when the product edge must orchestrate domain logic (placement rebuild, paywalled listing context, multi-step intake owned by matching):
 
 ```text
 User JWT ──► product (matching) ── SA JWT ──► peer (chat-agent)
@@ -59,6 +73,11 @@ User JWT ──► product (matching) ── SA JWT ──► peer (chat-agent)
                  │                      └── ReBAC: matching bot profile_id
                  └── subject_id = user profile_id (body)
 ```
+
+Either path is valid for chat-agent:
+
+- **Direct (U):** SPA → `/chat-agent` with user JWT; member has `chat_agent_turn`.
+- **BFF (B):** SPA → `/matching`; matching SA has peer contract (recipients + grants).
 
 ### Three gates for every S2S peer edge (all required)
 
@@ -122,9 +141,10 @@ Shipping **S** alone is not enough:
 
 | Event | Required work | Not required |
 |-------|---------------|--------------|
-| New tenant / partition | Partition seed, SPA client audiences for **product** APIs, access grants for humans | Chat-agent audience or `chat_agent_*` for each user |
-| New candidate logs in | Login + partition membership | Any SA grant row |
-| Product enables chat-agent | **One** update to product SA peer contract (platform root) | Migration per tenant |
+| New tenant / partition | Partition seed, SPA client (+ optional **product** audiences), access grants for humans | Per-user `chat_agent_*` / location / device grants |
+| New user logs in as member | Login + partition membership | Any SA grant row; any extra OAuth migration for platform baseline |
+| User sends location / registers device / personal LLM chat | Already covered by mode **U** | Admin role or product SA |
+| Product BFF enables chat-agent for domain orchestration | **One** update to product SA peer contract (mode **B**) | Migration per tenant |
 
 Platform SAs use plane-1 service access and `partition_tree` grants so **one**
 bot policy covers all partitions the product operates in.

--- a/tools/migrations/new-service.sh
+++ b/tools/migrations/new-service.sh
@@ -9,6 +9,17 @@
 #
 # For Thesa-bound SAs, use the root tenant/partition xids.
 # For stawi-jobs-bound SAs, use the stawi-jobs tenant/partition xids.
+#
+# IMPORTANT — this scaffolds ONLY the NEW service account (owner + its outbound
+# recipients and grants). It does NOT reverse-wire existing product consumers.
+#
+# When product P will call this new service S:
+#   1. Seed S with this tool (S owns its namespace grant).
+#   2. Separately update P's SA auth contract: oauth_client_recipients for
+#      https://api.stawi.org/<path> + SA grant on S's namespace + least-privilege
+#      permissions (deploy requested_audience_paths alone is NOT enough).
+#   3. Never write per-tenant / per-customer S2S grants.
+# See docs/adr/0002-product-peer-mesh-not-per-tenant-grants.md
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
1. **Live repair:** matching SA → chat-agent (+ checkout) recipients + ReBAC grants (platform bot, not per tenant).
2. **Public client baseline:** Hydra sync injects user-scoped platform audiences (`profile`, `devices`, `geolocation`, `chat-agent`, `settings`, `files`, `notification`) for all `type=public` clients — same plug-and-play pattern as `ensureTenancyAudience` for internal bots.
3. **Docs:** ADR 0002 — mode **U** (user JWT self-service) vs mode **B** (product S2S BFF). Never per-customer grants.

## Why
Logged-in members should send location, use devices, personal LLM chat, etc. with login + partition membership only. Product domain BFF remains for matching orchestration.

## Deploy
1. Merge + release tenancy
2. Run identity-tenancy-migrate (includes public client resync)
3. Release service-profile member OPL/proto (antinvestor/service-profile#new)
4. Smoke: user token includes baseline audiences; member can call geolocation ingest / chat-agent turn

## Related
- service-profile member self-service PR
- opportunities#163

## Test plan
- [ ] `go test ./apps/tenancy/service/events/ -run TestEnsure`
- [ ] After migrate+sync: public Hydra clients list baseline audiences
- [ ] Candidate `/me/chat` (BFF) without audience whitelist error
- [ ] No per-tenant grant rows required for new users