### PR TITLE
fix(tenancy): seed service-payment-flutterwave SA auth contract

### DIFF
--- a/apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql
+++ b/apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql
@@ -1,0 +1,276 @@
+-- Copyright 2023-2026 Ant Investor Ltd
+--
+-- Service account: service_payment_flutterwave
+-- Cloud Run: payment-flutterwave (client_id service-payment-flutterwave)
+--
+-- Flutterwave was deployed as a payment integration without a tenancy SA seed.
+-- That left Hydra client/authz/Keto grants incomplete, so StatusUpdate after a
+-- successful charge failed with permission_denied on payment_status_update and
+-- checkout hung on "Confirm payment".
+--
+-- Mirrors the stripe payment-integration SA contract (audiences + partition_tree
+-- grants on service_payment / service_profile / service_tenancy /
+-- service_notification).
+--
+-- Bot profile d9flwbotprof00000001 already exists in profile service (type bot).
+-- Hydra client service-payment-flutterwave must set metadata.profile_id to that
+-- profile and metadata.service_account_id to the SA row below.
+
+INSERT INTO clients (
+    id, tenant_id, partition_id, name, client_id, client_secret,
+    type, grant_types, scopes,
+    token_endpoint_auth_method, service_account_id, properties
+) VALUES (
+    'd9r3e64pf2t8o8sm3qtg',
+    'c2f4j7au6s7f91uqnojg',
+    'c2f4j7au6s7f91uqnokg',
+    'sa-service_payment_flutterwave',
+    'service-payment-flutterwave',
+    '',
+    'internal',
+    '{"types": ["client_credentials"]}',
+    'system_int openid',
+    'private_key_jwt',
+    'd9r3e64pf2t8o8sm3qu0',
+    '{"jwks_uri": "https://oauth2.stawi.org/.well-known/jwks.json"}'
+) ON CONFLICT (id) DO NOTHING;
+
+UPDATE clients
+SET name = 'sa-service_payment_flutterwave',
+    service_account_id = 'd9r3e64pf2t8o8sm3qu0',
+    token_endpoint_auth_method = 'private_key_jwt',
+    modified_at = NOW(),
+    synced_at = NULL
+WHERE client_id = 'service-payment-flutterwave';
+
+INSERT INTO service_accounts (
+    id, tenant_id, partition_id, name, profile_id,
+    client_id, client_ref, type, properties
+) VALUES (
+    'd9r3e64pf2t8o8sm3qu0',
+    'c2f4j7au6s7f91uqnojg',
+    'c2f4j7au6s7f91uqnokg',
+    'service_payment_flutterwave',
+    'd9flwbotprof00000001',
+    'service-payment-flutterwave',
+    'd9r3e64pf2t8o8sm3qtg',
+    'internal',
+    '{}'
+) ON CONFLICT (id) DO UPDATE SET
+    profile_id = EXCLUDED.profile_id,
+    client_id = EXCLUDED.client_id,
+    client_ref = EXCLUDED.client_ref,
+    type = EXCLUDED.type,
+    modified_at = NOW();
+
+-- If a legacy row exists under the same human client_id with a different id,
+-- retarget it to the bot profile / client ref (unique client_id prevents a
+-- second row).
+UPDATE service_accounts
+SET profile_id = 'd9flwbotprof00000001',
+    client_ref = (SELECT id FROM clients WHERE client_id = 'service-payment-flutterwave' LIMIT 1),
+    name = 'service_payment_flutterwave',
+    type = 'internal',
+    modified_at = NOW()
+WHERE client_id = 'service-payment-flutterwave';
+
+-- Resource audiences this SA may request (matches payment-flutterwave Cloud Run
+-- OAUTH2_REQUESTED_AUDIENCES + payment integration peers).
+INSERT INTO public.oauth_client_recipients (
+  id, created_at, modified_at, version, tenant_id, partition_id, client_ref, resource_audience
+)
+SELECT
+  v.id, NOW(), NOW(), 1, c.tenant_id, c.partition_id, c.id, v.aud
+FROM public.clients c
+CROSS JOIN (
+  VALUES
+    ('d9r3e64pf2t8o8sm3qv0', 'https://api.stawi.org/notification'),
+    ('d9r3e64pf2t8o8sm3qvg', 'https://api.stawi.org/payment'),
+    ('d9r3e64pf2t8o8sm3r00', 'https://api.stawi.org/profile'),
+    ('d9r3e64pf2t8o8sm3r0g', 'https://api.stawi.org/tenancy')
+) AS v(id, aud)
+WHERE c.client_id = 'service-payment-flutterwave'
+ON CONFLICT (client_ref, resource_audience) DO NOTHING;
+
+-- Authorization policy (pending → materialised by setup ReconcilePending / sync).
+INSERT INTO public.service_account_authorization_policies (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  service_account_id, schema_version, generation, applied_generation,
+  status, retry_count, last_error_code, last_error, next_attempt_at, synced_at
+)
+SELECT
+  'd9r3e64pf2t8o8sm3qug', NOW(), NOW(), '', '', 1,
+  sa.tenant_id, sa.partition_id, '', NULL,
+  sa.id, 1, 1, 0,
+  'pending', 0, '', '', NULL, NULL
+FROM public.service_accounts sa
+WHERE sa.client_id = 'service-payment-flutterwave'
+ON CONFLICT (id) DO NOTHING;
+
+-- Ensure a policy exists even if the fixed policy id collided empty.
+INSERT INTO public.service_account_authorization_policies (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  service_account_id, schema_version, generation, applied_generation,
+  status, retry_count, last_error_code, last_error, next_attempt_at, synced_at
+)
+SELECT
+  'd9r3e64pf2t8o8sm3qug', NOW(), NOW(), '', '', 1,
+  sa.tenant_id, sa.partition_id, '', NULL,
+  sa.id, 1, 1, 0,
+  'pending', 0, '', '', NULL, NULL
+FROM public.service_accounts sa
+WHERE sa.client_id = 'service-payment-flutterwave'
+  AND NOT EXISTS (
+    SELECT 1 FROM public.service_account_authorization_policies p
+    WHERE p.service_account_id = sa.id
+  );
+
+INSERT INTO public.service_account_authorization_grants (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  policy_id, namespace, scope
+)
+SELECT
+  v.id, NOW(), NOW(), '', '', 1,
+  p.tenant_id, p.partition_id, '', NULL,
+  p.id, v.ns, 'partition_tree'
+FROM public.service_account_authorization_policies p
+JOIN public.service_accounts sa ON sa.id = p.service_account_id
+CROSS JOIN (
+  VALUES
+    ('d9r3e64pf2t8o8sm3r10', 'service_notification'),
+    ('d9r3e64pf2t8o8sm3r1g', 'service_payment'),
+    ('d9r3e64pf2t8o8sm3r20', 'service_profile'),
+    ('d9r3e64pf2t8o8sm3r2g', 'service_tenancy')
+) AS v(id, ns)
+WHERE sa.client_id = 'service-payment-flutterwave'
+ON CONFLICT (id) DO NOTHING;
+
+-- service_notification permissions (parity with payment-stripe integration SA)
+INSERT INTO public.service_account_authorization_permissions (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  grant_id, permission
+)
+SELECT
+  v.id, NOW(), NOW(), '', '', 1,
+  g.tenant_id, g.partition_id, '', NULL,
+  g.id, v.perm
+FROM public.service_account_authorization_grants g
+CROSS JOIN (
+  VALUES
+    ('d9r3e64pf2t8o8sm3r30', 'notification_release'),
+    ('d9r3e64pf2t8o8sm3r3g', 'notification_search'),
+    ('d9r3e64pf2t8o8sm3r40', 'notification_send'),
+    ('d9r3e64pf2t8o8sm3r4g', 'notification_status_update'),
+    ('d9r3e64pf2t8o8sm3r50', 'notification_status_view'),
+    ('d9r3e64pf2t8o8sm3r5g', 'template_manage'),
+    ('d9r3e64pf2t8o8sm3r60', 'template_view')
+) AS v(id, perm)
+WHERE g.id = 'd9r3e64pf2t8o8sm3r10'
+ON CONFLICT (id) DO NOTHING;
+
+-- service_payment permissions — payment_status_update is required for charge
+-- result write-back that unblocks pay.stawi.org confirm polling.
+INSERT INTO public.service_account_authorization_permissions (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  grant_id, permission
+)
+SELECT
+  v.id, NOW(), NOW(), '', '', 1,
+  g.tenant_id, g.partition_id, '', NULL,
+  g.id, v.perm
+FROM public.service_account_authorization_grants g
+CROSS JOIN (
+  VALUES
+    ('d9r3e64pf2t8o8sm3r6g', 'payment_link_create'),
+    ('d9r3e64pf2t8o8sm3r70', 'payment_receive'),
+    ('d9r3e64pf2t8o8sm3r7g', 'payment_release'),
+    ('d9r3e64pf2t8o8sm3r80', 'payment_search'),
+    ('d9r3e64pf2t8o8sm3r8g', 'payment_send'),
+    ('d9r3e64pf2t8o8sm3r90', 'payment_status_update'),
+    ('d9r3e64pf2t8o8sm3r9g', 'payment_status_view'),
+    ('d9r3e64pf2t8o8sm3ra0', 'prompt_initiate'),
+    ('d9r3e64pf2t8o8sm3rag', 'reconcile')
+) AS v(id, perm)
+WHERE g.id = 'd9r3e64pf2t8o8sm3r1g'
+ON CONFLICT (id) DO NOTHING;
+
+-- service_profile
+INSERT INTO public.service_account_authorization_permissions (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  grant_id, permission
+)
+SELECT
+  v.id, NOW(), NOW(), '', '', 1,
+  g.tenant_id, g.partition_id, '', NULL,
+  g.id, v.perm
+FROM public.service_account_authorization_grants g
+CROSS JOIN (
+  VALUES
+    ('d9r3e64pf2t8o8sm3rb0', 'address_manage'),
+    ('d9r3e64pf2t8o8sm3rbg', 'contact_manage'),
+    ('d9r3e64pf2t8o8sm3rc0', 'profile_create'),
+    ('d9r3e64pf2t8o8sm3rcg', 'profile_merge'),
+    ('d9r3e64pf2t8o8sm3rd0', 'profile_update'),
+    ('d9r3e64pf2t8o8sm3rdg', 'profile_view'),
+    ('d9r3e64pf2t8o8sm3re0', 'relationship_manage'),
+    ('d9r3e64pf2t8o8sm3reg', 'relationship_view'),
+    ('d9r3e64pf2t8o8sm3rf0', 'roster_manage'),
+    ('d9r3e64pf2t8o8sm3rfg', 'roster_view')
+) AS v(id, perm)
+WHERE g.id = 'd9r3e64pf2t8o8sm3r20'
+ON CONFLICT (id) DO NOTHING;
+
+-- service_tenancy
+INSERT INTO public.service_account_authorization_permissions (
+  id, created_at, modified_at, created_by, modified_by, version,
+  tenant_id, partition_id, access_id, deleted_at,
+  grant_id, permission
+)
+SELECT
+  v.id, NOW(), NOW(), '', '', 1,
+  g.tenant_id, g.partition_id, '', NULL,
+  g.id, v.perm
+FROM public.service_account_authorization_grants g
+CROSS JOIN (
+  VALUES
+    ('d9r3e64pf2t8o8sm3rg0', 'access_manage'),
+    ('d9r3e64pf2t8o8sm3rgg', 'access_view'),
+    ('d9r3e64pf2t8o8sm3rh0', 'client_manage'),
+    ('d9r3e64pf2t8o8sm3rhg', 'client_view'),
+    ('d9r3e64pf2t8o8sm3ri0', 'page_manage'),
+    ('d9r3e64pf2t8o8sm3rig', 'page_view'),
+    ('d9r3e64pf2t8o8sm3rj0', 'partition_manage'),
+    ('d9r3e64pf2t8o8sm3rjg', 'partition_view'),
+    ('d9r3e64pf2t8o8sm3rk0', 'permission_grant'),
+    ('d9r3e64pf2t8o8sm3rkg', 'role_manage'),
+    ('d9r3e64pf2t8o8sm3rl0', 'service_account_manage'),
+    ('d9r3e64pf2t8o8sm3rlg', 'service_account_view'),
+    ('d9r3e64pf2t8o8sm3rm0', 'tenant_manage'),
+    ('d9r3ek4pf2t8vfqg5pn0', 'tenant_view')
+) AS v(id, perm)
+WHERE g.id = 'd9r3e64pf2t8o8sm3r2g'
+ON CONFLICT (id) DO NOTHING;
+
+-- Bump policy generation so setup/reconcile re-materialises Keto grants.
+UPDATE public.service_account_authorization_policies p
+SET generation = GREATEST(generation, 1) + 1,
+    status = 'pending',
+    applied_generation = 0,
+    modified_at = NOW(),
+    last_error = '',
+    last_error_code = ''
+FROM public.service_accounts sa
+WHERE p.service_account_id = sa.id
+  AND sa.client_id = 'service-payment-flutterwave';
+
+-- Force Hydra re-sync of this client (metadata profile_id/SA id).
+UPDATE public.clients
+SET modified_at = NOW(),
+    synced_at = NULL
+WHERE client_id = 'service-payment-flutterwave';

--- a/apps/tenancy/migrations/IDS.md
+++ b/apps/tenancy/migrations/IDS.md
@@ -212,3 +212,60 @@ configuration.
 | d9mchat1matchperm0001 | perm chat_agent_view (matching) | apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql |
 | d9mchat1matchperm0002 | perm chat_agent_manage (matching) | apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql |
 | d9mchat1matchperm0003 | perm chat_agent_turn (matching) | apps/tenancy/migrations/0001/20260806_01_matching_chat_agent_audience.sql |
+
+## Service payment-flutterwave seed (2026-08-07)
+| xid | what | file |
+|-----|------|------|
+| c2f4j7au6s7f91uqnojg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| c2f4j7au6s7f91uqnokg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3qtg | client row id | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3qu0 | service account | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3qug | authorization policy | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3qv0 | oauth recipient notification | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3qvg | oauth recipient payment | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r00 | oauth recipient profile | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r0g | oauth recipient tenancy | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r10 | auth grant service_notification | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r1g | auth grant service_payment | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r20 | auth grant service_profile | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r2g | auth grant service_tenancy | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r30 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r3g | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r40 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r4g | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r50 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r5g | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r60 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r6g | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r70 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r7g | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r80 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r8g | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r90 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3r9g | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3ra0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rag | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rb0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rbg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rc0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rcg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rd0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rdg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3re0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3reg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rf0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rfg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rg0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rgg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rh0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rhg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3ri0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rig | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rj0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rjg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rk0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rkg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rl0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rlg | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3e64pf2t8o8sm3rm0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |
+| d9r3ek4pf2t8vfqg5pn0 | auth permission/grant row | apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql |

--- a/docs/ops-flutterwave-sa-repair.md
+++ b/docs/ops-flutterwave-sa-repair.md
@@ -1,0 +1,31 @@
+# Ops: service-payment-flutterwave authz repair
+
+## Symptoms
+- pay.stawi.org confirm spinner stays on `{"status":"processing"}`
+- Flutterwave sandbox charge `status=succeeded`
+- `payment-flutterwave` logs: `could not update status` with either
+  - Hydra `invalid_client` (missing `service-payment-flutterwave` client), or
+  - Keto `permission_denied: … cannot payment_status_update`
+
+## Durable fix
+Migration `apps/tenancy/migrations/0001/20260807_01_service_payment_flutterwave.sql`
+plus tenancy migrate + SA policy reconcile (setup job or `/_internal/sync/clients`).
+
+## Emergency Keto materialisation (if migrate cannot run)
+Clone stripe bot subject tuples onto flutterwave bot profile
+`d9flwbotprof00000001` (see prior incident notes). Prefer migration +
+`ReconcilePending` so partition_tree stays in sync with policy rows.
+
+## Hydra client metadata (required for private_key_jwt enrichment)
+```json
+{
+  "type": "internal",
+  "tenant_id": "c2f4j7au6s7f91uqnojg",
+  "partition_id": "c2f4j7au6s7f91uqnokg",
+  "profile_id": "d9flwbotprof00000001",
+  "service_account_id": "<service_accounts.id for client_id service-payment-flutterwave>"
+}
+```
+
+## Bot profile
+Profile service: `d9flwbotprof00000001` (`profile_types.uid=2` bot).


### PR DESCRIPTION
## Summary
- Adds durable tenancy seed for `service-payment-flutterwave` (client, SA, oauth recipients, authorization policy/grants/permissions).
- Mirrors the stripe payment-integration SA contract so `payment_status_update` and related S2S permissions exist across the partition tree.
- Forces Hydra client re-sync and pending policy reconcile after migrate.
- Ops notes for repair.

## Why
Flutterwave charges could succeed while `StatusUpdate` failed with Keto `permission_denied` (bot profile had no ReBAC grants), leaving checkout stuck on **Confirm payment**.

## Apply
1. Merge + run `identity-tenancy-migrate`
2. Run tenancy setup / `POST /_internal/sync/clients` so pending SA policy materialises Keto
3. Confirm Hydra client `service-payment-flutterwave` metadata has `profile_id=d9flwbotprof00000001`

## Live note
Root-partition Keto grants for the bot profile were already materialised operationally; this seed makes that durable and complete for rebuilds.
**Blocker:** tenancy Neon currently exceeds data-transfer quota — migrate cannot be applied until quota is raised.